### PR TITLE
{cmake} Fix building when included as a submodule

### DIFF
--- a/cmake/Modules/E57ExportHeader.cmake
+++ b/cmake/Modules/E57ExportHeader.cmake
@@ -21,7 +21,7 @@ target_sources( E57Format
 )
 
 target_include_directories( ${PROJECT_NAME}
-	PRIVATE
+	PUBLIC
 	    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 )
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -18,7 +18,6 @@ install(
 target_include_directories( ${PROJECT_NAME}
 	PUBLIC
 		$<INSTALL_INTERFACE:include/E57Format>
-	PRIVATE
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 


### PR DESCRIPTION
`BUILD_INTERFACE` headers must be public when building as a submodule