### PR TITLE
E57 debug fixups

### DIFF
--- a/src/CompressedVectorReaderImpl.cpp
+++ b/src/CompressedVectorReaderImpl.cpp
@@ -574,6 +574,7 @@ namespace e57
       }
    }
 
+#ifdef E57_DEBUG
    void CompressedVectorReaderImpl::dump( int indent, std::ostream &os )
    {
       os << space( indent ) << "isOpen:" << isOpen_ << std::endl;
@@ -600,5 +601,6 @@ namespace e57
       os << space( indent ) << "maxRecordCount:          " << maxRecordCount_ << std::endl;
       os << space( indent ) << "sectionEndLogicalOffset: " << sectionEndLogicalOffset_ << std::endl;
    }
+#endif
 
 }

--- a/src/CompressedVectorWriterImpl.cpp
+++ b/src/CompressedVectorWriterImpl.cpp
@@ -614,6 +614,7 @@ namespace e57
       }
    }
 
+#ifdef E57_DEBUG
    void CompressedVectorWriterImpl::dump( int indent, std::ostream &os )
    {
       os << space( indent ) << "isOpen:" << isOpen_ << std::endl;
@@ -655,4 +656,5 @@ namespace e57
       os << space( indent ) << "dataPacketsCount:          " << dataPacketsCount_ << std::endl;
       os << space( indent ) << "indexPacketsCount:         " << indexPacketsCount_ << std::endl;
    }
+#endif
 }

--- a/src/DecodeChannel.cpp
+++ b/src/DecodeChannel.cpp
@@ -66,6 +66,7 @@ namespace e57
       return ( currentBytestreamBufferIndex == currentBytestreamBufferLength );
    }
 
+#ifdef E57_DEBUG
    void DecodeChannel::dump( int indent, std::ostream &os )
    {
       os << space( indent ) << "dbuf" << std::endl;
@@ -83,4 +84,5 @@ namespace e57
       os << space( indent ) << "isInputBlocked():              " << isInputBlocked() << std::endl;
       os << space( indent ) << "isOutputBlocked():             " << isOutputBlocked() << std::endl;
    }
+#endif
 }

--- a/src/ImageFileImpl.cpp
+++ b/src/ImageFileImpl.cpp
@@ -869,6 +869,7 @@ namespace e57
       }
    }
 
+#ifdef E57_DEBUG
    void ImageFileImpl::dump( int indent, std::ostream &os ) const
    {
       /// no checkImageFileOpen(__FILE__, __LINE__, __FUNCTION__)
@@ -884,6 +885,7 @@ namespace e57
       os << space( indent ) << "root:      " << std::endl;
       root_->dump( indent + 2, os );
    }
+#endif
 
    unsigned ImageFileImpl::bitsNeeded( int64_t minimum, int64_t maximum )
    {

--- a/src/NodeImpl.cpp
+++ b/src/NodeImpl.cpp
@@ -241,7 +241,9 @@ NodeImplSharedPtr NodeImpl::get( const ustring &pathName )
    /// function. Only absolute pathNames make any sense here, because the
    /// terminal types can't have children, so relative pathNames are illegal.
 
+#ifdef E57_DEBUG
    _verifyPathNameAbsolute( pathName );
+#endif
 
    NodeImplSharedPtr root = _verifyAndGetRoot();
 
@@ -256,7 +258,9 @@ void NodeImpl::set( const ustring &pathName, NodeImplSharedPtr ni, bool autoPath
    /// function. Only absolute pathNames make any sense here, because the
    /// terminal types can't have children, so relative pathNames are illegal.
 
+#ifdef E57_DEBUG
    _verifyPathNameAbsolute( pathName );
+#endif
 
    NodeImplSharedPtr root = _verifyAndGetRoot();
 
@@ -405,6 +409,7 @@ bool NodeImpl::_verifyPathNameAbsolute( const ustring &inPathName )
 
    return isRelative;
 }
+#endif
 
 NodeImplSharedPtr NodeImpl::_verifyAndGetRoot()
 {
@@ -424,4 +429,3 @@ NodeImplSharedPtr NodeImpl::_verifyAndGetRoot()
 
    return root;
 }
-#endif

--- a/src/NodeImpl.h
+++ b/src/NodeImpl.h
@@ -73,7 +73,9 @@ namespace e57
 #endif
 
    private:
+#ifdef E57_DEBUG
       bool _verifyPathNameAbsolute( const ustring &inPathName );
+#endif
 
       NodeImplSharedPtr _verifyAndGetRoot();
 


### PR DESCRIPTION
Without `E57_DEBUG` defined E57 point cloud reading and writing still seems to work (limited test coverage here) but some minor touch-ups are needed for building (and linking) the library.