### PR TITLE
Make CheckedFile support the *BSDs

### DIFF
--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -25,6 +25,11 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+// convenience helper for all the BSDs
+#if defined( __FreeBSD__ ) || defined( __NetBSD__ ) || defined( __OpenBSD__ )
+#define __BSD
+#endif
+
 #if defined( _WIN32 )
 #if defined( _MSC_VER )
 #include <codecvt>
@@ -45,6 +50,10 @@
 #include <sys/types.h>
 #include <unistd.h>
 #elif defined( __APPLE__ )
+#include <sys/types.h>
+#include <unistd.h>
+#elif defined( __BSD )
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 #else
@@ -483,7 +492,7 @@ uint64_t CheckedFile::lseek64( int64_t offset, int whence )
 #endif
 #elif defined( __linux__ )
    int64_t result = ::lseek64( fd_, offset, whence );
-#elif defined( __APPLE__ )
+#elif defined( __APPLE__ ) || defined( __BSD )
    int64_t result = ::lseek( fd_, offset, whence );
 #else
 #error "no supported OS platform defined"


### PR DESCRIPTION
Currently, CheckedFile.cpp feature checks only cover Apple, Windows
and Linux; on BSDs the build bombs out with "no supported OS platform
defined" (l.51).
The BSDs follow POSIX for file operations - which is almost like
Apple, only with the addition of sys/stat.h for the file modes,
so supporting Free/Open/NetBSD can be done with very little changes.
Alternatively, the "linux" branch could be changed from
_LARGEFILE64_SOURCE to _FILE_OFFSET_BITS=64 (switching from lseek64() to
lseek()), but there is no reason given for the current choice which
makes risk assessment harder. This patch chooses the path of least
change to other (linux) platforms.
Build tested on FreeBSD and as part of FreeCAD on FreeBSD (where I
noticed the problem for the first time), the other BSDs should be
fine according to their man pages.