### PR TITLE
Fixup for std::cout in E57_VERBOSE mode

### DIFF
--- a/src/E57XmlParser.cpp
+++ b/src/E57XmlParser.cpp
@@ -525,7 +525,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
             if ( toUString( attributes.getURI( i ) ) == "http://www.w3.org/2000/xmlns/" )
             {
 #ifdef E57_VERBOSE
-               cout << "declared extension, prefix=" << toUString( attributes.getLocalName( i ) )
+               std::cout << "declared extension, prefix=" << toUString( attributes.getLocalName( i ) )
                     << " URI=" << toUString( attributes.getValue( i ) ) << std::endl;
 #endif
                imf_->extensionsAdd( toUString( attributes.getLocalName( i ) ), toUString( attributes.getValue( i ) ) );


### PR DESCRIPTION
Appears to be a typo or oversight - missing `std::` namespace prefix.
Needed for building with -DE57_VERBOSE