### PR TITLE
E57SimpleWriter: Pass file guid as constructor argument

### DIFF
--- a/include/E57SimpleWriter.h
+++ b/include/E57SimpleWriter.h
@@ -43,7 +43,7 @@ namespace e57
       //! @brief This function is the constructor for the writer class
       //! @param [in] filePath file path to E57 file
       //! @param [in] coordinateMetaData Information describing the Coordinate Reference System to be used for the file
-      Writer( const ustring &filePath, const ustring &coordinateMetaData = {} );
+      Writer( const ustring &filePath, const ustring &coordinateMetaData = {}, const ustring &guid = {} );
 
       //! @brief This function returns true if the file is open
       bool IsOpen() const;

--- a/include/E57SimpleWriter.h
+++ b/include/E57SimpleWriter.h
@@ -35,6 +35,11 @@
 
 namespace e57
 {
+   struct E57_DLL WriterOptions
+   {
+      ustring guid;               //!< Optional file guid
+      ustring coordinateMetaData; //!< Information describing the Coordinate Reference System to be used for the file
+   };
 
    //! @brief Used for writing of the E57 file with E57 Simple API
    class E57_DLL Writer
@@ -43,7 +48,12 @@ namespace e57
       //! @brief This function is the constructor for the writer class
       //! @param [in] filePath file path to E57 file
       //! @param [in] coordinateMetaData Information describing the Coordinate Reference System to be used for the file
-      Writer( const ustring &filePath, const ustring &coordinateMetaData = {}, const ustring &guid = {} );
+      Writer( const ustring &filePath, const ustring &coordinateMetaData = {} );
+
+      //! @brief This function is the constructor for the writer class
+      //! @param [in] filePath file path to E57 file
+      //! @param [in] options Options to be used for the file
+      Writer( const ustring &filePath, const WriterOptions &options );
 
       //! @brief This function returns true if the file is open
       bool IsOpen() const;

--- a/include/E57SimpleWriter.h
+++ b/include/E57SimpleWriter.h
@@ -38,7 +38,7 @@ namespace e57
    struct E57_DLL WriterOptions
    {
       ustring guid;               //!< Optional file guid
-      ustring coordinateMetaData; //!< Information describing the Coordinate Reference System to be used for the file
+      ustring coordinateMetadata; //!< Information describing the Coordinate Reference System to be used for the file
    };
 
    //! @brief Used for writing of the E57 file with E57 Simple API
@@ -47,8 +47,8 @@ namespace e57
    public:
       //! @brief This function is the constructor for the writer class
       //! @param [in] filePath file path to E57 file
-      //! @param [in] coordinateMetaData Information describing the Coordinate Reference System to be used for the file
-      Writer( const ustring &filePath, const ustring &coordinateMetaData = {} );
+      //! @param [in] coordinateMetadata Information describing the Coordinate Reference System to be used for the file
+      Writer( const ustring &filePath, const ustring &coordinateMetadata = {} );
 
       //! @brief This function is the constructor for the writer class
       //! @param [in] filePath file path to E57 file

--- a/src/E57SimpleWriter.cpp
+++ b/src/E57SimpleWriter.cpp
@@ -32,7 +32,7 @@ namespace e57
 {
 
    Writer::Writer( const ustring &filePath, const ustring &coordinateMetadata ) :
-      impl_( new WriterImpl( filePath, coordinateMetadata ) )
+      impl_( new WriterImpl( filePath, WriterOptions{{}, coordinateMetadata} ) )
    {
    }
 

--- a/src/E57SimpleWriter.cpp
+++ b/src/E57SimpleWriter.cpp
@@ -31,8 +31,13 @@
 namespace e57
 {
 
-   Writer::Writer( const ustring &filePath, const ustring &coordinateMetaData, const ustring &guid ) :
-      impl_( new WriterImpl( filePath, coordinateMetaData, guid ) )
+   Writer::Writer( const ustring &filePath, const ustring &coordinateMetaData ) :
+      impl_( new WriterImpl( filePath, coordinateMetaData, {} ) )
+   {
+   }
+
+   Writer::Writer( const ustring &filePath, const WriterOptions &options ) :
+      impl_( new WriterImpl( filePath, options.coordinateMetaData, options.guid ) )
    {
    }
 

--- a/src/E57SimpleWriter.cpp
+++ b/src/E57SimpleWriter.cpp
@@ -31,13 +31,13 @@
 namespace e57
 {
 
-   Writer::Writer( const ustring &filePath, const ustring &coordinateMetaData ) :
-      impl_( new WriterImpl( filePath, coordinateMetaData, {} ) )
+   Writer::Writer( const ustring &filePath, const ustring &coordinateMetadata ) :
+      impl_( new WriterImpl( filePath, coordinateMetadata ) )
    {
    }
 
    Writer::Writer( const ustring &filePath, const WriterOptions &options ) :
-      impl_( new WriterImpl( filePath, options.coordinateMetaData, options.guid ) )
+      impl_( new WriterImpl( filePath, options ) )
    {
    }
 

--- a/src/E57SimpleWriter.cpp
+++ b/src/E57SimpleWriter.cpp
@@ -31,8 +31,8 @@
 namespace e57
 {
 
-   Writer::Writer( const ustring &filePath, const ustring &coordinateMetaData ) :
-      impl_( new WriterImpl( filePath, coordinateMetaData ) )
+   Writer::Writer( const ustring &filePath, const ustring &coordinateMetaData, const ustring &guid ) :
+      impl_( new WriterImpl( filePath, coordinateMetaData, guid ) )
    {
    }
 

--- a/src/WriterImpl.cpp
+++ b/src/WriterImpl.cpp
@@ -33,7 +33,7 @@
 namespace e57
 {
 
-   WriterImpl::WriterImpl( const ustring &filePath, const ustring &coordinateMetadata ) :
+   WriterImpl::WriterImpl( const ustring &filePath, const ustring &coordinateMetadata, const ustring &guid ) :
       imf_( filePath, "w" ), root_( imf_.root() ), data3D_( imf_, true ), images2D_( imf_, true )
    {
       // We are using the E57 v1.0 data format standard fieldnames.
@@ -44,7 +44,14 @@ namespace e57
       // Set per-file properties.
       // Path names: "/formatName", "/majorVersion", "/minorVersion", "/coordinateMetadata"
       root_.set( "formatName", StringNode( imf_, "ASTM E57 3D Imaging Data File" ) );
-      root_.set( "guid", StringNode( imf_, generateRandomGUID() ) );
+      if (guid.length())
+      {
+         root_.set( "guid", StringNode( imf_, guid ) );
+      }
+      else
+      {
+         root_.set( "guid", StringNode( imf_, generateRandomGUID() ) );
+      }
 
       // Get ASTM version number supported by library, so can write it into file
       int astmMajor;

--- a/src/WriterImpl.cpp
+++ b/src/WriterImpl.cpp
@@ -33,11 +33,6 @@
 namespace e57
 {
 
-   WriterImpl::WriterImpl( const ustring &filePath, const ustring &coordinateMetadata) :
-      WriterImpl( filePath, WriterOptions{{}, coordinateMetadata} )
-   {
-   }
-
    WriterImpl::WriterImpl( const ustring &filePath, const WriterOptions &options ) :
       imf_( filePath, "w" ), root_( imf_.root() ), data3D_( imf_, true ), images2D_( imf_, true )
    {

--- a/src/WriterImpl.cpp
+++ b/src/WriterImpl.cpp
@@ -33,7 +33,12 @@
 namespace e57
 {
 
-   WriterImpl::WriterImpl( const ustring &filePath, const ustring &coordinateMetadata, const ustring &guid ) :
+   WriterImpl::WriterImpl( const ustring &filePath, const ustring &coordinateMetadata) :
+      WriterImpl( filePath, WriterOptions{{}, coordinateMetadata} )
+   {
+   }
+
+   WriterImpl::WriterImpl( const ustring &filePath, const WriterOptions &options ) :
       imf_( filePath, "w" ), root_( imf_.root() ), data3D_( imf_, true ), images2D_( imf_, true )
    {
       // We are using the E57 v1.0 data format standard fieldnames.
@@ -44,9 +49,9 @@ namespace e57
       // Set per-file properties.
       // Path names: "/formatName", "/majorVersion", "/minorVersion", "/coordinateMetadata"
       root_.set( "formatName", StringNode( imf_, "ASTM E57 3D Imaging Data File" ) );
-      if (guid.length())
+      if (options.guid.length())
       {
-         root_.set( "guid", StringNode( imf_, guid ) );
+         root_.set( "guid", StringNode( imf_, options.guid ) );
       }
       else
       {
@@ -65,9 +70,9 @@ namespace e57
 
       // Save a dummy string for coordinate system.
       // Really should be a valid WKT string identifying the coordinate reference system (CRS).
-      if ( !coordinateMetadata.empty() )
+      if ( !options.coordinateMetadata.empty() )
       {
-         root_.set( "coordinateMetadata", StringNode( imf_, coordinateMetadata ) );
+         root_.set( "coordinateMetadata", StringNode( imf_, options.coordinateMetadata ) );
       }
 
 // Create creationDateTime structure

--- a/src/WriterImpl.h
+++ b/src/WriterImpl.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include "E57SimpleData.h"
+#include "E57SimpleWriter.h"
 
 namespace e57
 {
@@ -36,7 +37,8 @@ namespace e57
    class WriterImpl
    {
    public:
-      WriterImpl( const ustring &filePath, const ustring &coordinateMetaData, const ustring &guid );
+      WriterImpl( const ustring &filePath, const ustring &coordinateMetadata );
+      WriterImpl( const ustring &filePath, const WriterOptions &options );
 
       ~WriterImpl();
 

--- a/src/WriterImpl.h
+++ b/src/WriterImpl.h
@@ -37,7 +37,6 @@ namespace e57
    class WriterImpl
    {
    public:
-      WriterImpl( const ustring &filePath, const ustring &coordinateMetadata );
       WriterImpl( const ustring &filePath, const WriterOptions &options );
 
       ~WriterImpl();

--- a/src/WriterImpl.h
+++ b/src/WriterImpl.h
@@ -36,7 +36,7 @@ namespace e57
    class WriterImpl
    {
    public:
-      WriterImpl( const ustring &filePath, const ustring &coordinateMetaData );
+      WriterImpl( const ustring &filePath, const ustring &coordinateMetaData, const ustring &guid );
 
       ~WriterImpl();
 


### PR DESCRIPTION
In testing we noticed that E57 files are not completely deterministic.
Turns out to be due to random GUIDs generated at the file and Data3D scope.
This change is necesssary for using a user-specified GUID rather than a randomly generated one at the file scope.