### PR TITLE
Change default checksum policies to an enum

### DIFF
--- a/include/E57Format.h
+++ b/include/E57Format.h
@@ -89,18 +89,46 @@ namespace e57
       E57_USTRING = 11 //!< Unicode UTF-8 std::string
    };
 
+   //! @brief Default checksum policies for e57::ReadChecksumPolicy
+   //! @details These are some convenient default checksum policies, though you can use any value you want (0-100).
+   enum ChecksumPolicy
+   {
+      None = 0,    ///< Do not verify the checksums. (fast)
+      Sparse = 25, ///< Only verify 25% of the checksums. The last block is always verified.
+      Half = 50,   ///< Only verify 50% of the checksums. The last block is always verified.
+      All = 100    ///< Verify all checksums. This is the default. (slow)
+   };
+
    //! @brief Specifies the percentage of checksums which are verified when reading
    //! an ImageFile (0-100%).
+   //! @see e57::ChecksumPolicy
    using ReadChecksumPolicy = int;
 
+   //! @name Deprecated Checksum Policies
+   //! These have been replaced by the enum e57::ChecksumPolicy.
+   //!@{
+
    //! Do not verify the checksums. (fast)
+   //! @deprecated Will be removed in 4.0. Use ChecksumPolicy::None.
+   [[deprecated( "Will be removed in 4.0. Use ChecksumPolicy::None." )]] // TODO Remove in 4.0
    constexpr ReadChecksumPolicy CHECKSUM_POLICY_NONE = 0;
+
    //! Only verify 25% of the checksums. The last block is always verified.
+   //! @deprecated Will be removed in 4.0. Use ChecksumPolicy::Sparse.
+   [[deprecated( "Will be removed in 4.0. Use ChecksumPolicy::Sparse." )]] // TODO Remove in 4.0
    constexpr ReadChecksumPolicy CHECKSUM_POLICY_SPARSE = 25;
+
    //! Only verify 50% of the checksums. The last block is always verified.
+   //! @deprecated Will be removed in 4.0. Use ChecksumPolicy::Half.
+   [[deprecated( "Will be removed in 4.0. Use ChecksumPolicy::Half." )]] // TODO Remove in 4.0
    constexpr ReadChecksumPolicy CHECKSUM_POLICY_HALF = 50;
+
    //! Verify all checksums. This is the default. (slow)
+   //! @deprecated Will be removed in 4.0. Use ChecksumPolicy::All.
+   [[deprecated( "Will be removed in 4.0. Use ChecksumPolicy::All." )]] // TODO Remove in 4.0
    constexpr ReadChecksumPolicy CHECKSUM_POLICY_ALL = 100;
+
+   //!@}
 
    //! @brief The URI of ASTM E57 v1.0 standard XML namespace
    //! Note that even though this URI does not point to a valid document, the standard (section 8.4.2.3)
@@ -641,8 +669,8 @@ protected:                                                                      
    {
    public:
       ImageFile() = delete;
-      ImageFile( const ustring &fname, const ustring &mode, ReadChecksumPolicy checksumPolicy = CHECKSUM_POLICY_ALL );
-      ImageFile( const char *input, uint64_t size, ReadChecksumPolicy checksumPolicy = CHECKSUM_POLICY_ALL );
+      ImageFile( const ustring &fname, const ustring &mode, ReadChecksumPolicy checksumPolicy = ChecksumPolicy::All );
+      ImageFile( const char *input, uint64_t size, ReadChecksumPolicy checksumPolicy = ChecksumPolicy::All );
 
       StructureNode root() const;
       void close();

--- a/include/E57SimpleReader.h
+++ b/include/E57SimpleReader.h
@@ -43,7 +43,7 @@ namespace e57
    struct E57_DLL ReaderOptions
    {
       //! Set how frequently to verify the checksums (see ReadChecksumPolicy).
-      ReadChecksumPolicy checksumPolicy = CHECKSUM_POLICY_ALL;
+      ReadChecksumPolicy checksumPolicy = ChecksumPolicy::All;
    };
 
    //! @brief Used for reading an E57 file using E57 Simple API.

--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -70,7 +70,7 @@
 #include "CheckedFile.h"
 #include "StringFunctions.h"
 
-//#define E57_CHECK_FILE_DEBUG
+// #define E57_CHECK_FILE_DEBUG
 #ifdef E57_CHECK_FILE_DEBUG
 #include <cassert>
 #endif
@@ -289,10 +289,10 @@ void CheckedFile::read( char *buf, size_t nRead, size_t /*bufSize*/ )
 
       switch ( checkSumPolicy_ )
       {
-         case CHECKSUM_POLICY_NONE:
+         case ChecksumPolicy::None:
             break;
 
-         case CHECKSUM_POLICY_ALL:
+         case ChecksumPolicy::All:
             verifyChecksum( page_buffer, page );
             break;
 

--- a/src/CheckedFile.h
+++ b/src/CheckedFile.h
@@ -102,7 +102,7 @@ namespace e57
       uint64_t logicalLength_ = 0;
       uint64_t physicalLength_ = 0;
 
-      ReadChecksumPolicy checkSumPolicy_ = CHECKSUM_POLICY_ALL;
+      ReadChecksumPolicy checkSumPolicy_ = ChecksumPolicy::All;
 
       int fd_ = -1;
       BufferView *bufView_ = nullptr;

--- a/test/src/test_SimpleReader.cpp
+++ b/test/src/test_SimpleReader.cpp
@@ -52,7 +52,7 @@ TEST( SimpleReaderData, BadCRC )
 
 TEST( SimpleReaderData, DoNotCheckCRC )
 {
-   E57_ASSERT_NO_THROW( e57::Reader( TestData::Path() + "/self/bad-crc.e57", { e57::CHECKSUM_POLICY_NONE } ) );
+   E57_ASSERT_NO_THROW( e57::Reader( TestData::Path() + "/self/bad-crc.e57", { e57::ChecksumPolicy::None } ) );
 }
 
 // https://github.com/asmaloney/libE57Format/issues/26


### PR DESCRIPTION
Cleaner & easier to read than multiple constexprs (not quite sure why I did it that way to begin with...).