### PR TITLE
Generate Windows-like random UUIDs

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -10,23 +10,25 @@ namespace e57
 
    std::string generateRandomGUID()
    {
-      static constexpr const char UUID_CHARS[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+      static constexpr const char UUID_CHARS[] = "0123456789ABCDEF";
       static std::random_device rd;
       static std::mt19937 gen( rd() );
-      static std::uniform_int_distribution<> dis( 0, 61 /* number of chars in UUID_CHARS */ );
+      static std::uniform_int_distribution<> dis( 0, 15 /* number of chars in UUID_CHARS */ );
 
-      std::string uuid( 36, ' ' );
+      std::string uuid( 38, ' ' );
 
-      uuid[8] = '-';
-      uuid[13] = '-';
-      uuid[18] = '-';
-      uuid[23] = '-';
+      uuid[0] = '{';
+      uuid[9] = '-';
+      uuid[14] = '-';
+      uuid[19] = '-';
+      uuid[24] = '-';
+      uuid[37] = '}';
 
-      uuid[14] = '4';
+      uuid[15] = '4';
 
-      for ( int i = 0; i < 36; ++i )
+      for ( int i = 1; i < 37; ++i )
       {
-         if ( i != 8 && i != 13 && i != 18 && i != 14 && i != 23 )
+         if ( i != 9 && i != 14 && i != 19 && i != 24 && i != 15 )
          {
             uuid[i] = UUID_CHARS[dis( gen )];
          }


### PR DESCRIPTION
Hi,

Even though E57 specification does not specify a UUID format ("This standard does not specify the format of GUIDs or how they should be generated."), most of the E57 files contain Windows-formatted UUIDs. The reference implementation of E57Simple API used a platform specific APIs on Windows to generate the UUIDs, thus producing Windows-formatted UUIDs.

This allows parsing of the string GUIDs we write into 128-bit binary representation if desired by the processing software. The currently generated UUIDs have more than 128 bits. Microsoft's format with braces seems to be also widely supported and recognised by most of the UUID libraries.

Cheers,
Jiri

[![image](https://user-images.githubusercontent.com/44769714/83034194-45548080-a038-11ea-9960-de502a30d89d.png)](http://www.ptc.com/)
**Jiri Hörner**
Software Development Engineer, Vuforia

jhoerner@ptc.com

[vuforia.com](http://www.vuforia.com/)

---
Parametric Technology Gesellschaft m.b.H., Operngasse 17-21, 1040 Wien, Austria. Firmensitz: Wien, FN: 111171 m, Firmenbuchgericht: Handelsgericht Wien.
 
The information contained in this email transmission is confidential and may be privileged. If you are not the intended recipient, any use, dissemination, distribution, publication, or copying of the information contained in this email is strictly prohibited.  If you have received this email in error, please immediately notify me by calling the above number and delete the email from your system. Thank you for your co-operation.

Copyright © 2020 PTC Inc. and/or all its affiliates or subsidiaries. All rights reserved
