### PR TITLE
CheckedFile: Fix recent change for errno on Windows

### DIFF
--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -220,8 +220,8 @@ int CheckedFile::open64( const ustring &fileName, int flags, int mode )
    std::wstring widePath = converter.from_bytes( fileName );
 
    int handle;
-   int err = _wsopen_s( &handle, widePath.c_str(), flags, _SH_DENYNO, mode );
-   if ( err < 0 )
+   errno_t err = _wsopen_s( &handle, widePath.c_str(), flags, _SH_DENYNO, mode );
+   if ( err != 0 )
    {
       throw E57_EXCEPTION2( E57_ERROR_OPEN_FAILED, "errno=" + toString( errno ) + " error='" + strerror( errno ) +
                                                       "' fileName=" + fileName + " flags=" + toString( flags ) +


### PR DESCRIPTION
The error needs to be checked for non-zero, not negative like an fd.

Fixes commit e7edc4fb5f6172ef0b998bc581c56f8ae0f1c4e8