### PR TITLE
cmake: E57_VISIBILITY_HIDDEN option for hidden symbol visibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,10 +95,16 @@ option( E57_MAX_VERBOSE  "Compile library with maximum verbose logging" OFF )
 
 option( E57_WRITE_CRAZY_PACKET_MODE "Compile library to enable reader-stressing packets" OFF )
 
+option( E57_VISIBILITY_HIDDEN       "Compile library with hidden symbol visibility" OFF)
+
 #########################################################################################
 
 set( revision_id "${PROJECT_NAME}-${PROJECT_VERSION}-${${PROJECT_NAME}_BUILD_TAG}" )
 message( STATUS "[E57] Revision ID: ${revision_id}" )
+
+if ( E57_VISIBILITY_HIDDEN )
+    set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+endif()
 
 # Target
 if ( E57_BUILD_SHARED )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ option( E57_MAX_VERBOSE  "Compile library with maximum verbose logging" OFF )
 
 option( E57_WRITE_CRAZY_PACKET_MODE "Compile library to enable reader-stressing packets" OFF )
 
-option( E57_VISIBILITY_HIDDEN       "Compile library with hidden symbol visibility" OFF)
+option( E57_VISIBILITY_HIDDEN       "Compile library with hidden symbol visibility" ON )
 
 #########################################################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,10 +102,6 @@ option( E57_VISIBILITY_HIDDEN       "Compile library with hidden symbol visibili
 set( revision_id "${PROJECT_NAME}-${PROJECT_VERSION}-${${PROJECT_NAME}_BUILD_TAG}" )
 message( STATUS "[E57] Revision ID: ${revision_id}" )
 
-if ( E57_VISIBILITY_HIDDEN )
-    set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-endif()
-
 # Target
 if ( E57_BUILD_SHARED )
 	message( STATUS "[E57] Building shared library" )
@@ -160,6 +156,10 @@ endif()
 
 if ( E57_WRITE_CRAZY_PACKET_MODE )
     target_compile_definitions( E57Format PRIVATE E57_WRITE_CRAZY_PACKET_MODE )
+endif()
+
+if ( E57_VISIBILITY_HIDDEN )
+    set_target_properties( E57Format PROPERTIES CXX_VISIBILITY_PRESET hidden)
 endif()
 
 if ( WIN32 )


### PR DESCRIPTION
Hidden symbol visibility can be [helpful in various ways](https://gcc.gnu.org/wiki/Visibility).

In our case we limit shared library symbol to only public API methods that will be supported in the long term.
(The internals can change, the API may grow, but compatibility is assured)

This change adds a E57_VISIBILITY_HIDDEN cmake option for libE57Format.

