### PR TITLE
Remove all usage of dynamic_cast<>

### DIFF
--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -668,6 +668,7 @@ void CheckedFile::unlink()
 
    /// Try to remove the file, don't report a failure
    int result = std::remove( fileName_.c_str() ); //??? unicode support here
+   (void)result;                                  // this maybe unused
 #ifdef E57_MAX_VERBOSE
    if ( result < 0 )
    {

--- a/src/Common.h
+++ b/src/Common.h
@@ -77,9 +77,9 @@ namespace e57
 
    /// Create whitespace of given length, for indenting printouts in dump()
    /// functions
-   inline std::string space( int n )
+   inline std::string space( size_t n )
    {
-      return ( std::string( static_cast<size_t>( n ), ' ' ) );
+      return ( std::string( n, ' ' ) );
    }
 
    /// Convert number to decimal, hexadecimal, and binary strings  (Note hex

--- a/src/Decoder.cpp
+++ b/src/Decoder.cpp
@@ -617,7 +617,7 @@ BitpackIntegerDecoder<RegisterT>::BitpackIntegerDecoder( bool isScaledInteger, u
                                                                // imf->parentFile()  --> ImageFile?
 
    bitsPerRecord_ = imf->bitsNeeded( minimum_, maximum_ );
-   destBitMask_ = ( bitsPerRecord_ == 64 ) ? ~0 : ( 1ULL << bitsPerRecord_ ) - 1;
+   destBitMask_ = ( bitsPerRecord_ == 64 ) ? ~0 : static_cast<RegisterT>( 1ULL << bitsPerRecord_ ) - 1;
 }
 
 template <typename RegisterT>

--- a/src/Decoder.cpp
+++ b/src/Decoder.cpp
@@ -58,11 +58,7 @@ shared_ptr<Decoder> Decoder::DecoderFactory( unsigned bytestreamNumber, //!!! na
       case E57_INTEGER:
       {
          shared_ptr<IntegerNodeImpl> ini =
-            dynamic_pointer_cast<IntegerNodeImpl>( decodeNode ); // downcast to correct type
-         if ( !ini )                                             // check if failed
-         {
-            throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "elementName=" + decodeNode->elementName() );
-         }
+            static_pointer_cast<IntegerNodeImpl>( decodeNode ); // downcast to correct type
 
          /// Get pointer to parent ImageFileImpl, to call bitsNeeded()
          ImageFileImplSharedPtr imf( decodeNode->destImageFile_ ); //??? should be function for this,
@@ -110,11 +106,7 @@ shared_ptr<Decoder> Decoder::DecoderFactory( unsigned bytestreamNumber, //!!! na
       case E57_SCALED_INTEGER:
       {
          shared_ptr<ScaledIntegerNodeImpl> sini =
-            dynamic_pointer_cast<ScaledIntegerNodeImpl>( decodeNode ); // downcast to correct type
-         if ( !sini )                                                  // check if failed
-         {
-            throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "elementName=" + decodeNode->elementName() );
-         }
+            static_pointer_cast<ScaledIntegerNodeImpl>( decodeNode ); // downcast to correct type
 
          /// Get pointer to parent ImageFileImpl, to call bitsNeeded()
          ImageFileImplSharedPtr imf( decodeNode->destImageFile_ ); //??? should be function for this,
@@ -166,12 +158,7 @@ shared_ptr<Decoder> Decoder::DecoderFactory( unsigned bytestreamNumber, //!!! na
 
       case E57_FLOAT:
       {
-         shared_ptr<FloatNodeImpl> fni = dynamic_pointer_cast<FloatNodeImpl>( decodeNode ); // downcast to correct type
-
-         if ( !fni ) // check if failed
-         {
-            throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "elementName=" + decodeNode->elementName() );
-         }
+         shared_ptr<FloatNodeImpl> fni = static_pointer_cast<FloatNodeImpl>( decodeNode ); // downcast to correct type
 
          shared_ptr<Decoder> decoder(
             new BitpackFloatDecoder( bytestreamNumber, dbufs.at( 0 ), fni->precision(), maxRecordCount ) );

--- a/src/E57Format.cpp
+++ b/src/E57Format.cpp
@@ -2472,13 +2472,11 @@ StructureNode::operator Node()
 */
 StructureNode::StructureNode( const Node &n )
 {
-   /// Downcast from SharedNodeImplPtr to shared_ptr<StructureNodeImpl>
-   shared_ptr<StructureNodeImpl> ni( dynamic_pointer_cast<StructureNodeImpl>( n.impl() ) );
-   if ( !ni )
+   if ( n.type() != E57_STRUCTURE )
       throw E57_EXCEPTION2( E57_ERROR_BAD_NODE_DOWNCAST, "nodeType=" + toString( n.type() ) );
 
    /// Set our shared_ptr to the downcast shared_ptr
-   impl_ = ni;
+   impl_ = static_pointer_cast<StructureNodeImpl>( n.impl() );
 }
 
 //! @cond documentNonPublic   The following isn't part of the API, and isn't
@@ -2793,13 +2791,11 @@ VectorNode::operator Node()
 */
 VectorNode::VectorNode( const Node &n )
 {
-   /// Downcast from SharedNodeImplPtr to shared_ptr<VectorNodeImpl>
-   shared_ptr<VectorNodeImpl> ni( dynamic_pointer_cast<VectorNodeImpl>( n.impl() ) );
-   if ( !ni )
+   if ( n.type() != E57_VECTOR )
       throw E57_EXCEPTION2( E57_ERROR_BAD_NODE_DOWNCAST, "nodeType=" + toString( n.type() ) );
 
    /// Set our shared_ptr to the downcast shared_ptr
-   impl_ = ni;
+   impl_ = static_pointer_cast<VectorNodeImpl>( n.impl() );
 }
 
 //! @cond documentNonPublic   The following isn't part of the API, and isn't
@@ -4040,13 +4036,11 @@ Node()
 */
 CompressedVectorNode::CompressedVectorNode( const Node &n )
 {
-   /// Downcast from SharedNodeImplPtr to shared_ptr<CompressedVectorNodeImpl>
-   shared_ptr<CompressedVectorNodeImpl> ni( dynamic_pointer_cast<CompressedVectorNodeImpl>( n.impl() ) );
-   if ( !ni )
+   if ( n.type() != E57_COMPRESSED_VECTOR )
       throw E57_EXCEPTION2( E57_ERROR_BAD_NODE_DOWNCAST, "nodeType=" + toString( n.type() ) );
 
    /// Set our shared_ptr to the downcast shared_ptr
-   impl_ = ni;
+   impl_ = static_pointer_cast<CompressedVectorNodeImpl>( n.impl() );
 }
 
 //! @cond documentNonPublic   The following isn't part of the API, and isn't
@@ -4348,13 +4342,11 @@ automatically).
 */
 IntegerNode::IntegerNode( const Node &n )
 {
-   /// Downcast from SharedNodeImplPtr to shared_ptr<IntegerNodeImpl>
-   shared_ptr<IntegerNodeImpl> ni( dynamic_pointer_cast<IntegerNodeImpl>( n.impl() ) );
-   if ( !ni )
+   if ( n.type() != E57_INTEGER )
       throw E57_EXCEPTION2( E57_ERROR_BAD_NODE_DOWNCAST, "nodeType=" + toString( n.type() ) );
 
    /// Set our shared_ptr to the downcast shared_ptr
-   impl_ = ni;
+   impl_ = static_pointer_cast<IntegerNodeImpl>( n.impl() );
 }
 
 //! @cond documentNonPublic   The following isn't part of the API, and isn't
@@ -4707,13 +4699,11 @@ Node()
 */
 ScaledIntegerNode::ScaledIntegerNode( const Node &n )
 {
-   /// Downcast from SharedNodeImplPtr to shared_ptr<ScaledIntegerNodeImpl>
-   shared_ptr<ScaledIntegerNodeImpl> ni( dynamic_pointer_cast<ScaledIntegerNodeImpl>( n.impl() ) );
-   if ( !ni )
+   if ( n.type() != E57_SCALED_INTEGER )
       throw E57_EXCEPTION2( E57_ERROR_BAD_NODE_DOWNCAST, "nodeType=" + toString( n.type() ) );
 
    /// Set our shared_ptr to the downcast shared_ptr
-   impl_ = ni;
+   impl_ = static_pointer_cast<ScaledIntegerNodeImpl>( n.impl() );
 }
 
 //! @cond documentNonPublic   The following isn't part of the API, and isn't
@@ -4974,13 +4964,11 @@ automatically).
 */
 FloatNode::FloatNode( const Node &n )
 {
-   /// Downcast from SharedNodeImplPtr to shared_ptr<FloatNodeImpl>
-   shared_ptr<FloatNodeImpl> ni( dynamic_pointer_cast<FloatNodeImpl>( n.impl() ) );
-   if ( !ni )
+   if ( n.type() != E57_FLOAT )
       throw E57_EXCEPTION2( E57_ERROR_BAD_NODE_DOWNCAST, "nodeType=" + toString( n.type() ) );
 
    /// Set our shared_ptr to the downcast shared_ptr
-   impl_ = ni;
+   impl_ = static_pointer_cast<FloatNodeImpl>( n.impl() );
 }
 
 //! @cond documentNonPublic   The following isn't part of the API, and isn't
@@ -5154,13 +5142,11 @@ automatically).
 */
 StringNode::StringNode( const Node &n )
 {
-   /// Downcast from SharedNodeImplPtr to shared_ptr<StringNodeImpl>
-   shared_ptr<StringNodeImpl> ni( dynamic_pointer_cast<StringNodeImpl>( n.impl() ) );
-   if ( !ni )
+   if ( n.type() != E57_STRING )
       throw E57_EXCEPTION2( E57_ERROR_BAD_NODE_DOWNCAST, "nodeType=" + toString( n.type() ) );
 
    /// Set our shared_ptr to the downcast shared_ptr
-   impl_ = ni;
+   impl_ = static_pointer_cast<StringNodeImpl>( n.impl() );
 }
 
 //! @cond documentNonPublic   The following isn't part of the API, and isn't
@@ -5436,13 +5422,11 @@ automatically).
 */
 BlobNode::BlobNode( const Node &n )
 {
-   /// Downcast from SharedNodeImplPtr to shared_ptr<BlobNodeImpl>
-   shared_ptr<BlobNodeImpl> ni( dynamic_pointer_cast<BlobNodeImpl>( n.impl() ) );
-   if ( !ni )
+   if ( n.type() != E57_BLOB )
       throw E57_EXCEPTION2( E57_ERROR_BAD_NODE_DOWNCAST, "nodeType=" + toString( n.type() ) );
 
    /// Set our shared_ptr to the downcast shared_ptr
-   impl_ = ni;
+   impl_ = static_pointer_cast<BlobNodeImpl>( n.impl() );
 }
 
 //! @cond documentNonPublic   The following isn't part of the API, and isn't

--- a/src/E57FormatImpl.cpp
+++ b/src/E57FormatImpl.cpp
@@ -100,11 +100,7 @@ bool VectorNodeImpl::isTypeEquivalent( NodeImplSharedPtr ni )
    if ( ni->type() != E57_VECTOR )
       return ( false );
 
-   /// Downcast to shared_ptr<VectorNodeImpl>
-   shared_ptr<VectorNodeImpl> ai( dynamic_pointer_cast<VectorNodeImpl>( ni ) );
-   if ( !ai ) // check if failed
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL,
-                            "this->elementName=" + this->elementName() + " elementName=" + ni->elementName() );
+   shared_ptr<VectorNodeImpl> ai( static_pointer_cast<VectorNodeImpl>( ni ) );
 
    /// allowHeteroChildren must match
    if ( allowHeteroChildren_ != ai->allowHeteroChildren_ )
@@ -282,11 +278,7 @@ bool CompressedVectorNodeImpl::isTypeEquivalent( NodeImplSharedPtr ni )
    if ( ni->type() != E57_COMPRESSED_VECTOR )
       return ( false );
 
-   /// Downcast to shared_ptr<CompressedVectorNodeImpl>
-   shared_ptr<CompressedVectorNodeImpl> cvi( dynamic_pointer_cast<CompressedVectorNodeImpl>( ni ) );
-   if ( !cvi ) // check if failed
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL,
-                            "this->elementName=" + this->elementName() + " elementName=" + ni->elementName() );
+   shared_ptr<CompressedVectorNodeImpl> cvi( static_pointer_cast<CompressedVectorNodeImpl>( ni ) );
 
    /// recordCount must match
    if ( recordCount_ != cvi->recordCount_ )
@@ -418,10 +410,7 @@ shared_ptr<CompressedVectorWriterImpl> CompressedVectorNodeImpl::writer( vector<
    NodeImplSharedPtr ni( shared_from_this() );
 
    /// Downcast pointer to right type
-   shared_ptr<CompressedVectorNodeImpl> cai( dynamic_pointer_cast<CompressedVectorNodeImpl>( ni ) );
-   if ( !cai ) // check if failed
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL,
-                            "this->elementName=" + this->elementName() + " elementName=" + ni->elementName() );
+   shared_ptr<CompressedVectorNodeImpl> cai( static_pointer_cast<CompressedVectorNodeImpl>( ni ) );
 
    /// Return a shared_ptr to new object
    shared_ptr<CompressedVectorWriterImpl> cvwi( new CompressedVectorWriterImpl( cai, sbufs ) );
@@ -464,10 +453,7 @@ shared_ptr<CompressedVectorReaderImpl> CompressedVectorNodeImpl::reader( vector<
 #endif
 
    /// Downcast pointer to right type
-   shared_ptr<CompressedVectorNodeImpl> cai( dynamic_pointer_cast<CompressedVectorNodeImpl>( ni ) );
-   if ( !cai ) // check if failed
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL,
-                            "this->elementName=" + this->elementName() + " elementName=" + ni->elementName() );
+   shared_ptr<CompressedVectorNodeImpl> cai( static_pointer_cast<CompressedVectorNodeImpl>( ni ) );
 #ifdef E57_MAX_VERBOSE
       // cout<<"constructing CAReader, cai:"<<endl;
       // cai->dump(4);
@@ -503,10 +489,7 @@ bool IntegerNodeImpl::isTypeEquivalent( NodeImplSharedPtr ni )
       return ( false );
 
    /// Downcast to shared_ptr<IntegerNodeImpl>
-   shared_ptr<IntegerNodeImpl> ii( dynamic_pointer_cast<IntegerNodeImpl>( ni ) );
-   if ( !ii ) // check if failed
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL,
-                            "this->elementName=" + this->elementName() + " elementName=" + ni->elementName() );
+   shared_ptr<IntegerNodeImpl> ii( static_pointer_cast<IntegerNodeImpl>( ni ) );
 
    /// minimum must match
    if ( minimum_ != ii->minimum_ )
@@ -643,10 +626,7 @@ bool ScaledIntegerNodeImpl::isTypeEquivalent( NodeImplSharedPtr ni )
       return ( false );
 
    /// Downcast to shared_ptr<ScaledIntegerNodeImpl>
-   shared_ptr<ScaledIntegerNodeImpl> ii( dynamic_pointer_cast<ScaledIntegerNodeImpl>( ni ) );
-   if ( !ii ) // check if failed
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL,
-                            "this->elementName=" + this->elementName() + " elementName=" + ni->elementName() );
+   shared_ptr<ScaledIntegerNodeImpl> ii( static_pointer_cast<ScaledIntegerNodeImpl>( ni ) );
 
    /// minimum must match
    if ( minimum_ != ii->minimum_ )
@@ -816,10 +796,7 @@ bool FloatNodeImpl::isTypeEquivalent( NodeImplSharedPtr ni )
       return ( false );
 
    /// Downcast to shared_ptr<FloatNodeImpl>
-   shared_ptr<FloatNodeImpl> fi( dynamic_pointer_cast<FloatNodeImpl>( ni ) );
-   if ( !fi ) // check if failed
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL,
-                            "this->elementName=" + this->elementName() + " elementName=" + ni->elementName() );
+   shared_ptr<FloatNodeImpl> fi( static_pointer_cast<FloatNodeImpl>( ni ) );
 
    /// precision must match
    if ( precision_ != fi->precision_ )
@@ -1118,10 +1095,7 @@ bool BlobNodeImpl::isTypeEquivalent( NodeImplSharedPtr ni )
       return ( false );
 
    /// Downcast to shared_ptr<BlobNodeImpl>
-   shared_ptr<BlobNodeImpl> bi( dynamic_pointer_cast<BlobNodeImpl>( ni ) );
-   if ( !bi ) // check if failed
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL,
-                            "this->elementName=" + this->elementName() + " elementName=" + ni->elementName() );
+   shared_ptr<BlobNodeImpl> bi( static_pointer_cast<BlobNodeImpl>( ni ) );
 
    /// blob lengths must match
    if ( blobLogicalLength_ != bi->blobLogicalLength_ )

--- a/src/E57XmlParser.cpp
+++ b/src/E57XmlParser.cpp
@@ -697,7 +697,7 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
                                   " uri=" + toUString( uri ) + " localName=" + toUString( localName ) +
                                   " qName=" + toUString( qName ) );
       }
-      imf_->root_ = dynamic_pointer_cast<StructureNodeImpl>( current_ni );
+      imf_->root_ = static_pointer_cast<StructureNodeImpl>( current_ni );
       return;
    }
 
@@ -717,7 +717,7 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
    {
       case E57_STRUCTURE:
       {
-         shared_ptr<StructureNodeImpl> struct_ni = dynamic_pointer_cast<StructureNodeImpl>( parent_ni );
+         shared_ptr<StructureNodeImpl> struct_ni = static_pointer_cast<StructureNodeImpl>( parent_ni );
 
          /// Add named child to structure
          struct_ni->set( toUString( qName ), current_ni );
@@ -725,7 +725,7 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
       break;
       case E57_VECTOR:
       {
-         shared_ptr<VectorNodeImpl> vector_ni = dynamic_pointer_cast<VectorNodeImpl>( parent_ni );
+         shared_ptr<VectorNodeImpl> vector_ni = static_pointer_cast<VectorNodeImpl>( parent_ni );
 
          /// Add unnamed child to vector
          vector_ni->append( current_ni );
@@ -733,7 +733,7 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
       break;
       case E57_COMPRESSED_VECTOR:
       {
-         shared_ptr<CompressedVectorNodeImpl> cv_ni = dynamic_pointer_cast<CompressedVectorNodeImpl>( parent_ni );
+         shared_ptr<CompressedVectorNodeImpl> cv_ni = static_pointer_cast<CompressedVectorNodeImpl>( parent_ni );
          ustring uQName = toUString( qName );
 
          /// n can be either prototype or codecs
@@ -748,7 +748,7 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
                                         " uri=" + toUString( uri ) + " localName=" + toUString( localName ) +
                                         " qName=" + toUString( qName ) );
             }
-            shared_ptr<VectorNodeImpl> vi = dynamic_pointer_cast<VectorNodeImpl>( current_ni );
+            shared_ptr<VectorNodeImpl> vi = static_pointer_cast<VectorNodeImpl>( current_ni );
 
             /// Check VectorNode is hetero
             if ( !vi->allowHeteroChildren() )

--- a/src/Encoder.cpp
+++ b/src/Encoder.cpp
@@ -60,11 +60,7 @@ shared_ptr<Encoder> Encoder::EncoderFactory( unsigned bytestreamNumber, shared_p
       case E57_INTEGER:
       {
          shared_ptr<IntegerNodeImpl> ini =
-            dynamic_pointer_cast<IntegerNodeImpl>( encodeNode ); // downcast to correct type
-         if ( !ini )                                             // check if failed
-         {
-            throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "elementName=" + encodeNode->elementName() );
-         }
+            static_pointer_cast<IntegerNodeImpl>( encodeNode ); // downcast to correct type
 
          /// Get pointer to parent ImageFileImpl, to call bitsNeeded()
          ImageFileImplSharedPtr imf( encodeNode->destImageFile_ ); //??? should be function for this,
@@ -112,9 +108,7 @@ shared_ptr<Encoder> Encoder::EncoderFactory( unsigned bytestreamNumber, shared_p
       case E57_SCALED_INTEGER:
       {
          shared_ptr<ScaledIntegerNodeImpl> sini =
-            dynamic_pointer_cast<ScaledIntegerNodeImpl>( encodeNode ); // downcast to correct type
-         if ( !sini )                                                  // check if failed
-            throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "elementName=" + encodeNode->elementName() );
+            static_pointer_cast<ScaledIntegerNodeImpl>( encodeNode ); // downcast to correct type
 
          /// Get pointer to parent ImageFileImpl, to call bitsNeeded()
          ImageFileImplSharedPtr imf( encodeNode->destImageFile_ ); //??? should be function for this,
@@ -165,11 +159,7 @@ shared_ptr<Encoder> Encoder::EncoderFactory( unsigned bytestreamNumber, shared_p
 
       case E57_FLOAT:
       {
-         shared_ptr<FloatNodeImpl> fni = dynamic_pointer_cast<FloatNodeImpl>( encodeNode ); // downcast to correct type
-         if ( !fni )                                                                        // check if failed
-         {
-            throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "elementName=" + encodeNode->elementName() );
-         }
+         shared_ptr<FloatNodeImpl> fni = static_pointer_cast<FloatNodeImpl>( encodeNode ); // downcast to correct type
 
          //!!! need to pick smarter channel buffer sizes, here and elsewhere
          shared_ptr<Encoder> encoder(

--- a/src/NodeImpl.cpp
+++ b/src/NodeImpl.cpp
@@ -209,10 +209,7 @@ bool NodeImpl::isTypeConstrained()
          case E57_VECTOR:
          {
             /// Downcast to shared_ptr<VectorNodeImpl>
-            shared_ptr<VectorNodeImpl> ai( dynamic_pointer_cast<VectorNodeImpl>( p ) );
-            if ( !ai ) // check if failed
-               throw E57_EXCEPTION2( E57_ERROR_INTERNAL,
-                                     "this->elementName=" + this->elementName() + " elementName=" + p->elementName() );
+            shared_ptr<VectorNodeImpl> ai( static_pointer_cast<VectorNodeImpl>( p ) );
 
             /// If homogenous vector and have more than one child, then can't
             /// change them
@@ -326,18 +323,15 @@ bool NodeImpl::findTerminalPosition( const NodeImplSharedPtr &target, uint64_t &
    {
       case E57_STRUCTURE:
       {
-         auto sni = dynamic_cast<StructureNodeImpl *>( this );
+         auto sni = static_cast<StructureNodeImpl *>( this );
 
          /// Recursively visit child nodes
-         if ( sni != nullptr )
+         int64_t childCount = sni->childCount();
+         for ( int64_t i = 0; i < childCount; ++i )
          {
-            int64_t childCount = sni->childCount();
-            for ( int64_t i = 0; i < childCount; ++i )
+            if ( sni->get( i )->findTerminalPosition( target, countFromLeft ) )
             {
-               if ( sni->get( i )->findTerminalPosition( target, countFromLeft ) )
-               {
-                  return true;
-               }
+               return true;
             }
          }
       }
@@ -345,18 +339,15 @@ bool NodeImpl::findTerminalPosition( const NodeImplSharedPtr &target, uint64_t &
 
       case E57_VECTOR:
       {
-         auto vni = dynamic_cast<VectorNodeImpl *>( this );
+         auto vni = static_cast<VectorNodeImpl *>( this );
 
          /// Recursively visit child nodes
-         if ( vni != nullptr )
+         int64_t childCount = vni->childCount();
+         for ( int64_t i = 0; i < childCount; ++i )
          {
-            int64_t childCount = vni->childCount();
-            for ( int64_t i = 0; i < childCount; ++i )
+            if ( vni->get( i )->findTerminalPosition( target, countFromLeft ) )
             {
-               if ( vni->get( i )->findTerminalPosition( target, countFromLeft ) )
-               {
-                  return true;
-               }
+               return true;
             }
          }
       }

--- a/src/StructureNodeImpl.cpp
+++ b/src/StructureNodeImpl.cpp
@@ -53,11 +53,8 @@ bool StructureNodeImpl::isTypeEquivalent( NodeImplSharedPtr ni )
    if ( ni->type() != E57_STRUCTURE )
       return ( false );
 
-   /// Downcast to shared_ptr<StructureNodeImpl>, should succeed
-   shared_ptr<StructureNodeImpl> si( dynamic_pointer_cast<StructureNodeImpl>( ni ) );
-   if ( !si ) // check if failed
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL,
-                            "this->pathName=" + this->pathName() + " elementName=" + ni->elementName() );
+   /// Downcast to shared_ptr<StructureNodeImpl>
+   shared_ptr<StructureNodeImpl> si( static_pointer_cast<StructureNodeImpl>( ni ) );
 
    /// Same number of children?
    if ( childCount() != si->childCount() )


### PR DESCRIPTION
Hi,

This removes usage of dynamic_cast from the library.

As all the nodes already hold E57 type information, we don't need to rely on RTTI. dynamic_cast<> is much slower (especially on MSVC) than custom simple type checks as it must be much more generic. Moreover, there are already those checks in place so usage of dynamic_cast<> is redundant.

This also fixes a couple of warnings reported when compiling with Xcode.

I have formatted the changes with the new `.clang-format` style.

Cheers,
Jiri

[![image](https://user-images.githubusercontent.com/44769714/83034194-45548080-a038-11ea-9960-de502a30d89d.png)](http://www.ptc.com/)
**Jiri Hörner**
Software Development Engineer, Vuforia

jhoerner@ptc.com

[vuforia.com](http://www.vuforia.com/)

---
Parametric Technology Gesellschaft m.b.H., Operngasse 17-21, 1040 Wien, Austria. Firmensitz: Wien, FN: 111171 m, Firmenbuchgericht: Handelsgericht Wien.
 
The information contained in this email transmission is confidential and may be privileged. If you are not the intended recipient, any use, dissemination, distribution, publication, or copying of the information contained in this email is strictly prohibited.  If you have received this email in error, please immediately notify me by calling the above number and delete the email from your system. Thank you for your co-operation.

Copyright © 2020 PTC Inc. and/or all its affiliates or subsidiaries. All rights reserved
