### PR TITLE
cmake opt-ins for E57_MAX_DEBUG, E57_VERBOSE and E57_MAX_VERBOSE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,10 @@ if( BUILD_SHARED_LIBS )
 	set( E57_BUILD_SHARED ON )
 endif()
 
+option( E57_MAX_DEBUG, "Compile library with maximum debug checking" OFF )
+option( E57_VERBOSE,   "Compile library with vebose logging" OFF )
+option( E57_MAX_VERBOSE, "Compile library with maximum verbose logging" OFF )
+
 set( revision_id "${PROJECT_NAME}-${PROJECT_VERSION}-${${PROJECT_NAME}_BUILD_TAG}" )
 message( STATUS "[E57] Revison ID: ${revision_id}" )
 
@@ -114,6 +118,18 @@ target_compile_definitions( E57Format
         CRCPP_BRANCHLESS
         REVISION_ID="${revision_id}"
 )
+
+if ( E57_MAX_DEBUG )
+target_compile_definitions( E57Format PRIVATE E57_MAX_DEBUG )
+endif()
+
+if ( E57_VERBOSE )
+target_compile_definitions( E57Format PRIVATE E57_VERBOSE )
+endif()
+
+if ( E57_MAX_VERBOSE )
+target_compile_definitions( E57Format PRIVATE E57_MAX_VERBOSE )
+endif()
 
 if ( WIN32 )
     option( USING_STATIC_XERCES "Turn on if you are linking with Xerces as a static lib" OFF )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,26 @@ if( BUILD_SHARED_LIBS )
 	set( E57_BUILD_SHARED ON )
 endif()
 
+#########################################################################################
+
+# Various levels of cross checking and verification in the code.
+# The extra code does not change the file contents.
+# Recommend that E57_DEBUG remain defined even for production versions.
+
+option( E57_DEBUG,     "Compile library with minimal debug checking" ON )
 option( E57_MAX_DEBUG, "Compile library with maximum debug checking" OFF )
-option( E57_VERBOSE,   "Compile library with vebose logging" OFF )
+
+# Various levels of printing to the console of what is going on in the code.
+# Optional
+
+option( E57_VERBOSE,     "Compile library with verbose logging" OFF )
 option( E57_MAX_VERBOSE, "Compile library with maximum verbose logging" OFF )
+
+# Enable writing packets that are correct but will stress the reader.
+
+option( E57_WRITE_CRAZY_PACKET_MODE, "Compile library to enable reader-stressing packets" OFF )
+
+#########################################################################################
 
 set( revision_id "${PROJECT_NAME}-${PROJECT_VERSION}-${${PROJECT_NAME}_BUILD_TAG}" )
 message( STATUS "[E57] Revison ID: ${revision_id}" )
@@ -119,16 +136,24 @@ target_compile_definitions( E57Format
         REVISION_ID="${revision_id}"
 )
 
+if ( E57_DEBUG )
+    target_compile_definitions( E57Format PRIVATE E57_DEBUG )
+endif()
+
 if ( E57_MAX_DEBUG )
-target_compile_definitions( E57Format PRIVATE E57_MAX_DEBUG )
+    target_compile_definitions( E57Format PRIVATE E57_MAX_DEBUG )
 endif()
 
 if ( E57_VERBOSE )
-target_compile_definitions( E57Format PRIVATE E57_VERBOSE )
+    target_compile_definitions( E57Format PRIVATE E57_VERBOSE )
 endif()
 
 if ( E57_MAX_VERBOSE )
-target_compile_definitions( E57Format PRIVATE E57_MAX_VERBOSE )
+    target_compile_definitions( E57Format PRIVATE E57_MAX_VERBOSE )
+endif()
+
+if ( E57_WRITE_CRAZY_PACKET_MODE )
+    target_compile_definitions( E57Format PRIVATE E57_WRITE_CRAZY_PACKET_MODE )
 endif()
 
 if ( WIN32 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,18 +82,18 @@ endif()
 # The extra code does not change the file contents.
 # Recommend that E57_DEBUG remain defined even for production versions.
 
-option( E57_DEBUG,     "Compile library with minimal debug checking" ON )
-option( E57_MAX_DEBUG, "Compile library with maximum debug checking" OFF )
+option( E57_DEBUG      "Compile library with minimal debug checking" ON )
+option( E57_MAX_DEBUG  "Compile library with maximum debug checking" OFF )
 
 # Various levels of printing to the console of what is going on in the code.
 # Optional
 
-option( E57_VERBOSE,     "Compile library with verbose logging" OFF )
-option( E57_MAX_VERBOSE, "Compile library with maximum verbose logging" OFF )
+option( E57_VERBOSE      "Compile library with verbose logging" OFF )
+option( E57_MAX_VERBOSE  "Compile library with maximum verbose logging" OFF )
 
 # Enable writing packets that are correct but will stress the reader.
 
-option( E57_WRITE_CRAZY_PACKET_MODE, "Compile library to enable reader-stressing packets" OFF )
+option( E57_WRITE_CRAZY_PACKET_MODE "Compile library to enable reader-stressing packets" OFF )
 
 #########################################################################################
 

--- a/src/Common.h
+++ b/src/Common.h
@@ -39,21 +39,6 @@
 #define E57_INTERNAL_IMPLEMENTATION_ENABLE 1
 #include "E57Format.h"
 
-// Uncomment the lines below to enable various levels of cross checking and
-// verification in the code. The extra code does not change the file contents.
-// Recommend that E57_DEBUG remain defined even for production versions.
-#define E57_DEBUG 1
-//#define E57_MAX_DEBUG   1
-
-// Uncomment the lines below to enable various levels of printing to the console
-// of what is going on in the code.
-//#define E57_VERBOSE     1
-//#define E57_MAX_VERBOSE 1
-
-// Uncomment the line below to enable writing packets that are correct but will
-// stress the reader.
-//#define E57_WRITE_CRAZY_PACKET_MODE 1
-
 #ifdef _MSC_VER
 // Disable MSVC warning: warning C4224: nonstandard extension used : formal
 // parameter 'locale' was previously defined as a type


### PR DESCRIPTION
libE57Format has some internal conditional compilation for additional checks and logging.
This change puts these in reach of cmake.