### PR TITLE
E57XmlParser: Parse doubles in a local-independent way

### DIFF
--- a/src/E57XmlParser.cpp
+++ b/src/E57XmlParser.cpp
@@ -85,17 +85,6 @@ inline int64_t convertStrToLL( const std::string &inStr )
 #endif
 }
 
-/// Parse a double according the the classic ("C") locale.
-/// \return The parsed double or 0.0 on error.
-inline double convertStrToDouble( const std::string &inStr )
-{
-    std::istringstream iss{ inStr };
-    iss.imbue( std::locale::classic() );
-    double res = 0.;
-    iss >> res;
-    return res;
-}
-
 //=============================================================================
 // E57FileInputStream
 
@@ -384,7 +373,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       if ( isAttributeDefined( attributes, att_scale ) )
       {
          ustring scale_str = lookupAttribute( attributes, att_scale );
-         pi.scale = convertStrToDouble( scale_str ); //??? use exact rounding library
+         pi.scale = strToDouble( scale_str ); //??? use exact rounding library
       }
       else
       {
@@ -395,7 +384,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       if ( isAttributeDefined( attributes, att_offset ) )
       {
          ustring offset_str = lookupAttribute( attributes, att_offset );
-         pi.offset = convertStrToDouble( offset_str ); //??? use exact rounding library
+         pi.offset = strToDouble( offset_str ); //??? use exact rounding library
       }
       else
       {
@@ -441,7 +430,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       if ( isAttributeDefined( attributes, att_minimum ) )
       {
          ustring minimum_str = lookupAttribute( attributes, att_minimum );
-         pi.floatMinimum = convertStrToDouble( minimum_str ); //??? use exact rounding library
+         pi.floatMinimum = strToDouble( minimum_str ); //??? use exact rounding library
       }
       else
       {
@@ -460,7 +449,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       if ( isAttributeDefined( attributes, att_maximum ) )
       {
          ustring maximum_str = lookupAttribute( attributes, att_maximum );
-         pi.floatMaximum = convertStrToDouble( maximum_str ); //??? use exact rounding library
+         pi.floatMaximum = strToDouble( maximum_str ); //??? use exact rounding library
       }
       else
       {
@@ -717,7 +706,7 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
          double floatValue;
          if ( pi.childText.length() > 0 )
          {
-            floatValue = convertStrToDouble( pi.childText );
+            floatValue = strToDouble( pi.childText );
          }
          else
          {

--- a/src/E57XmlParser.cpp
+++ b/src/E57XmlParser.cpp
@@ -26,6 +26,8 @@
  */
 
 #include <limits>
+#include <locale>
+#include <sstream>
 
 #include <xercesc/sax2/Attributes.hpp>
 #include <xercesc/sax2/XMLReaderFactory.hpp>
@@ -81,6 +83,17 @@ inline int64_t convertStrToLL( const std::string &inStr )
 #else
 #error "Need to define string to long long conversion for this compiler"
 #endif
+}
+
+/// Parse a double according the the classic ("C") locale.
+/// \return The parsed double or 0.0 on error.
+inline double convertStrToDouble( const std::string &inStr )
+{
+    std::istringstream iss{ inStr };
+    iss.imbue( std::locale::classic() );
+    double res = 0.;
+    iss >> res;
+    return res;
 }
 
 //=============================================================================
@@ -371,7 +384,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       if ( isAttributeDefined( attributes, att_scale ) )
       {
          ustring scale_str = lookupAttribute( attributes, att_scale );
-         pi.scale = atof( scale_str.c_str() ); //??? use exact rounding library
+         pi.scale = convertStrToDouble( scale_str ); //??? use exact rounding library
       }
       else
       {
@@ -382,7 +395,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       if ( isAttributeDefined( attributes, att_offset ) )
       {
          ustring offset_str = lookupAttribute( attributes, att_offset );
-         pi.offset = atof( offset_str.c_str() ); //??? use exact rounding library
+         pi.offset = convertStrToDouble( offset_str ); //??? use exact rounding library
       }
       else
       {
@@ -428,7 +441,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       if ( isAttributeDefined( attributes, att_minimum ) )
       {
          ustring minimum_str = lookupAttribute( attributes, att_minimum );
-         pi.floatMinimum = atof( minimum_str.c_str() ); //??? use exact rounding library
+         pi.floatMinimum = convertStrToDouble( minimum_str ); //??? use exact rounding library
       }
       else
       {
@@ -447,7 +460,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       if ( isAttributeDefined( attributes, att_maximum ) )
       {
          ustring maximum_str = lookupAttribute( attributes, att_maximum );
-         pi.floatMaximum = atof( maximum_str.c_str() ); //??? use exact rounding library
+         pi.floatMaximum = convertStrToDouble( maximum_str ); //??? use exact rounding library
       }
       else
       {
@@ -704,7 +717,7 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
          double floatValue;
          if ( pi.childText.length() > 0 )
          {
-            floatValue = atof( pi.childText.c_str() );
+            floatValue = convertStrToDouble( pi.childText );
          }
          else
          {

--- a/src/StringFunctions.cpp
+++ b/src/StringFunctions.cpp
@@ -1,5 +1,7 @@
 #include "StringFunctions.h"
 
+#include <locale>
+
 namespace e57
 {
    template <class FTYPE> std::string floatingPointToStr( FTYPE value, int precision )
@@ -53,4 +55,14 @@ namespace e57
 
    template std::string floatingPointToStr<float>( float value, int precision );
    template std::string floatingPointToStr<double>( double value, int precision );
+
+   double strToDouble( const std::string &inStr )
+   {
+      std::istringstream iss{ inStr };
+      iss.imbue( std::locale::classic() );
+      double res = 0.;
+      iss >> res;
+      return res;
+   }
+
 }

--- a/src/StringFunctions.h
+++ b/src/StringFunctions.h
@@ -197,4 +197,8 @@ namespace e57
 
    extern template std::string floatingPointToStr<float>( float value, int precision );
    extern template std::string floatingPointToStr<double>( double value, int precision );
+
+   /// Parse a double according the the classic ("C") locale.
+   /// @return The parsed double or 0.0 on error.
+   double strToDouble( const std::string &inStr );
 }


### PR DESCRIPTION
Use std::istringstream with `imbue(std::locale::classic())` to parse doubles to avoid locale related problem when parsing text floats.

I could have also done it for convertStrToLL, but I am not aware of locale-related issue with integers.

Fixes #172