### PR TITLE
[gcc:11] missing header.

### DIFF
--- a/src/E57XmlParser.cpp
+++ b/src/E57XmlParser.cpp
@@ -42,6 +42,10 @@
 #include "StringNodeImpl.h"
 #include "VectorNodeImpl.h"
 
+#if __GNUC__ >= 11
+	#include <limits>
+#endif
+
 using namespace e57;
 using namespace XERCES_CPP_NAMESPACE;
 


### PR DESCRIPTION
`std::numeric_limits` requires `<limits>` header 

https://gcc.gnu.org/gcc-11/porting_to.html#header-dep-changes