### PR TITLE
E57Simple: Use uint16_t for colours

### DIFF
--- a/include/E57SimpleData.h
+++ b/include/E57SimpleData.h
@@ -487,9 +487,9 @@ namespace e57
       //! Value = 0 if the intensity is considered valid, 1 otherwise
       int8_t *isIntensityInvalid = nullptr;
 
-      uint8_t *colorRed = nullptr;      //!< Pointer to a buffer with the Red color coefficient. Unit is unspecified
-      uint8_t *colorGreen = nullptr;    //!< Pointer to a buffer with the Green color coefficient. Unit is unspecified
-      uint8_t *colorBlue = nullptr;     //!< Pointer to a buffer with the Blue color coefficient. Unit is unspecified
+      uint16_t *colorRed = nullptr;     //!< Pointer to a buffer with the Red color coefficient. Unit is unspecified
+      uint16_t *colorGreen = nullptr;   //!< Pointer to a buffer with the Green color coefficient. Unit is unspecified
+      uint16_t *colorBlue = nullptr;    //!< Pointer to a buffer with the Blue color coefficient. Unit is unspecified
       int8_t *isColorInvalid = nullptr; //!< Value = 0 if the color is considered valid, 1 otherwise
 
       //! Pointer to a buffer with the range (in meters) of points in spherical coordinates.

--- a/src/E57SimpleData.cpp
+++ b/src/E57SimpleData.cpp
@@ -81,17 +81,17 @@ namespace e57
 
       if ( data3D.pointFields.colorRedField )
       {
-         colorRed = new uint8_t[cPointCount];
+         colorRed = new uint16_t[cPointCount];
       }
 
       if ( data3D.pointFields.colorGreenField )
       {
-         colorGreen = new uint8_t[cPointCount];
+         colorGreen = new uint16_t[cPointCount];
       }
 
       if ( data3D.pointFields.colorBlueField )
       {
-         colorBlue = new uint8_t[cPointCount];
+         colorBlue = new uint16_t[cPointCount];
       }
 
       if ( data3D.pointFields.isColorInvalidField )

--- a/test/src/test_SimpleReader.cpp
+++ b/test/src/test_SimpleReader.cpp
@@ -214,3 +214,42 @@ TEST( SimpleReaderData, BunnyInt32 )
 
    delete reader;
 }
+
+TEST( SimpleReaderData, ColourRepresentation )
+{
+   e57::Reader *reader = nullptr;
+
+   E57_ASSERT_NO_THROW( reader =
+                           new e57::Reader( TestData::Path() + "/3rdParty/las2e57/ColourRepresentation.e57", {} ) );
+
+   ASSERT_TRUE( reader->IsOpen() );
+   EXPECT_EQ( reader->GetImage2DCount(), 0 );
+   ASSERT_EQ( reader->GetData3DCount(), 1 );
+
+   e57::E57Root fileHeader;
+   ASSERT_TRUE( reader->GetE57Root( fileHeader ) );
+
+   CheckFileHeader( fileHeader );
+   EXPECT_EQ( fileHeader.guid, "6107aa44-6289-4e9c-80bd-f36cc3fbd44b" );
+
+   e57::Data3D data3DHeader;
+   ASSERT_TRUE( reader->ReadData3D( 0, data3DHeader ) );
+
+   ASSERT_EQ( data3DHeader.pointCount, 153 );
+   EXPECT_EQ( data3DHeader.guid, "98d85152-82b3-4120-b06e-0c1bb10b6dec" );
+
+   const uint64_t cNumPoints = data3DHeader.pointCount;
+
+   e57::Data3DPointsData pointsData( data3DHeader );
+
+   auto vectorReader = reader->SetUpData3DPointsData( 0, cNumPoints, pointsData );
+
+   uint64_t cNumRead = 0;
+   E57_ASSERT_NO_THROW( cNumRead = vectorReader.read() );
+
+   vectorReader.close();
+
+   EXPECT_EQ( cNumRead, cNumPoints );
+
+   delete reader;
+}


### PR DESCRIPTION
This allows us to use the E57Reader to read colours in las2e57-produced files.

Fixes #159