### PR TITLE
Allow image header without guid

### DIFF
--- a/src/ReaderImpl.cpp
+++ b/src/ReaderImpl.cpp
@@ -124,9 +124,11 @@ namespace e57
       image2DHeader = {};
 
       StructureNode image( images2D_.get( imageIndex ) );
-
-      image2DHeader.guid = StringNode( image.get( "guid" ) ).value();
-
+      
+      if ( image.isDefined( "guid" ) )
+      {
+      	 image2DHeader.guid = StringNode( image.get( "guid" ) ).value();
+      }
       if ( image.isDefined( "name" ) )
       {
          image2DHeader.name = StringNode( image.get( "name" ) ).value();


### PR DESCRIPTION
When the image header does not have the field `guid` the library throws an exception.

I understand that in this situation, the method  `ReaderImpl::ReadImage2D` should either return `false` or allow image headers without guid.

I encontered this problem when trying to read an e57 where the images have no guid. What is the reason to force the header to have a guid? I'm working with an e57 file from Matterport, you can download a sample file to reproduce the issue from here: https://support.matterport.com/s/article/Overview-of-Matterport-E57-File?language=en_US