### PR TITLE
{test} Set up basic testing with GoogleTest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+
+      - name: Checkout Test Data
+        uses: actions/checkout@v3
+        with:
+          repository: 'asmaloney/libE57Format-test-data'
+          path: libE57Format-test-data
+
+      - name: List Test Data Files (macOS/Linux)
+        if: matrix.config.os != 'windows-latest'
+        run: |
+          pwd
+
+          ls -laR libE57Format-test-data/images
+
+          ls -laR libE57Format-test-data/reference
+
+          ls -laR libE57Format-test-data/self
 
       - name: Install Dependencies (macOS)
         if: matrix.config.os == 'macos-latest'
@@ -81,5 +100,7 @@ jobs:
           .
 
       - name: Build
-        run: |
-          cmake --build libE57Format-build
+        run: cmake --build libE57Format-build
+
+      - name: Test
+        run: libE57Format-build/test/testE57

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -6,15 +6,10 @@ jobs:
   formatting-check:
     name: Formatting Check
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        path:
-          - 'include'
-          - 'src'
     steps:
       - uses: actions/checkout@v3
       - name: Run clang-format style check
         uses: jidicula/clang-format-action@v4.9.0
         with:
           clang-format-version: '13'
-          check-path: ${{ matrix.path }}
+          exclude-regex: 'extern'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/extern/googletest"]
+	path = test/extern/googletest
+	url = https://github.com/google/googletest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,6 @@ if( BUILD_SHARED_LIBS )
 endif()
 
 #########################################################################################
-
 # Various levels of cross checking and verification in the code.
 # The extra code does not change the file contents.
 # Recommend that E57_DEBUG remain defined even for production versions.
@@ -124,6 +123,7 @@ if ( CCACHE_PROGRAM )
 endif()
 
 include( E57ExportHeader )
+include( GitUpdate )
 
 # Main sources and includes
 add_subdirectory( extern/CRCpp )
@@ -195,6 +195,18 @@ install(
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
 )
+
+# Testing
+option( E57_BUILD_TEST
+    "Build tests"
+    ${E57_BUILDING_SELF}
+)
+
+if ( E57_BUILD_TEST )
+    enable_testing()
+
+    add_subdirectory( test )
+endif()
 
 # CMake package files
 install(

--- a/cmake/Modules/GitUpdate.cmake
+++ b/cmake/Modules/GitUpdate.cmake
@@ -1,0 +1,22 @@
+find_package( Git QUIET )
+
+if ( GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git" )
+    # Update submodules as needed
+    option( E57_GIT_SUBMODULE_UPDATE "Check submodules and update during build" ON )
+
+    if ( E57_GIT_SUBMODULE_UPDATE )
+        message( STATUS "Submodule update using git (${GIT_EXECUTABLE})" )
+        message( STATUS "Submodule update directory: ${CMAKE_CURRENT_SOURCE_DIR}" )
+
+        execute_process( COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+                            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                            RESULT_VARIABLE GIT_SUBMOD_RESULT
+                            ERROR_VARIABLE GIT_SUBMOD_RESULT)
+
+        if ( GIT_SUBMOD_RESULT EQUAL "0" )
+            message( STATUS "Submodule update complete" )
+        else()
+            message( FATAL_ERROR "Submodule update failed with ${GIT_SUBMOD_RESULT}, please checkout submodules" )
+        endif()
+    endif()
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2022 Andy Maloney <asmaloney@gmail.com>
+
+project( testE57
+    LANGUAGES
+        CXX
+)
+
+add_executable( testE57 )
+
+add_subdirectory( include )
+add_subdirectory( src )
+
+set_target_properties( testE57
+	PROPERTIES
+	    CXX_STANDARD 14
+		CXX_STANDARD_REQUIRED YES
+		CXX_EXTENSIONS NO
+		POSITION_INDEPENDENT_CODE ON
+)
+
+if ( E57_VISIBILITY_HIDDEN )
+	set_target_properties( testE57 PROPERTIES CXX_VISIBILITY_PRESET hidden)
+endif()
+
+# ccache
+# https://crascit.com/2016/04/09/using-ccache-with-cmake/
+find_program( CCACHE_PROGRAM ccache )
+if ( CCACHE_PROGRAM )
+    message( STATUS "[E57 Test] Using ccache" )
+    set_target_properties( testE57
+        PROPERTIES
+            CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}"
+            C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}"
+    )
+endif()
+
+target_link_libraries( testE57
+    PRIVATE
+        E57Format
+)
+
+# Turn on ASAN
+target_link_libraries( testE57
+    PRIVATE
+        $<$<CONFIG:DEBUG>:-fno-omit-frame-pointer>
+        $<$<CONFIG:DEBUG>:-fsanitize=address>
+)
+
+# Test data
+# Find our test data and offer an option to set the path to it
+find_path( E57_TEST_DATA_PATH
+    NAMES libE57Format-test-data
+    PATHS
+        ${PROJECT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/..
+        ${PROJECT_SOURCE_DIR}/../..
+    NO_DEFAULT_PATH
+    DOC "Path to directory containing the libE57Format-test-data repository"
+)
+
+if ( E57_TEST_DATA_PATH )
+    message( STATUS "[E57 Test] Using test data from: ${E57_TEST_DATA_PATH}/libE57Format-test-data")
+
+    target_compile_definitions( testE57
+        PRIVATE
+            TEST_DATA_PATH="${E57_TEST_DATA_PATH}/libE57Format-test-data"
+    )
+else()
+    message( WARNING "[E57 Test] Test data not found. Please set E57_TEST_DATA_PATH to the directory containing libE57Format-test-data.")
+endif()
+
+# GoogleTest from here: https://github.com/google/googletest
+
+if ( NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/extern/googletest/CMakeLists.txt" )
+    message( FATAL_ERROR "[E57 Test] The GoogleTest submodule was not downloaded. E57_GIT_SUBMODULE_UPDATE was turned off or failed. Please update submodules and try again." )
+endif()
+
+set( BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject" )
+set( INSTALL_GTEST OFF CACHE BOOL "Enable installation of googletest. (Projects embedding googletest may want to turn this OFF.)" )
+
+if ( MSVC )
+    # Prevent overriding the parent project's compiler/linker settings on Windows
+    set( gtest_force_shared_crt ON CACHE BOOL "" FORCE )
+endif()
+
+add_subdirectory( extern/googletest )
+
+unset( BUILD_GMOCK CACHE )
+unset( INSTALL_GTEST CACHE )
+
+target_include_directories( testE57
+    PRIVATE
+        "${gtest_SOURCE_DIR}/include"
+)
+
+target_link_libraries( testE57
+    PRIVATE
+        gtest_main
+)

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,43 @@
+# libE57Format Testing
+
+Testing uses the [GoogleTest](https://github.com/google/googletest) framework. The documentation for it may be [found here](https://google.github.io/googletest/).
+
+## Turning Testing On
+
+To turn testing on, set the CMake option `E57_BUILD_TEST` to ON.
+
+## Testing Data
+
+Currently, the testing data is found in another repo: [libE57Format-test-data](https://github.com/asmaloney/libE57Format-test-data).
+
+As we build out testing, the number & size of the test data might grow very quickly. For this reason, the test data is kept separate from the main repo. This gives us some flexibility depending on how large the data set becomes. If ends up being too big for a git repo, for example, we can make it available as a zip download somewhere. It will also let us manage the data in CI better so it doesn't have to be downloaded every time CI is run.
+
+CMake will attempt to find this test data in the following locations:
+
+- in this test directory (`./libE57Format-test-data`)
+- in the parent directory (`../libE57Format-test-data`)
+- in the grandparent directory (`../../libE57Format-test-data`)
+
+If it is found, `E57_TEST_DATA_PATH` will be set automatically.
+
+If not, you can set `E57_TEST_DATA_PATH` manually to point at the directory containing `libE57Format-test-data`.
+
+A couple of minor tests can run without this test data, but for more complete coverage, it should be present.
+
+## Adding New Tests
+
+If the tests being added require data from the testing data repository, then the name of the test suite needs to end with `Data`. These tests will be skipped if the data files are not available.
+
+e.g.
+
+```cpp
+TEST( SimpleWriter, WriteFoo )
+{
+   // Will always run
+}
+
+TEST( SimpleWriterData, WriteFoo )
+{
+   // Will only run if the test data is available
+}
+```

--- a/test/include/CMakeLists.txt
+++ b/test/include/CMakeLists.txt
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2022 Andy Maloney <asmaloney@gmail.com>
+
+target_sources( ${PROJECT_NAME}
+	PRIVATE
+	    ${CMAKE_CURRENT_SOURCE_DIR}/Helpers.h
+		${CMAKE_CURRENT_SOURCE_DIR}/TestData.h
+)
+
+target_include_directories( ${PROJECT_NAME}
+	PUBLIC
+	    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)

--- a/test/include/Helpers.h
+++ b/test/include/Helpers.h
@@ -1,0 +1,17 @@
+#pragma once
+// libE57Format testing Copyright © 2022 Andy Maloney <asmaloney@gmail.com>
+// SPDX-License-Identifier: MIT
+
+// GoogleTest's ASSERT_NO_THROW() doesn't let us show any info about the exceptions.
+// This wrapper macro will output the e57::E57Exception context on failure.
+#define E57_ASSERT_NO_THROW( code )                                                                                    \
+   try                                                                                                                 \
+   {                                                                                                                   \
+      code;                                                                                                            \
+   }                                                                                                                   \
+   catch ( e57::E57Exception & err )                                                                                   \
+   {                                                                                                                   \
+      FAIL() << err.errorStr() << ": " << err.context();                                                               \
+   }
+
+#define E57_ASSERT_THROW( code ) ASSERT_THROW( code, e57::E57Exception )

--- a/test/include/TestData.h
+++ b/test/include/TestData.h
@@ -1,0 +1,12 @@
+#pragma once
+// libE57Format testing Copyright © 2022 Andy Maloney <asmaloney@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include <string>
+
+namespace TestData
+{
+   bool Exists();
+
+   const std::string &Path();
+}

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2022 Andy Maloney <asmaloney@gmail.com>
+
+target_sources( ${PROJECT_NAME}
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/TestData.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_SimpleReader.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_SimpleWriter.cpp
+)

--- a/test/src/TestData.cpp
+++ b/test/src/TestData.cpp
@@ -1,0 +1,49 @@
+// libE57Format testing Copyright © 2022 Andy Maloney <asmaloney@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include <fstream>
+#include <sys/stat.h>
+
+#include "gtest/gtest.h"
+
+#include "TestData.h"
+
+namespace
+{
+   bool dirExists( const std::string &inPath )
+   {
+      struct stat info = {};
+
+      if ( stat( inPath.c_str(), &info ) != 0 )
+      {
+         return false;
+      }
+
+      return info.st_mode & S_IFDIR;
+   }
+}
+
+namespace TestData
+{
+#ifndef TEST_DATA_PATH
+#pragma message( "warning: Test data not found. Some tests will not be run." )
+#define TEST_DATA_PATH "DATA_NOT_FOUND"
+#endif
+
+   static const std::string sPath( TEST_DATA_PATH );
+
+   const std::string &Path()
+   {
+      return sPath;
+   }
+
+   bool Exists()
+   {
+      return dirExists( TestData::Path() );
+   }
+}
+
+TEST( TestData, RepoExists )
+{
+   ASSERT_TRUE( dirExists( TestData::Path() ) ) << "Data path: " << TestData::Path();
+}

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -1,0 +1,20 @@
+// libE57Format testing Copyright © 2022 Andy Maloney <asmaloney@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include "gtest/gtest.h"
+
+#include "TestData.h"
+
+int main( int argc, char **argv )
+{
+   ::testing::FLAGS_gtest_color = "yes";
+   ::testing::InitGoogleTest( &argc, argv );
+
+   // IF our data path doesn't exist, then exclude some tests.
+   if ( !TestData::Exists() )
+   {
+      ::testing::GTEST_FLAG( filter ) = "-*Data.*";
+   }
+
+   return RUN_ALL_TESTS();
+}

--- a/test/src/test_SimpleReader.cpp
+++ b/test/src/test_SimpleReader.cpp
@@ -1,0 +1,118 @@
+// libE57Format testing Copyright © 2022 Andy Maloney <asmaloney@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include "gtest/gtest.h"
+
+#include "E57SimpleReader.h"
+
+#include "Helpers.h"
+#include "TestData.h"
+
+namespace
+{
+   void CheckFileHeader( const e57::E57Root &fileHeader )
+   {
+      // These are invariant.
+      // See ASTM Standard Table 12.
+
+      EXPECT_EQ( fileHeader.formatName, "ASTM E57 3D Imaging Data File" );
+      EXPECT_EQ( fileHeader.versionMajor, 1 );
+      EXPECT_EQ( fileHeader.versionMinor, 0 );
+   }
+}
+
+TEST( SimpleReader, PathError )
+{
+   E57_ASSERT_THROW( e57::Reader( "./no-path/empty.e57" ) );
+}
+
+TEST( SimpleReaderData, ReadEmpty )
+{
+   e57::Reader *reader = nullptr;
+
+   E57_ASSERT_NO_THROW( reader = new e57::Reader( TestData::Path() + "/self/empty.e57" ) );
+
+   ASSERT_TRUE( reader->IsOpen() );
+   EXPECT_EQ( reader->GetImage2DCount(), 0 );
+   EXPECT_EQ( reader->GetData3DCount(), 0 );
+
+   e57::E57Root fileHeader;
+   ASSERT_TRUE( reader->GetE57Root( fileHeader ) );
+
+   CheckFileHeader( fileHeader );
+   EXPECT_EQ( fileHeader.guid, "File GUID" );
+
+   delete reader;
+}
+
+TEST( SimpleReaderData, BadCRC )
+{
+   E57_ASSERT_THROW( e57::Reader( TestData::Path() + "/self/bad-crc.e57" ) );
+}
+
+// https://github.com/asmaloney/libE57Format/issues/26
+// File name UTF-8 encoded to avoid editor issues.
+TEST( SimpleReaderData, ReadChineseFileName )
+{
+   E57_ASSERT_NO_THROW(
+      e57::Reader( TestData::Path() + "/self/\xe6\xb5\x8b\xe8\xaf\x95\xe7\x82\xb9\xe4\xba\x91.e57" ) );
+}
+
+// https://github.com/asmaloney/libE57Format/issues/69
+// File name UTF-8 encoded to avoid editor issues.
+// No idea why this fails on Linux and Windows with "No such file or directory".
+// TEST( SimpleReaderData, ReadUmlautFileName )
+//{
+//   E57_ASSERT_NO_THROW(
+//      e57::Reader( TestData::Path() + "/self/test filename \x61\xcc\x88\x6f\xcc\x88\x75\xcc\x88.e57" ) );
+//}
+
+TEST( SimpleReaderData, ReadBunnyDouble )
+{
+   e57::Reader *reader = nullptr;
+
+   E57_ASSERT_NO_THROW( reader = new e57::Reader( TestData::Path() + "/reference/bunnyDouble.e57" ) );
+
+   ASSERT_TRUE( reader->IsOpen() );
+   EXPECT_EQ( reader->GetImage2DCount(), 0 );
+   ASSERT_EQ( reader->GetData3DCount(), 1 );
+
+   e57::E57Root fileHeader;
+   ASSERT_TRUE( reader->GetE57Root( fileHeader ) );
+
+   CheckFileHeader( fileHeader );
+   EXPECT_EQ( fileHeader.guid, "{19AA90ED-145E-4B3B-922C-80BC00648844}" );
+
+   e57::Data3D data3DHeader;
+   ASSERT_TRUE( reader->ReadData3D( 0, data3DHeader ) );
+
+   ASSERT_EQ( data3DHeader.pointsSize, 30'571 );
+   EXPECT_EQ( data3DHeader.guid, "{9CA24C38-C93E-40E8-A366-F49977C7E3EB}" );
+
+   delete reader;
+}
+
+TEST( SimpleReaderData, ReadBunnyInt32 )
+{
+   e57::Reader *reader = nullptr;
+
+   E57_ASSERT_NO_THROW( reader = new e57::Reader( TestData::Path() + "/reference/bunnyInt32.e57" ) );
+
+   ASSERT_TRUE( reader->IsOpen() );
+   EXPECT_EQ( reader->GetImage2DCount(), 0 );
+   ASSERT_EQ( reader->GetData3DCount(), 1 );
+
+   e57::E57Root fileHeader;
+   ASSERT_TRUE( reader->GetE57Root( fileHeader ) );
+
+   CheckFileHeader( fileHeader );
+   EXPECT_EQ( fileHeader.guid, "{991574D2-854C-4CEF-8CB8-D0132E4BCD0A}" );
+
+   e57::Data3D data3DHeader;
+   ASSERT_TRUE( reader->ReadData3D( 0, data3DHeader ) );
+
+   EXPECT_EQ( data3DHeader.pointsSize, 30'571 );
+   EXPECT_EQ( data3DHeader.guid, "{9CA24C38-C93E-40E8-A366-F49977C7E3EB}" );
+
+   delete reader;
+}

--- a/test/src/test_SimpleWriter.cpp
+++ b/test/src/test_SimpleWriter.cpp
@@ -1,0 +1,194 @@
+// libE57Format testing Copyright © 2022 Andy Maloney <asmaloney@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include <fstream>
+
+#include "gtest/gtest.h"
+
+#include "E57SimpleWriter.h"
+
+#include "Helpers.h"
+#include "TestData.h"
+
+TEST( SimpleWriter, PathError )
+{
+   e57::WriterOptions options;
+   options.guid = "File GUID";
+
+   E57_ASSERT_THROW( e57::Writer( "./no-path/empty.e57", options ) );
+}
+
+TEST( SimpleWriter, WriteEmpty )
+{
+   e57::WriterOptions options;
+   options.guid = "File GUID";
+
+   E57_ASSERT_NO_THROW( e57::Writer writer( "./empty.e57", options ) );
+}
+
+// https://github.com/asmaloney/libE57Format/issues/26
+// File name UTF-8 encoded to avoid editor issues.
+TEST( SimpleWriter, WriteChineseFileName )
+{
+   e57::WriterOptions options;
+   options.guid = "File GUID";
+
+   E57_ASSERT_NO_THROW( e57::Writer writer( "./\xe6\xb5\x8b\xe8\xaf\x95\xe7\x82\xb9\xe4\xba\x91.e57", options ) );
+}
+
+// https://github.com/asmaloney/libE57Format/issues/69
+// File name UTF-8 encoded to avoid editor issues.
+TEST( SimpleWriter, WriteUmlautFileName )
+{
+   e57::WriterOptions options;
+   options.guid = "File GUID";
+
+   E57_ASSERT_NO_THROW( e57::Writer writer( "./test filename \x61\xcc\x88\x6f\xcc\x88\x75\xcc\x88.e57", options ) );
+}
+
+TEST( SimpleWriter, WriteCartesianPoints )
+{
+   e57::WriterOptions options;
+   options.guid = "File GUID";
+
+   e57::Writer *writer = nullptr;
+
+   E57_ASSERT_NO_THROW( writer = new e57::Writer( "./Cartesian-Points-1025.e57", options ) );
+
+   constexpr int64_t cNumPoints = 1025;
+
+   e57::Data3D header;
+   header.guid = "Header GUID";
+   header.pointsSize = cNumPoints;
+   header.pointFields.cartesianXField = true;
+   header.pointFields.cartesianYField = true;
+   header.pointFields.cartesianZField = true;
+
+   const int64_t scanIndex = writer->NewData3D( header );
+
+   e57::Data3DPointsData pointsData;
+   pointsData.cartesianX = new float[cNumPoints];
+   pointsData.cartesianY = new float[cNumPoints];
+   pointsData.cartesianZ = new float[cNumPoints];
+
+   for ( int64_t i = 0; i < cNumPoints; ++i )
+   {
+      auto floati = static_cast<float>( i );
+      pointsData.cartesianX[i] = floati;
+      pointsData.cartesianY[i] = floati;
+      pointsData.cartesianZ[i] = floati;
+   }
+
+   e57::CompressedVectorWriter dataWriter = writer->SetUpData3DPointsData( scanIndex, cNumPoints, pointsData );
+
+   dataWriter.write( cNumPoints );
+   dataWriter.close();
+
+   delete[] pointsData.cartesianX;
+   delete[] pointsData.cartesianY;
+   delete[] pointsData.cartesianZ;
+
+   delete writer;
+}
+
+TEST( SimpleWriter, WriteColouredCartesianPoints )
+{
+   e57::WriterOptions options;
+   options.guid = "File GUID";
+
+   e57::Writer *writer = nullptr;
+
+   E57_ASSERT_NO_THROW( writer = new e57::Writer( "./Coloured-Cartesian-Points-1025.e57", options ) );
+
+   constexpr int64_t cNumPoints = 1025;
+
+   e57::Data3D header;
+   header.guid = "Header GUID";
+   header.pointsSize = cNumPoints;
+   header.pointFields.cartesianXField = true;
+   header.pointFields.cartesianYField = true;
+   header.pointFields.cartesianZField = true;
+   header.pointFields.colorRedField = true;
+   header.pointFields.colorGreenField = true;
+   header.pointFields.colorBlueField = true;
+   header.colorLimits.colorRedMaximum = 255;
+   header.colorLimits.colorGreenMaximum = 255;
+   header.colorLimits.colorBlueMaximum = 255;
+
+   const int64_t scanIndex = writer->NewData3D( header );
+
+   e57::Data3DPointsData pointsData;
+   pointsData.cartesianX = new float[cNumPoints];
+   pointsData.cartesianY = new float[cNumPoints];
+   pointsData.cartesianZ = new float[cNumPoints];
+   pointsData.colorRed = new uint8_t[cNumPoints];
+   pointsData.colorGreen = new uint8_t[cNumPoints];
+   pointsData.colorBlue = new uint8_t[cNumPoints];
+
+   for ( int64_t i = 0; i < cNumPoints; ++i )
+   {
+      auto floati = static_cast<float>( i );
+      pointsData.cartesianX[i] = floati;
+      pointsData.cartesianY[i] = floati;
+      pointsData.cartesianZ[i] = floati;
+
+      pointsData.colorRed[i] = 0;
+      pointsData.colorGreen[i] = 0;
+      pointsData.colorBlue[i] = 255;
+   }
+
+   e57::CompressedVectorWriter dataWriter = writer->SetUpData3DPointsData( scanIndex, cNumPoints, pointsData );
+
+   dataWriter.write( cNumPoints );
+   dataWriter.close();
+
+   delete[] pointsData.cartesianX;
+   delete[] pointsData.cartesianY;
+   delete[] pointsData.cartesianZ;
+   delete[] pointsData.colorRed;
+   delete[] pointsData.colorGreen;
+   delete[] pointsData.colorBlue;
+
+   delete writer;
+}
+
+TEST( SimpleWriterData, WriteVisualRefImage )
+{
+   e57::WriterOptions options;
+   options.guid = "File GUID";
+
+   e57::Writer *writer = nullptr;
+
+   E57_ASSERT_NO_THROW( writer = new e57::Writer( "./VisualRefImage.e57", options ) );
+
+   std::ifstream image( TestData::Path() + "/images/image.jpg", std::ifstream::ate | std::ifstream::binary );
+
+   ASSERT_EQ( image.rdstate(), std::ios_base::goodbit );
+
+   const int64_t cImageSize = image.tellg();
+
+   image.clear();
+   image.seekg( 0 );
+
+   auto imageBuffer = new char[cImageSize];
+
+   image.read( imageBuffer, cImageSize );
+
+   ASSERT_EQ( image.rdstate(), std::ios_base::goodbit );
+
+   e57::Image2D image2DHeader;
+   image2DHeader.name = "JPEG Image Test";
+   image2DHeader.guid = "JPEG Image GUID";
+   image2DHeader.description = "JPEG image test";
+   image2DHeader.visualReferenceRepresentation.imageWidth = 225;
+   image2DHeader.visualReferenceRepresentation.imageHeight = 300;
+   image2DHeader.visualReferenceRepresentation.jpegImageSize = cImageSize;
+
+   int64_t imageIndex = writer->NewImage2D( image2DHeader );
+
+   writer->WriteImage2DData( imageIndex, e57::E57_JPEG_IMAGE, e57::E57_VISUAL, imageBuffer, 0, cImageSize );
+
+   delete[] imageBuffer;
+
+   delete writer;
+}


### PR DESCRIPTION
This sets up a testing framework using [GoogleTest](https://google.github.io/googletest/).

It uses test data from another repo ([libE57Format-test-data](https://github.com/asmaloney/libE57Format-test-data)) to keep this one a reasonable size. If the test data is not found, it will still run a coupe of basic write tests.

It is set up to run in the CI with the test data from the other repo.

I am looking for feedback on this setup before I merge it.