### PR TITLE
Fixup for logging non-string char buffer in E57_MAX_VERBOSE mode

### DIFF
--- a/src/Decoder.cpp
+++ b/src/Decoder.cpp
@@ -361,7 +361,7 @@ BitpackFloatDecoder::BitpackFloatDecoder( unsigned bytestreamNumber, SourceDestB
 size_t BitpackFloatDecoder::inputProcessAligned( const char *inbuf, const size_t firstBit, const size_t endBit )
 {
 #ifdef E57_MAX_VERBOSE
-   std::cout << "BitpackFloatDecoder::inputProcessAligned() called, inbuf=" << inbuf << " firstBit=" << firstBit
+   std::cout << "BitpackFloatDecoder::inputProcessAligned() called, inbuf=" << reinterpret_cast<const void *>(inbuf) << " firstBit=" << firstBit
              << " endBit=" << endBit << std::endl;
 #endif
    /// Read from inbuf, decode, store in destBuffer


### PR DESCRIPTION
valgrind picked up this runtime error in BitpackFloatDecoder.
The buffer is not necessarily a valid NUL-terminated c-string.
Probably the intention was to log the pointer, not the content?