### PR TITLE
Make explicit the call to open() in CheckedFile.cpp

### DIFF
--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -194,7 +194,7 @@ int CheckedFile::open64( const ustring &fileName, int flags, int mode )
    }
    return handle;
 #elif defined( __GNUC__ )
-   int result = open( fileName_.c_str(), flags, mode );
+   int result = ::open( fileName_.c_str(), flags, mode );
    if ( result < 0 )
    {
       throw E57_EXCEPTION2( E57_ERROR_OPEN_FAILED, "result=" + toString( result ) + " fileName=" + fileName +


### PR DESCRIPTION
Due to the define in fcntl.h:174 (`#define open open64`), the call to `open()` in CheckedFile.cpp:197 may lead to an infinite loop (depending on the compilation environment).

This can be reproduced by compiling libE57Format under alpine linux when using musl.