### PR TITLE
Templatize E57Simple to support double coordinates

### DIFF
--- a/include/E57SimpleData.h
+++ b/include/E57SimpleData.h
@@ -435,15 +435,16 @@ namespace e57
    };
 
    //! @brief Stores pointers to user-provided buffers
-   struct E57_DLL Data3DPointsData
+   template <typename COORDTYPE=float>
+   struct Data3DPointsData_t
    {
-      float *cartesianX{
+      COORDTYPE *cartesianX{
          nullptr
       }; //!< pointer to a buffer with the X coordinate (in meters) of the point in Cartesian coordinates
-      float *cartesianY{
+      COORDTYPE *cartesianY{
          nullptr
       }; //!< pointer to a buffer with the Y coordinate (in meters) of the point in Cartesian coordinates
-      float *cartesianZ{
+      COORDTYPE *cartesianZ{
          nullptr
       }; //!< pointer to a buffer with the Z coordinate (in meters) of the point in Cartesian coordinates
       int8_t *cartesianInvalidState{ nullptr }; //!< Value = 0 if the point is considered valid, 1 otherwise
@@ -456,13 +457,13 @@ namespace e57
       uint8_t *colorBlue{ nullptr };     //!< pointer to a buffer with the Blue color coefficient. Unit is unspecified
       int8_t *isColorInvalid{ nullptr }; //!< Value = 0 if the color is considered valid, 1 otherwise
 
-      float *sphericalRange{
+      COORDTYPE *sphericalRange{
          nullptr
       }; //!< pointer to a buffer with the range (in meters) of points in spherical coordinates. Shall be non-negative
-      float *sphericalAzimuth{
+      COORDTYPE *sphericalAzimuth{
          nullptr
       }; //!< pointer to a buffer with the Azimuth angle (in radians) of point in spherical coordinates
-      float *sphericalElevation{
+      COORDTYPE *sphericalElevation{
          nullptr
       }; //!< pointer to a buffer with the Elevation angle (in radians) of point in spherical coordinates
       int8_t *sphericalInvalidState{ nullptr }; //!< Value = 0 if the range is considered valid, 1 otherwise
@@ -493,6 +494,9 @@ namespace e57
       float *normalY{ nullptr }; //!< The Y component of a surface normal vector (E57_EXT_surface_normals).
       float *normalZ{ nullptr }; //!< The Z component of a surface normal vector (E57_EXT_surface_normals).
    };
+
+   typedef Data3DPointsData_t<float> Data3DPointsData;
+   typedef Data3DPointsData_t<double> Data3DPointsData_d;
 
    //! @brief Stores an image that is to be used only as a visual reference.
    struct E57_DLL VisualReferenceRepresentation

--- a/include/E57SimpleReader.h
+++ b/include/E57SimpleReader.h
@@ -145,6 +145,16 @@ namespace e57
       CompressedVectorReader SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
                                                     const Data3DPointsData &buffers ) const;
 
+      //! @brief Use this function to read the actual 3D data
+      //! @details All the non-NULL buffers in buffers have number of elements = pointCount.
+      //!          Call the CompressedVectorReader::read() until all data is read.
+      //! @param [in] dataIndex data block index given by the NewData3D
+      //! @param [in] pointCount size of each element buffer.
+      //! @param [in] buffers pointers to user-provided buffers
+      //! @return vector reader setup to read the selected data into the provided buffers
+      CompressedVectorReader SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
+                                                    const Data3DPointsData_d &buffers ) const;
+
       //!@}
 
       //! @name Foundation API file information

--- a/include/E57SimpleWriter.h
+++ b/include/E57SimpleWriter.h
@@ -91,6 +91,14 @@ namespace e57
       CompressedVectorWriter SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
                                                     const Data3DPointsData &buffers );
 
+      //! @brief This function setups a writer to write the actual scan data
+      //! @param [in] dataIndex index returned by NewData3D
+      //! @param [in] pointCount Number of points to write (number of elements in each of the buffers)
+      //! @param [in] buffers pointers to user-provided buffers
+      //! @return returns a vector writer setup to write the selected scan data
+      CompressedVectorWriter SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
+                                                    const Data3DPointsData_d &buffers );
+
       //! @brief This function writes out the group data
       //! @param [in] dataIndex data block index given by the NewData3D
       //! @param [in] groupCount size of each of the buffers given

--- a/src/E57SimpleReader.cpp
+++ b/src/E57SimpleReader.cpp
@@ -122,4 +122,10 @@ namespace e57
       return impl_->SetUpData3DPointsData( dataIndex, pointCount, buffers );
    }
 
+   CompressedVectorReader Reader::SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
+                                                         const Data3DPointsData_d &buffers ) const
+   {
+      return impl_->SetUpData3DPointsData( dataIndex, pointCount, buffers );
+   }
+
 } // end namespace e57

--- a/src/E57SimpleWriter.cpp
+++ b/src/E57SimpleWriter.cpp
@@ -88,6 +88,12 @@ namespace e57
       return impl_->SetUpData3DPointsData( dataIndex, pointCount, buffers );
    }
 
+   CompressedVectorWriter Writer::SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
+                                                         const Data3DPointsData_d &buffers )
+   {
+      return impl_->SetUpData3DPointsData( dataIndex, pointCount, buffers );
+   }
+
    bool Writer::WriteData3DGroupsData( int64_t dataIndex, int64_t groupCount, int64_t *idElementValue,
                                        int64_t *startPointIndex, int64_t *pointCount )
    {

--- a/src/ReaderImpl.cpp
+++ b/src/ReaderImpl.cpp
@@ -1280,8 +1280,9 @@ namespace e57
       return true;
    }
 
+   template <typename COORDTYPE>
    CompressedVectorReader ReaderImpl::SetUpData3DPointsData( int64_t dataIndex, size_t count,
-                                                             const Data3DPointsData &buffers ) const
+                                                             const Data3DPointsData_t<COORDTYPE> &buffers ) const
    {
       StructureNode scan( data3D_.get( dataIndex ) );
       CompressedVectorNode points( scan.get( "points" ) );
@@ -1422,5 +1423,12 @@ namespace e57
 
       return reader;
    }
+
+   // Explicit template instantiation
+   template CompressedVectorReader ReaderImpl::SetUpData3DPointsData(
+      int64_t dataIndex, size_t pointCount, const Data3DPointsData_t<float> &buffers ) const;
+
+   template CompressedVectorReader ReaderImpl::SetUpData3DPointsData(
+      int64_t dataIndex, size_t pointCount, const Data3DPointsData_t<double> &buffers ) const;
 
 } // end namespace e57

--- a/src/ReaderImpl.h
+++ b/src/ReaderImpl.h
@@ -67,8 +67,9 @@ namespace e57
       bool ReadData3DGroupsData( int64_t dataIndex, int64_t groupCount, int64_t *idElementValue,
                                  int64_t *startPointIndex, int64_t *pointCount ) const;
 
+      template <typename COORDTYPE>
       CompressedVectorReader SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
-                                                    const Data3DPointsData &buffers ) const;
+                                                    const Data3DPointsData_t<COORDTYPE> &buffers ) const;
 
       StructureNode GetRawE57Root() const;
 

--- a/src/WriterImpl.cpp
+++ b/src/WriterImpl.cpp
@@ -941,8 +941,9 @@ namespace e57
       return pos;
    }
 
+   template <typename COORDTYPE>
    CompressedVectorWriter WriterImpl::SetUpData3DPointsData( int64_t dataIndex, size_t count,
-                                                             const Data3DPointsData &buffers )
+                                                             const Data3DPointsData_t<COORDTYPE> &buffers )
    {
       StructureNode scan( data3D_.get( dataIndex ) );
       CompressedVectorNode points( scan.get( "points" ) );
@@ -1060,6 +1061,13 @@ namespace e57
 
       return writer;
    }
+
+   // Explicit template instantiation
+   template CompressedVectorWriter WriterImpl::SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
+                                                                      const Data3DPointsData_t<float> &buffers );
+
+   template CompressedVectorWriter WriterImpl::SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
+                                                                      const Data3DPointsData_t<double> &buffers );
 
    // This funtion writes out the group data
    bool WriterImpl::WriteData3DGroupsData( int64_t dataIndex, int64_t groupCount, int64_t *idElementValue,

--- a/src/WriterImpl.h
+++ b/src/WriterImpl.h
@@ -51,8 +51,9 @@ namespace e57
 
       int64_t NewData3D( Data3D &data3DHeader );
 
+      template <typename COORDTYPE>
       CompressedVectorWriter SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
-                                                    const Data3DPointsData &buffers );
+                                                    const Data3DPointsData_t<COORDTYPE> &buffers );
 
       bool WriteData3DGroupsData( int64_t dataIndex, int64_t groupCount, int64_t *idElementValue,
                                   int64_t *startPointIndex, int64_t *pointCount );


### PR DESCRIPTION
Hi,

The E57Format lib is overloaded to work with several coordinate types, yet the current E57Simple API only supports float coordinates.
Making the E57Simple `Data3DPointsData` struct a template enables the use of different types, such as double.

In order to keep the current behavior of the API, the default float template was typedefined using the previous `Data3DPointsData` name.
A new double version `Data3DPointsData_d` was also typedefined so that it can be used directly as well.

The intent behind this change is that the last official release of the E57Simple API was using double coordinates, and there are still some use-cases where this level of precision is needed.
This is especially the case when working on large scale scenes - such as we do here at Trimble - and this feature should provide more retro-compatibility to the API.

Regards,
Grégoire

![trimble](https://user-images.githubusercontent.com/75491316/103636583-7ee45700-4f4a-11eb-8d84-971c90d406d2.png)
**Grégoire Jacquemin** | Trimble
Software Development Engineer