### PR TITLE
Added fallback configuration for RelWithDebInfo and MinSizeRel

### DIFF
--- a/cmake/E57Format-config.cmake
+++ b/cmake/E57Format-config.cmake
@@ -2,3 +2,8 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(XercesC REQUIRED)
 include(${CMAKE_CURRENT_LIST_DIR}/E57Format-export.cmake)
+
+set_target_properties(E57Format PROPERTIES
+    MAP_IMPORTED_CONFIG_MINSIZEREL "MinSizeRel;Release"
+    MAP_IMPORTED_CONFIG_RELWITHDEBINFO "RelWithDebInfo;Release"
+)


### PR DESCRIPTION
Environment: Visual Studio 2019, libE57Format installed with both Release and Debug configuration.
Problem: RelWithDebInfo falls back to Debug build (because it's first in alphabetical order).

I have added mapping for RelWithDebInfo and MinSizeRel to fall back to Release if corresponding build is not installed. Without this options, there were linking problems between RelWithDebInfo exe project and Debug libE57Format.

For more information check [MAP_IMPORTED_CONFIG](https://cmake.org/cmake/help/v3.9/prop_tgt/MAP_IMPORTED_CONFIG_CONFIG.html).