### PR TITLE
Fix: default to identity quaternion, rather than invalid

### DIFF
--- a/include/E57SimpleData.h
+++ b/include/E57SimpleData.h
@@ -71,7 +71,7 @@ namespace e57
    //! @brief Represents a rigid body rotation.
    struct E57_DLL Quaternion
    {
-      double w{ 0. }; //!< The real part of the quaternion. Shall be nonnegative
+      double w{ 1. }; //!< The real part of the quaternion. Shall be nonnegative
       double x{ 0. }; //!< The i coefficient of the quaternion
       double y{ 0. }; //!< The j coefficient of the quaternion
       double z{ 0. }; //!< The k coefficient of the quaternion


### PR DESCRIPTION
As discussed in PR #107 

Better to default to the indentity quaternion, rather than invalid one that might not be properly handled by consumers.

I'm not 100% certain w=1 _is_ the identity quaternion, but that's my impression.

See also [CloudCompare PR #1690](https://github.com/CloudCompare/CloudCompare/pull/1690)