### PR TITLE
Add extensionsLookupPrefix overload for more concise user code

### DIFF
--- a/include/E57Format.h
+++ b/include/E57Format.h
@@ -655,6 +655,7 @@ protected:                                                                      
 
       // Manipulate registered extensions in the file
       void extensionsAdd( const ustring &prefix, const ustring &uri );
+      bool extensionsLookupPrefix( const ustring &prefix ) const;
       bool extensionsLookupPrefix( const ustring &prefix, ustring &uri ) const;
       bool extensionsLookupUri( const ustring &uri, ustring &prefix ) const;
       size_t extensionsCount() const;

--- a/src/ImageFile.cpp
+++ b/src/ImageFile.cpp
@@ -375,6 +375,26 @@ void ImageFile::extensionsAdd( const ustring &prefix, const ustring &uri )
 }
 
 /*!
+@brief   Look up an E57 extension prefix in the ImageFile.
+@param   [in] prefix The shorthand name of the extension to look up.
+@details
+If @a prefix = "" or @a prefix is declared in the ImageFile, then the function returns true. It is an error if @a prefix
+contains an illegal character combination for E57 namespace prefixes.
+@pre     This ImageFile must be open (i.e. isOpen()).
+@post    No visible state is modified.
+@return  true if prefix is declared in the ImageFile.
+@throw   ::E57_ERROR_BAD_API_ARGUMENT
+@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
+@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@see     ImageFile::extensionsLookupUri
+*/
+bool ImageFile::extensionsLookupPrefix( const ustring &prefix ) const
+{
+   ustring uri;
+   return impl_->extensionsLookupPrefix( prefix, uri );
+}
+
+/*!
 @brief   Get URI associated with an E57 extension prefix in the ImageFile.
 @param   [in] prefix    The shorthand name of the extension to look up.
 @param   [out] uri      The URI that was associated with the given @a prefix.

--- a/src/ReaderImpl.cpp
+++ b/src/ReaderImpl.cpp
@@ -1136,8 +1136,7 @@ namespace e57
 
       // E57_EXT_surface_normals
       // See: http://www.libe57.org/E57_EXT_surface_normals.txt
-      ustring norExtUri;
-      if ( imf_.extensionsLookupPrefix( "nor", norExtUri ) )
+      if ( imf_.extensionsLookupPrefix( "nor" ) )
       {
          data3DHeader.pointFields.normalXField = proto.isDefined( "nor:normalX" );
          data3DHeader.pointFields.normalYField = proto.isDefined( "nor:normalY" );

--- a/src/WriterImpl.cpp
+++ b/src/WriterImpl.cpp
@@ -941,8 +941,7 @@ namespace e57
            data3DHeader.pointFields.normalZField )
       {
          // make sure we declare the extension before using the fields with prefix
-         ustring norExtUri;
-         if ( !imf_.extensionsLookupPrefix( "nor", norExtUri ) )
+         if ( !imf_.extensionsLookupPrefix( "nor" ) )
          {
             imf_.extensionsAdd( "nor", "http://www.libe57.org/E57_EXT_surface_normals.txt" );
          }
@@ -1088,8 +1087,7 @@ namespace e57
       }
 
       // E57_EXT_surface_normals
-      ustring norExtUri;
-      if ( imf_.extensionsLookupPrefix( "nor", norExtUri ) )
+      if ( imf_.extensionsLookupPrefix( "nor" ) )
       {
          if ( proto.isDefined( "nor:normalX" ) && ( buffers.normalX != nullptr ) )
          {


### PR DESCRIPTION
Users of the API probably don't care about the extension URI in general. Some don't even point to valid files online.