### PR TITLE
CheckedFile: Linux open64 mode flags to match what POSIX/C99 fopen

### DIFF
--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -163,7 +163,11 @@ CheckedFile::CheckedFile( const ustring &fileName, Mode mode, ReadChecksumPolicy
 
       case WriteCreate:
          /// File truncated to zero length if already exists
+#if defined( _MSC_VER )
          fd_ = open64( fileName_, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, S_IWRITE | S_IREAD );
+#else
+         fd_ = open64( fileName_, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH );
+#endif
          break;
 
       case WriteExisting:


### PR DESCRIPTION
On Linux the conventional permissions for POSIX/C99 [fopen](https://man7.org/linux/man-pages/man3/fopen.3.html):

> Any created file will have the mode S_IRUSR | S_IWUSR | S_IRGRP |
>        S_IWGRP | S_IROTH | S_IWOTH (0666), as modified by the process's
>        umask value (see [umask(2)](https://man7.org/linux/man-pages/man2/umask.2.html)).

It just seems "suprising" (and inconsistant) that a written E57 file is not group or other readable. (Aside from umask)