### PR TITLE
[CMAKE] More strict.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 find_package( Threads REQUIRED )
 
 # Xerces-c
-find_package( XercesC )
+find_package( XercesC REQUIRED )
 
 if ( NOT XercesC_FOUND )
     set( XercesC_INCLUDE_DIR "" CACHE PATH "Xerces include directory" )


### PR DESCRIPTION
The library XercesC is essential for libE57Format, so I passed it as a requierement.