### PR TITLE
fixup: BitpackIntegerDecoder sometimes reads past end of input buffer

### DIFF
--- a/src/Decoder.cpp
+++ b/src/Decoder.cpp
@@ -739,7 +739,7 @@ size_t BitpackIntegerDecoder<RegisterT>::inputProcessAligned( const char *inbuf,
       }
       // Avoid reading the next word, unless it is needed
       // If the last record finishes on the last bit of input, avoid UMR
-      else if ( bitOffset + bitsPerRecord_ <= registerBits_)
+      else if ( bitOffset + bitsPerRecord_ <= RegisterBits )
       {
          w = low >> bitOffset;
       }
@@ -755,7 +755,7 @@ size_t BitpackIntegerDecoder<RegisterT>::inputProcessAligned( const char *inbuf,
          /// Shift high to just above the lower bits, shift low LSBit to bit0,
          /// OR together. Note shifts are logical (not arithmetic) because using
          /// unsigned variables.
-         w = ( high << ( registerBits_ - bitOffset ) ) | ( low >> bitOffset );
+         w = ( high << ( RegisterBits - bitOffset ) ) | ( low >> bitOffset );
       }
 
 #ifdef E57_MAX_VERBOSE

--- a/src/Decoder.cpp
+++ b/src/Decoder.cpp
@@ -645,8 +645,7 @@ BitpackIntegerDecoder<RegisterT>::BitpackIntegerDecoder( bool isScaledInteger, u
                                                          SourceDestBuffer &dbuf, int64_t minimum, int64_t maximum,
                                                          double scale, double offset, uint64_t maxRecordCount ) :
    BitpackDecoder( bytestreamNumber, dbuf, sizeof( RegisterT ), maxRecordCount ),
-   isScaledInteger_( isScaledInteger ), minimum_( minimum ), maximum_( maximum ), scale_( scale ), offset_( offset ),
-   registerBits_( sizeof(RegisterT) * 8)
+   isScaledInteger_( isScaledInteger ), minimum_( minimum ), maximum_( maximum ), scale_( scale ), offset_( offset )
 {
    /// Get pointer to parent ImageFileImpl
    ImageFileImplSharedPtr imf( dbuf.impl()->destImageFile() ); //??? should be function for this,

--- a/src/Decoder.h
+++ b/src/Decoder.h
@@ -149,6 +149,7 @@ namespace e57
       double offset_;
       unsigned bitsPerRecord_;
       RegisterT destBitMask_;
+      const size_t registerBits_;
    };
 
    class ConstantIntegerDecoder : public Decoder

--- a/src/Decoder.h
+++ b/src/Decoder.h
@@ -149,7 +149,7 @@ namespace e57
       double offset_;
       unsigned bitsPerRecord_;
       RegisterT destBitMask_;
-      static const size_t registerBits_ = sizeof(RegisterT) * 8;
+      static constexpr size_t RegisterBits = sizeof( RegisterT ) * 8;
    };
 
    class ConstantIntegerDecoder : public Decoder

--- a/src/Decoder.h
+++ b/src/Decoder.h
@@ -149,7 +149,7 @@ namespace e57
       double offset_;
       unsigned bitsPerRecord_;
       RegisterT destBitMask_;
-      const size_t registerBits_;
+      static const size_t registerBits_ = sizeof(RegisterT) * 8;
    };
 
    class ConstantIntegerDecoder : public Decoder


### PR DESCRIPTION
There appears to be a corner-case bug in the E57 BitpackIntegerDecoder implementation. valgrind is complaining about a UMR (uninitialised memory read) when the last bit of the last record is the last in the input buffer. The decoder is reading the next "register" (word) of data, eventhough it is not needed or valid.

This fix pleases valgrind and our own unit tests still pass.