### PR TITLE
Fix writing floating point numbers when std::locale::global is set

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,8 @@ jobs:
 
           sudo apt-get install -y libxerces-c-dev ninja-build
 
+          sudo locale-gen fr_FR
+
       - name: Cache miniconda (Windows)
         if: matrix.config.os == 'windows-latest'
         uses: actions/cache@v3
@@ -58,8 +60,7 @@ jobs:
           CACHE_NUMBER: 0 # Increase this value to reset cache if environment.yml has not changed
         with:
           path: ~/conda_pkgs_dir
-          key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('.github/conda/environment.yml') }}
+          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('.github/conda/environment.yml') }}
 
       - name: Setup miniconda (Windows)
         if: matrix.config.os == 'windows-latest'

--- a/src/StringFunctions.cpp
+++ b/src/StringFunctions.cpp
@@ -9,6 +9,8 @@ namespace e57
       static_assert( std::is_floating_point<FTYPE>::value, "Floating point type required." );
 
       std::stringstream ss;
+      ss.imbue( std::locale::classic() );
+
       ss << std::scientific << std::setprecision( precision ) << value;
 
       // Try to remove trailing zeroes and decimal point

--- a/test/src/test_StringFunctions.cpp
+++ b/test/src/test_StringFunctions.cpp
@@ -1,6 +1,8 @@
 // libE57Format testing Copyright © 2022 Andy Maloney <asmaloney@gmail.com>
 // SPDX-License-Identifier: MIT
 
+#include <clocale>
+
 #include "gtest/gtest.h"
 
 #include "StringFunctions.h"
@@ -24,4 +26,26 @@ TEST( StringFunctions, FloatToStrConversion2 )
    const auto converted = e57::floatingPointToStr<float>( 123456.0f, 7 );
 
    ASSERT_EQ( converted, "1.2345600e+05" );
+}
+
+// Related to https://github.com/asmaloney/libE57Format/issues/172
+// Floating point should always use '.'.
+TEST( StringFunctions, FloatToStrLocale )
+{
+   try
+   {
+      std::locale::global( std::locale( "fr_FR" ) );
+   }
+   catch ( std::exception &err )
+   {
+      GTEST_SKIP() << "fr_FR locale not available: " << err.what();
+   }
+
+   std::wcout.imbue( std::locale() );
+
+   const auto converted = e57::floatingPointToStr<float>( 123456.0f, 7 );
+
+   ASSERT_EQ( converted, "1.2345600e+05" );
+
+   std::locale::global( std::locale::classic() );
 }


### PR DESCRIPTION
If the global locale is set to something not using '.' in floating point numbers, it would result in invalid E57 XML.