### PR TITLE
FindXerces.cmake should look for dylib versions when checking for debug/release libraries

### DIFF
--- a/cmake/Modules/FindXerces.cmake
+++ b/cmake/Modules/FindXerces.cmake
@@ -41,12 +41,12 @@ find_path(Xerces_INCLUDE_DIR
 #if (WIN32)
 if (Xerces_USE_STATIC_LIBS)
     find_library(Xerces_LIBRARY_DEBUG
-        NAMES xerces-c_static_3D.lib libxerces-c.a
+        NAMES xerces-c_static_3D.lib libxerces-c.a libxerces-c-3.2.dylib
         PATHS ${XERCES_ROOT}/lib /usr/lib
     )
 
     find_library(Xerces_LIBRARY_RELEASE
-        NAMES xerces-c_static_3.lib libxerces-c.a
+        NAMES xerces-c_static_3.lib libxerces-c.a libxerces-c-3.2.dylib
         PATHS ${XERCES_ROOT}/lib usr/lib
     )
 else(Xerces_USE_STATIC_LIBS)


### PR DESCRIPTION
For example, when I install Xerces on OS X with `brew install xerces-c`, I wind up with Xerces installed at `/usr/local/Cellar/xerces-c/3.2.1/`. If I pass that as `XERCES_ROOT` with the current CMake file, it doesn't get detected, because the library is named `libxerces-c-3.2.dylib` (under `lib/`). With this change, it correctly detects and uses the Xerces install from Homebrew.