### PR TITLE
Fix for shared library build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ install(
     EXPORT
         E57Format-export
     ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
 )
 


### PR DESCRIPTION
Trying to build a shared library in Debian 10 results in the following CMake error:
```
install TARGETS given no LIBRARY DESTINATION for shared library target
   "E57Format"
```
This pull request solves this issue.