### PR TITLE
E57Simple: Reading & Writing cleanups

### DIFF
--- a/include/E57SimpleData.h
+++ b/include/E57SimpleData.h
@@ -450,7 +450,7 @@ namespace e57
       Data3DPointsData_t() = default;
 
       //! @brief Constructor which allocates buffers for all valid fields in the given Data3D header
-      //! @param [in] data3D Completed header which indicates the fields wee are using
+      //! @param [in] data3D Completed header which indicates the fields we are using
       explicit Data3DPointsData_t( const e57::Data3D &data3D );
 
       //! @brief Destructor will delete any memory allocated using the Data3DPointsData_t( const e57::Data3D & )

--- a/src/E57SimpleData.cpp
+++ b/src/E57SimpleData.cpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: BSL-1.0
 // Copyright (c) 2020 PTC Inc.
+// Copyright (c) 2022 Andy Maloney <asmaloney@gmail.com>
 
-// for M_PI. This needs to be first, otherwise we might already include math header
+// For M_PI. This needs to be first, otherwise we might already include math header
 // without M_PI and we would get nothing because of the header guards.
 #define _USE_MATH_DEFINES
 #include <cmath>
@@ -20,8 +21,11 @@ namespace e57
       rangeMaximum = E57_DOUBLE_MAX;
       azimuthStart = -M_PI;
       azimuthEnd = M_PI;
-      elevationMinimum = -M_PI / 2.;
-      elevationMaximum = M_PI / 2.;
+
+      constexpr auto HALF_PI = M_PI / 2.0;
+
+      elevationMinimum = -HALF_PI;
+      elevationMaximum = HALF_PI;
    }
 
    template <typename COORDTYPE>

--- a/src/E57SimpleReader.cpp
+++ b/src/E57SimpleReader.cpp
@@ -78,7 +78,12 @@ namespace e57
    int64_t Reader::ReadImage2DData( int64_t imageIndex, Image2DProjection imageProjection, Image2DType imageType,
                                     void *pBuffer, int64_t start, int64_t count ) const
    {
-      return impl_->ReadImage2DData( imageIndex, imageProjection, imageType, pBuffer, start, count );
+      auto *buffer = static_cast<uint8_t *>( pBuffer );
+      const auto size = static_cast<size_t>( count );
+
+      const size_t read = impl_->ReadImage2DData( imageIndex, imageProjection, imageType, buffer, start, size );
+
+      return static_cast<int64_t>( read );
    };
 
    int64_t Reader::GetData3DCount() const

--- a/src/E57SimpleWriter.cpp
+++ b/src/E57SimpleWriter.cpp
@@ -81,8 +81,13 @@ namespace e57
    int64_t Writer::WriteImage2DData( int64_t imageIndex, Image2DType imageType, Image2DProjection imageProjection,
                                      void *pBuffer, int64_t start, int64_t count )
    {
-      return impl_->WriteImage2DData( imageIndex, imageType, imageProjection, pBuffer, start, count );
-   };
+      auto *buffer = static_cast<uint8_t *>( pBuffer );
+      const auto size = static_cast<size_t>( count );
+
+      const size_t written = impl_->WriteImage2DData( imageIndex, imageType, imageProjection, buffer, start, size );
+
+      return static_cast<int64_t>( written );
+   }
 
    int64_t Writer::NewData3D( Data3D &data3DHeader )
    {

--- a/src/ReaderImpl.h
+++ b/src/ReaderImpl.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2010 Stan Coleby (scoleby@intelisum.com)
  * Copyright (c) 2020 PTC Inc.
+ * Copyright (c) 2022 Andy Maloney <asmaloney@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person or organization
  * obtaining a copy of the software and accompanying documentation covered by
@@ -32,14 +33,18 @@
 
 namespace e57
 {
-
    //! most of the functions follows Reader
    class ReaderImpl
    {
    public:
       explicit ReaderImpl( const ustring &filePath, const ReaderOptions &options );
-
       ~ReaderImpl();
+
+      // disallow copying a ReaderImpl
+      ReaderImpl( const ReaderImpl & ) = delete;
+      ReaderImpl &operator=( ReaderImpl const & ) = delete;
+      ReaderImpl( const ReaderImpl && ) = delete;
+      ReaderImpl &operator=( const ReaderImpl && ) = delete;
 
       bool IsOpen() const;
 
@@ -55,8 +60,8 @@ namespace e57
                             int64_t &imageWidth, int64_t &imageHeight, int64_t &imageSize, Image2DType &imageMaskType,
                             Image2DType &imageVisualType ) const;
 
-      int64_t ReadImage2DData( int64_t imageIndex, Image2DProjection imageProjection, Image2DType imageType,
-                               void *pBuffer, int64_t start, int64_t count ) const;
+      size_t ReadImage2DData( int64_t imageIndex, Image2DProjection imageProjection, Image2DType imageType,
+                              uint8_t *pBuffer, int64_t start, size_t count ) const;
 
       int64_t GetData3DCount() const;
 
@@ -87,27 +92,5 @@ namespace e57
       VectorNode data3D_;
 
       VectorNode images2D_;
-
-      //! @brief This function reads one of the image blobs
-      //! @param [in] image 1 of 3 projects or the visual
-      //! @param [out] imageType identifies the image format desired.
-      //! @param [out] imageWidth The image width (in pixels).
-      //! @param [out] imageHeight The image height (in pixels).
-      //! @param [out] imageSize This is the total number of bytes for the image blob.
-      //! @param [out] imageMaskType This is E57_PNG_IMAGE_MASK if "imageMask" is defined in the projection
-      //! @return Returns true if successful
-      bool GetImage2DNodeSizes( StructureNode image, Image2DType &imageType, int64_t &imageWidth, int64_t &imageHeight,
-                                int64_t &imageSize, Image2DType &imageMaskType ) const;
-
-      //! @brief Reads the data out of a given image node
-      //! @param [in] image 1 of 3 projects or the visual
-      //! @param [in] imageType identifies the image format desired.
-      //! @param [out] pBuffer pointer the buffer
-      //! @param [out] start position in the block to start reading
-      //! @param [out] count size of desired chuck or buffer size
-      //! @return number of bytes read
-      int64_t ReadImage2DNode( StructureNode image, Image2DType imageType, void *pBuffer, int64_t start,
-                               int64_t count ) const;
    }; // end Reader class
-
 } // end namespace e57

--- a/src/WriterImpl.h
+++ b/src/WriterImpl.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2010 Stan Coleby (scoleby@intelisum.com)
  * Copyright (c) 2020 PTC Inc.
+ * Copyright (c) 2022 Andy Maloney <asmaloney@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person or organization
  * obtaining a copy of the software and accompanying documentation covered by
@@ -32,14 +33,18 @@
 
 namespace e57
 {
-
    //! most of the functions follows Writer
    class WriterImpl
    {
    public:
       WriterImpl( const ustring &filePath, const WriterOptions &options );
-
       ~WriterImpl();
+
+      // disallow copying a WriterImpl
+      WriterImpl( const WriterImpl & ) = delete;
+      WriterImpl &operator=( WriterImpl const & ) = delete;
+      WriterImpl( const WriterImpl && ) = delete;
+      WriterImpl &operator=( const WriterImpl && ) = delete;
 
       bool IsOpen() const;
 
@@ -47,8 +52,8 @@ namespace e57
 
       int64_t NewImage2D( Image2D &image2DHeader );
 
-      int64_t WriteImage2DData( int64_t imageIndex, Image2DType imageType, Image2DProjection imageProjection,
-                                void *pBuffer, int64_t start, int64_t count );
+      size_t WriteImage2DData( int64_t imageIndex, Image2DType imageType, Image2DProjection imageProjection,
+                               uint8_t *pBuffer, int64_t start, size_t count );
 
       int64_t NewData3D( Data3D &data3DHeader );
 
@@ -74,15 +79,5 @@ namespace e57
       VectorNode data3D_;
 
       VectorNode images2D_;
-
-      //! @brief This function writes the projection image
-      //! @param image 1 of 3 projects or the visual
-      //! @param imageType identifies the image format desired.
-      //! @param pBuffer pointer the buffer
-      //! @param start position in the block to start reading
-      //! @param count size of desired chuck or buffer size
-      int64_t WriteImage2DNode( StructureNode image, Image2DType imageType, void *pBuffer, int64_t start,
-                                int64_t count );
    }; // end Writer class
-
 } // end namespace e57


### PR DESCRIPTION
- avoid extra copying of nodes
- avoid getting the same prototype multiple times
- add consts
- replace C-style casts with static_cast
- avoid casting by changing internal function prototypes
- disallow copying of implementation classes
- formatting & style