### PR TITLE
Clean up enums/global consts

### DIFF
--- a/include/E57Exception.h
+++ b/include/E57Exception.h
@@ -40,62 +40,197 @@ namespace e57
    //! @brief Numeric error identifiers used in E57Exception
    enum ErrorCode
    {
-      // N.B.  *** When changing error strings here, remember to update the error
-      // strings in E57Exception.cpp ****
-      E57_SUCCESS = 0,                         //!< operation was successful
-      E57_ERROR_BAD_CV_HEADER = 1,             //!< a CompressedVector binary header was bad
-      E57_ERROR_BAD_CV_PACKET = 2,             //!< a CompressedVector binary packet was bad
-      E57_ERROR_CHILD_INDEX_OUT_OF_BOUNDS = 3, //!< a numerical index identifying a child was out of bounds
-      E57_ERROR_SET_TWICE = 4,                 //!< attempted to set an existing child element to a new value
-      E57_ERROR_HOMOGENEOUS_VIOLATION = 5,     //!< attempted to add an E57 Element that would have made the children
-                                               //!< of a homogeneous Vector have different types
-      E57_ERROR_VALUE_NOT_REPRESENTABLE = 6,   //!< a value could not be represented in the requested type
-      E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE = 7, //!< after scaling the result could not be represented in the
-                                                    //!< requested type
-      E57_ERROR_REAL64_TOO_LARGE = 8,            //!< a 64 bit IEEE float was too large to store in a 32 bit IEEE float
-      E57_ERROR_EXPECTING_NUMERIC = 9,           //!< Expecting numeric representation in user's buffer, found ustring
-      E57_ERROR_EXPECTING_USTRING = 10,          //!< Expecting string representation in user's buffer, found numeric
-      E57_ERROR_INTERNAL = 11,                   //!< An unrecoverable inconsistent internal state was detected
-      E57_ERROR_BAD_XML_FORMAT = 12,             //!< E57 primitive not encoded in XML correctly
-      E57_ERROR_XML_PARSER = 13,                 //!< XML not well formed
-      E57_ERROR_BAD_API_ARGUMENT = 14,           //!< bad API function argument provided by user
-      E57_ERROR_FILE_IS_READ_ONLY = 15,          //!< can't modify read only file
-      E57_ERROR_BAD_CHECKSUM = 16,               //!< checksum mismatch, file is corrupted
-      E57_ERROR_OPEN_FAILED = 17,                //!< open() failed
-      E57_ERROR_CLOSE_FAILED = 18,               //!< close() failed
-      E57_ERROR_READ_FAILED = 19,                //!< read() failed
-      E57_ERROR_WRITE_FAILED = 20,               //!< write() failed
-      E57_ERROR_LSEEK_FAILED = 21,               //!< lseek() failed
-      E57_ERROR_PATH_UNDEFINED = 22,             //!< E57 element path well formed but not defined
-      E57_ERROR_BAD_BUFFER = 23,                 //!< bad SourceDestBuffer
-      E57_ERROR_NO_BUFFER_FOR_ELEMENT = 24,      //!< no buffer specified for an element in CompressedVectorNode during
-                                                 //!< write
-      E57_ERROR_BUFFER_SIZE_MISMATCH = 25,       //!< SourceDestBuffers not all same size
-      E57_ERROR_BUFFER_DUPLICATE_PATHNAME = 26,  //!< duplicate pathname in CompressedVectorNode read/write
-      E57_ERROR_BAD_FILE_SIGNATURE = 27,         //!< file signature not "ASTM-E57"
-      E57_ERROR_UNKNOWN_FILE_VERSION = 28,       //!< incompatible file version
-      E57_ERROR_BAD_FILE_LENGTH = 29,            //!< size in file header not same as actual
-      E57_ERROR_XML_PARSER_INIT = 30,            //!< XML parser failed to initialize
-      E57_ERROR_DUPLICATE_NAMESPACE_PREFIX = 31, //!< namespace prefix already defined
-      E57_ERROR_DUPLICATE_NAMESPACE_URI = 32,    //!< namespace URI already defined
-      E57_ERROR_BAD_PROTOTYPE = 33,              //!< bad prototype in CompressedVectorNode
-      E57_ERROR_BAD_CODECS = 34,                 //!< bad codecs in CompressedVectorNode
-      E57_ERROR_VALUE_OUT_OF_BOUNDS = 35,        //!< element value out of min/max bounds
-      E57_ERROR_CONVERSION_REQUIRED = 36,        //!< conversion required to assign element value, but not requested
-      E57_ERROR_BAD_PATH_NAME = 37,              //!< E57 path name is not well formed
-      E57_ERROR_NOT_IMPLEMENTED = 38,            //!< functionality not implemented
-      E57_ERROR_BAD_NODE_DOWNCAST = 39,          //!< bad downcast from Node to specific node type
-      E57_ERROR_WRITER_NOT_OPEN = 40,            //!< CompressedVectorWriter is no longer open
-      E57_ERROR_READER_NOT_OPEN = 41,            //!< CompressedVectorReader is no longer open
-      E57_ERROR_NODE_UNATTACHED = 42,            //!< node is not yet attached to tree of ImageFile
-      E57_ERROR_ALREADY_HAS_PARENT = 43,         //!< node already has a parent
-      E57_ERROR_DIFFERENT_DEST_IMAGEFILE = 44,   //!< nodes were constructed with different destImageFiles
-      E57_ERROR_IMAGEFILE_NOT_OPEN = 45,         //!< destImageFile is no longer open
-      E57_ERROR_BUFFERS_NOT_COMPATIBLE = 46,     //!< SourceDestBuffers not compatible with previously given ones
-      E57_ERROR_TOO_MANY_WRITERS = 47,           //!< too many open CompressedVectorWriters of an ImageFile
-      E57_ERROR_TOO_MANY_READERS = 48,           //!< too many open CompressedVectorReaders of an ImageFile
-      E57_ERROR_BAD_CONFIGURATION = 49,          //!< bad configuration string
-      E57_ERROR_INVARIANCE_VIOLATION = 50        //!< class invariance constraint violation in debug mode
+      // NOTE: When changing error strings here, remember to update the error strings in E57Exception.cpp
+
+      Success = 0,                          //!< operation was successful
+      ErrorBadCVHeader = 1,                 //!< a CompressedVector binary header was bad
+      ErrorBadCVPacket = 2,                 //!< a CompressedVector binary packet was bad
+      ErrorChildIndexOutOfBounds = 3,       //!< a numerical index identifying a child was out of bounds
+      ErrorSetTwice = 4,                    //!< attempted to set an existing child element to a new value
+      ErrorHomogeneousViolation = 5,        //!< attempted to add an element that would have made the children of a
+                                            //!< homogeneous ::TypeVector have different types
+      ErrorValueNotRepresentable = 6,       //!< a value could not be represented in the requested type
+      ErrorScaledValueNotRepresentable = 7, //!< after scaling the result could not be represented in the requested type
+      ErrorReal64TooLarge = 8,              //!< a 64 bit IEEE float was too large to store in a 32 bit IEEE float
+      ErrorExpectingNumeric = 9,            //!< Expecting numeric representation in user's buffer, found ustring
+      ErrorExpectingUString = 10,           //!< Expecting string representation in user's buffer, found numeric
+      ErrorInternal = 11,                   //!< An unrecoverable inconsistent internal state was detected
+      ErrorBadXMLFormat = 12,               //!< E57 primitive not encoded in XML correctly
+      ErrorXMLParser = 13,                  //!< XML not well formed
+      ErrorBadAPIArgument = 14,             //!< bad API function argument provided by user
+      ErrorFileReadOnly = 15,               //!< can't modify read only file
+      ErrorBadChecksum = 16,                //!< checksum mismatch, file is corrupted
+      ErrorOpenFailed = 17,                 //!< open() failed
+      ErrorCloseFailed = 18,                //!< close() failed
+      ErrorReadFailed = 19,                 //!< read() failed
+      ErrorWriteFailed = 20,                //!< write() failed
+      ErrorSeekFailed = 21,                 //!< lseek() failed
+      ErrorPathUndefined = 22,              //!< element path well formed but not defined
+      ErrorBadBuffer = 23,                  //!< bad SourceDestBuffer
+      ErrorNoBufferForElement = 24,         //!< no buffer specified for an element in CompressedVectorNode during write
+      ErrorBufferSizeMismatch = 25,         //!< SourceDestBuffers not all same size
+      ErrorBufferDuplicatePathName = 26,    //!< duplicate pathname in CompressedVectorNode read/write
+      ErrorBadFileSignature = 27,           //!< file signature not "ASTM-E57"
+      ErrorUnknownFileVersion = 28,         //!< incompatible file version
+      ErrorBadFileLength = 29,              //!< size in file header not same as actual
+      ErrorXMLParserInit = 30,              //!< XML parser failed to initialize
+      ErrorDuplicateNamespacePrefix = 31,   //!< namespace prefix already defined
+      ErrorDuplicateNamespaceURI = 32,      //!< namespace URI already defined
+      ErrorBadPrototype = 33,               //!< bad prototype in CompressedVectorNode
+      ErrorBadCodecs = 34,                  //!< bad codecs in CompressedVectorNode
+      ErrorValueOutOfBounds = 35,           //!< element value out of min/max bounds
+      ErrorConversionRequired = 36,         //!< conversion required to assign element value, but not requested
+      ErrorBadPathName = 37,                //!< E57 path name is not well formed
+      ErrorNotImplemented = 38,             //!< functionality not implemented
+      ErrorBadNodeDowncast = 39,            //!< bad downcast from Node to specific node type
+      ErrorWriterNotOpen = 40,              //!< CompressedVectorWriter is no longer open
+      ErrorReaderNotOpen = 41,              //!< CompressedVectorReader is no longer open
+      ErrorNodeUnattached = 42,             //!< node is not yet attached to tree of ImageFile
+      ErrorAlreadyHasParent = 43,           //!< node already has a parent
+      ErrorDifferentDestImageFile = 44,     //!< nodes were constructed with different destImageFiles
+      ErrorImageFileNotOpen = 45,           //!< destImageFile is no longer open
+      ErrorBuffersNotCompatible = 46,       //!< SourceDestBuffers not compatible with previously given ones
+      ErrorTooManyWriters = 47,             //!< too many open CompressedVectorWriters of an ImageFile
+      ErrorTooManyReaders = 48,             //!< too many open CompressedVectorReaders of an ImageFile
+      ErrorBadConfiguration = 49,           //!< bad configuration string
+      ErrorInvarianceViolation = 50,        //!< class invariance constraint violation in debug mode
+
+      /// @deprecated Will be removed in 4.0. Use e57::Success.
+      E57_SUCCESS [[deprecated( "Will be removed in 4.0. Use Success." )]] = Success,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorBadCVHeader.
+      E57_ERROR_BAD_CV_HEADER [[deprecated( "Will be removed in 4.0. Use ErrorBadCVHeader." )]] = ErrorBadCVHeader,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorBadCVPacket.
+      E57_ERROR_BAD_CV_PACKET [[deprecated( "Will be removed in 4.0. Use ErrorBadCVPacket." )]] = ErrorBadCVPacket,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorChildIndexOutOfBounds.
+      E57_ERROR_CHILD_INDEX_OUT_OF_BOUNDS [[deprecated( "Will be removed in 4.0. Use ErrorChildIndexOutOfBounds." )]] =
+         ErrorChildIndexOutOfBounds,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorSetTwice.
+      E57_ERROR_SET_TWICE [[deprecated( "Will be removed in 4.0. Use ErrorSetTwice." )]] = ErrorSetTwice,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorHomogeneousViolation.
+      E57_ERROR_HOMOGENEOUS_VIOLATION [[deprecated( "Will be removed in 4.0. Use ErrorHomogeneousViolation." )]] =
+         ErrorHomogeneousViolation,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorValueNotRepresentable.
+      E57_ERROR_VALUE_NOT_REPRESENTABLE [[deprecated( "Will be removed in 4.0. Use ErrorValueNotRepresentable." )]] =
+         ErrorValueNotRepresentable,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorScaledValueNotRepresentable.
+      E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE
+      [[deprecated( "Will be removed in 4.0. Use ErrorScaledValueNotRepresentable." )]] =
+         ErrorScaledValueNotRepresentable,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorReal64TooLarge.
+      E57_ERROR_REAL64_TOO_LARGE [[deprecated( "Will be removed in 4.0. Use ErrorReal64TooLarge." )]] =
+         ErrorReal64TooLarge,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorExpectingNumeric.
+      E57_ERROR_EXPECTING_NUMERIC [[deprecated( "Will be removed in 4.0. Use ErrorExpectingNumeric." )]] =
+         ErrorExpectingNumeric,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorExpectingUString.
+      E57_ERROR_EXPECTING_USTRING [[deprecated( "Will be removed in 4.0. Use ErrorExpectingUString." )]] =
+         ErrorExpectingUString,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorInternal.
+      E57_ERROR_INTERNAL [[deprecated( "Will be removed in 4.0. Use ErrorInternal." )]] = ErrorInternal,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorBadXMLFormat.
+      E57_ERROR_BAD_XML_FORMAT [[deprecated( "Will be removed in 4.0. Use ErrorBadXMLFormat." )]] = ErrorBadXMLFormat,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorXMLParser.
+      E57_ERROR_XML_PARSER [[deprecated( "Will be removed in 4.0. Use ErrorXMLParser." )]] = ErrorXMLParser,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorBadAPIArgument.
+      E57_ERROR_BAD_API_ARGUMENT [[deprecated( "Will be removed in 4.0. Use ErrorBadAPIArgument." )]] =
+         ErrorBadAPIArgument,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorFileReadOnly.
+      E57_ERROR_FILE_IS_READ_ONLY [[deprecated( "Will be removed in 4.0. Use ErrorFileReadOnly." )]] =
+         ErrorFileReadOnly,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorBadChecksum.
+      E57_ERROR_BAD_CHECKSUM [[deprecated( "Will be removed in 4.0. Use ErrorBadChecksum." )]] = ErrorBadChecksum,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorOpenFailed.
+      E57_ERROR_OPEN_FAILED [[deprecated( "Will be removed in 4.0. Use ErrorOpenFailed." )]] = ErrorOpenFailed,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorCloseFailed.
+      E57_ERROR_CLOSE_FAILED [[deprecated( "Will be removed in 4.0. Use ErrorCloseFailed." )]] = ErrorCloseFailed,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorReadFailed.
+      E57_ERROR_READ_FAILED [[deprecated( "Will be removed in 4.0. Use ErrorReadFailed." )]] = ErrorReadFailed,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorWriteFailed.
+      E57_ERROR_WRITE_FAILED [[deprecated( "Will be removed in 4.0. Use ErrorWriteFailed." )]] = ErrorWriteFailed,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorSeekFailed.
+      E57_ERROR_LSEEK_FAILED [[deprecated( "Will be removed in 4.0. Use ErrorSeekFailed." )]] = ErrorSeekFailed,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorPathUndefined.
+      E57_ERROR_PATH_UNDEFINED [[deprecated( "Will be removed in 4.0. Use ErrorPathUndefined." )]] = ErrorPathUndefined,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorBadBuffer.
+      E57_ERROR_BAD_BUFFER [[deprecated( "Will be removed in 4.0. Use ErrorBadBuffer." )]] = ErrorBadBuffer,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorNoBufferForElement.
+      E57_ERROR_NO_BUFFER_FOR_ELEMENT [[deprecated( "Will be removed in 4.0. Use ErrorNoBufferForElement." )]] =
+         ErrorNoBufferForElement,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorBufferSizeMismatch.
+      E57_ERROR_BUFFER_SIZE_MISMATCH [[deprecated( "Will be removed in 4.0. Use ErrorBufferSizeMismatch." )]] =
+         ErrorBufferSizeMismatch,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorBufferDuplicatePathName.
+      E57_ERROR_BUFFER_DUPLICATE_PATHNAME
+      [[deprecated( "Will be removed in 4.0. Use ErrorBufferDuplicatePathName." )]] = ErrorBufferDuplicatePathName,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorBadFileSignature.
+      E57_ERROR_BAD_FILE_SIGNATURE [[deprecated( "Will be removed in 4.0. Use ErrorBadFileSignature." )]] =
+         ErrorBadFileSignature,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorUnknownFileVersion.
+      E57_ERROR_UNKNOWN_FILE_VERSION [[deprecated( "Will be removed in 4.0. Use ErrorUnknownFileVersion." )]] =
+         ErrorUnknownFileVersion,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorBadFileLength.
+      E57_ERROR_BAD_FILE_LENGTH [[deprecated( "Will be removed in 4.0. Use ErrorBadFileLength." )]] =
+         ErrorBadFileLength,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorXMLParserInit.
+      E57_ERROR_XML_PARSER_INIT [[deprecated( "Will be removed in 4.0. Use ErrorXMLParserInit." )]] =
+         ErrorXMLParserInit,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorDuplicateNamespacePrefix.
+      E57_ERROR_DUPLICATE_NAMESPACE_PREFIX
+      [[deprecated( "Will be removed in 4.0. Use ErrorDuplicateNamespacePrefix." )]] = ErrorDuplicateNamespacePrefix,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorDuplicateNamespaceURI.
+      E57_ERROR_DUPLICATE_NAMESPACE_URI [[deprecated( "Will be removed in 4.0. Use ErrorDuplicateNamespaceURI." )]] =
+         ErrorDuplicateNamespaceURI,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorBadPrototype.
+      E57_ERROR_BAD_PROTOTYPE [[deprecated( "Will be removed in 4.0. Use ErrorBadPrototype." )]] = ErrorBadPrototype,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorBadCodecs.
+      E57_ERROR_BAD_CODECS [[deprecated( "Will be removed in 4.0. Use ErrorBadCodecs." )]] = ErrorBadCodecs,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorValueOutOfBounds.
+      E57_ERROR_VALUE_OUT_OF_BOUNDS [[deprecated( "Will be removed in 4.0. Use ErrorValueOutOfBounds." )]] =
+         ErrorValueOutOfBounds,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorConversionRequired.
+      E57_ERROR_CONVERSION_REQUIRED [[deprecated( "Will be removed in 4.0. Use ErrorConversionRequired." )]] =
+         ErrorConversionRequired,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorBadPathName.
+      E57_ERROR_BAD_PATH_NAME [[deprecated( "Will be removed in 4.0. Use ErrorBadPathName." )]] = ErrorBadPathName,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorNotImplemented.
+      E57_ERROR_NOT_IMPLEMENTED [[deprecated( "Will be removed in 4.0. Use ErrorNotImplemented." )]] =
+         ErrorNotImplemented,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorBadNodeDowncast.
+      E57_ERROR_BAD_NODE_DOWNCAST [[deprecated( "Will be removed in 4.0. Use ErrorBadNodeDowncast." )]] =
+         ErrorBadNodeDowncast,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorWriterNotOpen.
+      E57_ERROR_WRITER_NOT_OPEN [[deprecated( "Will be removed in 4.0. Use ErrorWriterNotOpen." )]] =
+         ErrorWriterNotOpen,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorReaderNotOpen.
+      E57_ERROR_READER_NOT_OPEN [[deprecated( "Will be removed in 4.0. Use ErrorReaderNotOpen." )]] =
+         ErrorReaderNotOpen,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorNodeUnattached.
+      E57_ERROR_NODE_UNATTACHED [[deprecated( "Will be removed in 4.0. Use ErrorNodeUnattached." )]] =
+         ErrorNodeUnattached,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorAlreadyHasParent.
+      E57_ERROR_ALREADY_HAS_PARENT [[deprecated( "Will be removed in 4.0. Use ErrorAlreadyHasParent." )]] =
+         ErrorAlreadyHasParent,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorDifferentDestImageFile.
+      E57_ERROR_DIFFERENT_DEST_IMAGEFILE [[deprecated( "Will be removed in 4.0. Use ErrorDifferentDestImageFile." )]] =
+         ErrorDifferentDestImageFile,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorImageFileNotOpen.
+      E57_ERROR_IMAGEFILE_NOT_OPEN [[deprecated( "Will be removed in 4.0. Use ErrorImageFileNotOpen." )]] =
+         ErrorImageFileNotOpen,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorBuffersNotCompatible.
+      E57_ERROR_BUFFERS_NOT_COMPATIBLE [[deprecated( "Will be removed in 4.0. Use ErrorBuffersNotCompatible." )]] =
+         ErrorBuffersNotCompatible,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorTooManyWriters.
+      E57_ERROR_TOO_MANY_WRITERS [[deprecated( "Will be removed in 4.0. Use ErrorTooManyWriters." )]] =
+         ErrorTooManyWriters,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorTooManyReaders.
+      E57_ERROR_TOO_MANY_READERS [[deprecated( "Will be removed in 4.0. Use ErrorTooManyReaders." )]] =
+         ErrorTooManyReaders,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorBadConfiguration.
+      E57_ERROR_BAD_CONFIGURATION [[deprecated( "Will be removed in 4.0. Use ErrorBadConfiguration." )]] =
+         ErrorBadConfiguration,
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorInvarianceViolation.
+      E57_ERROR_INVARIANCE_VIOLATION [[deprecated( "Will be removed in 4.0. Use ErrorInvarianceViolation." )]] =
+         ErrorInvarianceViolation,
    };
 
    class E57_DLL E57Exception : public std::exception

--- a/include/E57Format.h
+++ b/include/E57Format.h
@@ -32,6 +32,7 @@
 //! @file  E57Format.h Header file for the E57 API.
 
 #include <cfloat>
+#include <cstdint>
 #include <memory>
 #include <vector>
 
@@ -55,48 +56,93 @@ namespace e57
    //! @brief Identifiers for types of E57 elements
    enum NodeType
    {
-      E57_STRUCTURE = 1,         //!< StructureNode class
-      E57_VECTOR = 2,            //!< VectorNode class
-      E57_COMPRESSED_VECTOR = 3, //!< CompressedVectorNode class
-      E57_INTEGER = 4,           //!< IntegerNode class
-      E57_SCALED_INTEGER = 5,    //!< ScaledIntegerNode class
-      E57_FLOAT = 6,             //!< FloatNode class
-      E57_STRING = 7,            //!< StringNode class
-      E57_BLOB = 8               //!< BlobNode class
+      TypeStructure = 1,        //!< StructureNode class
+      TypeVector = 2,           //!< VectorNode class
+      TypeCompressedVector = 3, //!< CompressedVectorNode class
+      TypeInteger = 4,          //!< IntegerNode class
+      TypeScaledInteger = 5,    //!< ScaledIntegerNode class
+      TypeFloat = 6,            //!< FloatNode class
+      TypeString = 7,           //!< StringNode class
+      TypeBlob = 8,             //!< BlobNode class
+
+      /// @deprecated Will be removed in 4.0. Use e57::TypeStructure.
+      E57_STRUCTURE [[deprecated( "Will be removed in 4.0. Use TypeStructure." )]] = TypeStructure,
+      /// @deprecated Will be removed in 4.0. Use e57::TypeVector.
+      E57_VECTOR [[deprecated( "Will be removed in 4.0. Use TypeVector." )]] = TypeVector,
+      /// @deprecated Will be removed in 4.0. Use e57::TypeCompressedVector.
+      E57_COMPRESSED_VECTOR [[deprecated( "Will be removed in 4.0. Use TypeCompressedVector." )]] =
+         TypeCompressedVector,
+      /// @deprecated Will be removed in 4.0. Use e57::TypeInteger.
+      E57_INTEGER [[deprecated( "Will be removed in 4.0. Use TypeInteger." )]] = TypeInteger,
+      /// @deprecated Will be removed in 4.0. Use e57::TypeScaledInteger.
+      E57_SCALED_INTEGER [[deprecated( "Will be removed in 4.0. Use TypeScaledInteger." )]] = TypeScaledInteger,
+      /// @deprecated Will be removed in 4.0. Use e57::TypeFloat.
+      E57_FLOAT [[deprecated( "Will be removed in 4.0. Use TypeFloat." )]] = TypeFloat,
+      /// @deprecated Will be removed in 4.0. Use e57::TypeString.
+      E57_STRING [[deprecated( "Will be removed in 4.0. Use TypeString." )]] = TypeString,
+      /// @deprecated Will be removed in 4.0. Use e57::TypeBlob.
+      E57_BLOB [[deprecated( "Will be removed in 4.0. Use TypeBlob." )]] = TypeBlob
    };
 
    //! @brief The IEEE floating point number precisions supported
    enum FloatPrecision
    {
-      E57_SINGLE = 1, //!< 32 bit IEEE floating point number format
-      E57_DOUBLE = 2  //!< 64 bit IEEE floating point number format
+      PrecisionSingle = 1, //!< 32 bit IEEE floating point number format
+      PrecisionDouble = 2, //!< 64 bit IEEE floating point number format
+
+      /// @deprecated Will be removed in 4.0. Use e57::PrecisionSingle.
+      E57_SINGLE [[deprecated( "Will be removed in 4.0. Use PrecisionSingle." )]] = PrecisionSingle,
+      /// @deprecated Will be removed in 4.0. Use e57::PrecisionDouble.
+      E57_DOUBLE [[deprecated( "Will be removed in 4.0. Use PrecisionDouble." )]] = PrecisionDouble
    };
 
-   //! @brief Identifies the representations of memory elements API can transfer
-   //! data to/from
+   //! @brief Identifies the representations of memory elements API can transfer data to/from
    enum MemoryRepresentation
    {
-      E57_INT8 = 1,    //!< 8 bit signed integer
-      E57_UINT8 = 2,   //!< 8 bit unsigned integer
-      E57_INT16 = 3,   //!< 16 bit signed integer
-      E57_UINT16 = 4,  //!< 16 bit unsigned integer
-      E57_INT32 = 5,   //!< 32 bit signed integer
-      E57_UINT32 = 6,  //!< 32 bit unsigned integer
-      E57_INT64 = 7,   //!< 64 bit signed integer
-      E57_BOOL = 8,    //!< C++ boolean type
-      E57_REAL32 = 9,  //!< C++ float type
-      E57_REAL64 = 10, //!< C++ double type
-      E57_USTRING = 11 //!< Unicode UTF-8 std::string
+      Int8 = 1,     //!< 8 bit signed integer
+      UInt8 = 2,    //!< 8 bit unsigned integer
+      Int16 = 3,    //!< 16 bit signed integer
+      UInt16 = 4,   //!< 16 bit unsigned integer
+      Int32 = 5,    //!< 32 bit signed integer
+      UInt32 = 6,   //!< 32 bit unsigned integer
+      Int64 = 7,    //!< 64 bit signed integer
+      Bool = 8,     //!< C++ boolean type
+      Real32 = 9,   //!< C++ float type
+      Real64 = 10,  //!< C++ double type
+      UString = 11, //!< Unicode UTF-8 std::string
+
+      /// @deprecated Will be removed in 4.0. Use e57::Int8.
+      E57_INT8 [[deprecated( "Will be removed in 4.0. Use Int8." )]] = Int8,
+      /// @deprecated Will be removed in 4.0. Use e57::UInt8.
+      E57_UINT8 [[deprecated( "Will be removed in 4.0. Use UInt8." )]] = UInt8,
+      /// @deprecated Will be removed in 4.0. Use e57::Int16.
+      E57_INT16 [[deprecated( "Will be removed in 4.0. Use Int16." )]] = Int16,
+      /// @deprecated Will be removed in 4.0. Use e57::UInt16.
+      E57_UINT16 [[deprecated( "Will be removed in 4.0. Use UInt16." )]] = UInt16,
+      /// @deprecated Will be removed in 4.0. Use e57::Int32.
+      E57_INT32 [[deprecated( "Will be removed in 4.0. Use Int32." )]] = Int32,
+      /// @deprecated Will be removed in 4.0. Use e57::UInt32.
+      E57_UINT32 [[deprecated( "Will be removed in 4.0. Use UInt32." )]] = UInt32,
+      /// @deprecated Will be removed in 4.0. Use e57::Int64.
+      E57_INT64 [[deprecated( "Will be removed in 4.0. Use Int64." )]] = Int64,
+      /// @deprecated Will be removed in 4.0. Use e57::Bool.
+      E57_BOOL [[deprecated( "Will be removed in 4.0. Use Bool." )]] = Bool,
+      /// @deprecated Will be removed in 4.0. Use e57::Real32.
+      E57_REAL32 [[deprecated( "Will be removed in 4.0. Use Real32." )]] = Real32,
+      /// @deprecated Will be removed in 4.0. Use e57::Real64.
+      E57_REAL64 [[deprecated( "Will be removed in 4.0. Use Real64." )]] = Real64,
+      /// @deprecated Will be removed in 4.0. Use e57::UString.
+      E57_USTRING [[deprecated( "Will be removed in 4.0. Use UString." )]] = UString
    };
 
    //! @brief Default checksum policies for e57::ReadChecksumPolicy
    //! @details These are some convenient default checksum policies, though you can use any value you want (0-100).
    enum ChecksumPolicy
    {
-      None = 0,    ///< Do not verify the checksums. (fast)
-      Sparse = 25, ///< Only verify 25% of the checksums. The last block is always verified.
-      Half = 50,   ///< Only verify 50% of the checksums. The last block is always verified.
-      All = 100    ///< Verify all checksums. This is the default. (slow)
+      ChecksumNone = 0,    ///< Do not verify the checksums. (fast)
+      ChecksumSparse = 25, ///< Only verify 25% of the checksums. The last block is always verified.
+      ChecksumHalf = 50,   ///< Only verify 50% of the checksums. The last block is always verified.
+      ChecksumAll = 100    ///< Verify all checksums. This is the default. (slow)
    };
 
    //! @brief Specifies the percentage of checksums which are verified when reading
@@ -109,55 +155,47 @@ namespace e57
    //!@{
 
    //! Do not verify the checksums. (fast)
-   //! @deprecated Will be removed in 4.0. Use ChecksumPolicy::None.
-   [[deprecated( "Will be removed in 4.0. Use ChecksumPolicy::None." )]] // TODO Remove in 4.0
-   constexpr ReadChecksumPolicy CHECKSUM_POLICY_NONE = 0;
+   //! @deprecated Will be removed in 4.0. Use ChecksumPolicy::ChecksumNone.
+   [[deprecated( "Will be removed in 4.0. Use ChecksumPolicy::ChecksumNone." )]] // TODO Remove in 4.0
+   constexpr ReadChecksumPolicy CHECKSUM_POLICY_NONE = ChecksumNone;
 
    //! Only verify 25% of the checksums. The last block is always verified.
-   //! @deprecated Will be removed in 4.0. Use ChecksumPolicy::Sparse.
-   [[deprecated( "Will be removed in 4.0. Use ChecksumPolicy::Sparse." )]] // TODO Remove in 4.0
-   constexpr ReadChecksumPolicy CHECKSUM_POLICY_SPARSE = 25;
+   //! @deprecated Will be removed in 4.0. Use ChecksumPolicy::ChecksumSparse.
+   [[deprecated( "Will be removed in 4.0. Use ChecksumPolicy::ChecksumSparse." )]] // TODO Remove in 4.0
+   constexpr ReadChecksumPolicy CHECKSUM_POLICY_SPARSE = ChecksumSparse;
 
    //! Only verify 50% of the checksums. The last block is always verified.
-   //! @deprecated Will be removed in 4.0. Use ChecksumPolicy::Half.
-   [[deprecated( "Will be removed in 4.0. Use ChecksumPolicy::Half." )]] // TODO Remove in 4.0
-   constexpr ReadChecksumPolicy CHECKSUM_POLICY_HALF = 50;
+   //! @deprecated Will be removed in 4.0. Use ChecksumPolicy::ChecksumHalf.
+   [[deprecated( "Will be removed in 4.0. Use ChecksumPolicy::ChecksumHalf." )]] // TODO Remove in 4.0
+   constexpr ReadChecksumPolicy CHECKSUM_POLICY_HALF = ChecksumHalf;
 
    //! Verify all checksums. This is the default. (slow)
-   //! @deprecated Will be removed in 4.0. Use ChecksumPolicy::All.
-   [[deprecated( "Will be removed in 4.0. Use ChecksumPolicy::All." )]] // TODO Remove in 4.0
-   constexpr ReadChecksumPolicy CHECKSUM_POLICY_ALL = 100;
+   //! @deprecated Will be removed in 4.0. Use ChecksumPolicy::ChecksumAll.
+   [[deprecated( "Will be removed in 4.0. Use ChecksumPolicy::ChecksumAll." )]] // TODO Remove in 4.0
+   constexpr ReadChecksumPolicy CHECKSUM_POLICY_ALL = ChecksumAll;
 
    //!@}
 
    //! @brief The URI of ASTM E57 v1.0 standard XML namespace
    //! @note Even though this URI does not point to a valid document, the standard (section 8.4.2.3)
    //! says that this is the required namespace.
-   constexpr char E57_V1_0_URI[] = "http://www.astm.org/COMMIT/E57/2010-e57-v1.0";
+   constexpr char VERSION_1_0_URI[] = "http://www.astm.org/COMMIT/E57/2010-e57-v1.0";
+
+   /// @deprecated Will be removed in 4.0. Use e57::VERSION_1_0_URI.
+   [[deprecated( "Will be removed in 4.0. Use e57::VERSION_1_0_URI." )]] // TODO Remove in 4.0
+   constexpr auto E57_V1_0_URI = VERSION_1_0_URI;
 
    //! @cond documentNonPublic   The following aren't documented
    // Minimum and maximum values for integers
-   constexpr int8_t E57_INT8_MIN = -128;
-   constexpr int8_t E57_INT8_MAX = 127;
-   constexpr int16_t E57_INT16_MIN = -32768;
-   constexpr int16_t E57_INT16_MAX = 32767;
-   constexpr int32_t E57_INT32_MIN = -2147483647 - 1;
-   constexpr int32_t E57_INT32_MAX = 2147483647;
-   constexpr int64_t E57_INT64_MIN = -9223372036854775807LL - 1;
-   constexpr int64_t E57_INT64_MAX = 9223372036854775807LL;
-   constexpr uint8_t E57_UINT8_MIN = 0U;
-   constexpr uint8_t E57_UINT8_MAX = 0xffU; /* 255U */
-   constexpr uint16_t E57_UINT16_MIN = 0U;
-   constexpr uint16_t E57_UINT16_MAX = 0xffffU; /* 65535U */
-   constexpr uint32_t E57_UINT32_MIN = 0U;
-   constexpr uint32_t E57_UINT32_MAX = 0xffffffffU; /* 4294967295U */
-   constexpr uint64_t E57_UINT64_MIN = 0ULL;
-   constexpr uint64_t E57_UINT64_MAX = 0xffffffffffffffffULL; /* 18446744073709551615ULL */
+   constexpr uint8_t UINT8_MIN = 0U;
+   constexpr uint16_t UINT16_MIN = 0U;
+   constexpr uint32_t UINT32_MIN = 0U;
+   constexpr uint64_t UINT64_MIN = 0ULL;
 
-   constexpr float E57_FLOAT_MIN = -FLT_MAX;
-   constexpr float E57_FLOAT_MAX = FLT_MAX;
-   constexpr double E57_DOUBLE_MIN = -DBL_MAX;
-   constexpr double E57_DOUBLE_MAX = DBL_MAX;
+   constexpr float FLOAT_MIN = -FLT_MAX;
+   constexpr float FLOAT_MAX = FLT_MAX;
+   constexpr double DOUBLE_MIN = -DBL_MAX;
+   constexpr double DOUBLE_MAX = DBL_MAX;
 //! @endcond
 
 //! @cond documentNonPublic   The following isn't part of the API, and isn't
@@ -470,8 +508,8 @@ protected:                                                                      
    {
    public:
       IntegerNode() = delete;
-      explicit IntegerNode( ImageFile destImageFile, int64_t value = 0, int64_t minimum = E57_INT64_MIN,
-                            int64_t maximum = E57_INT64_MAX );
+      explicit IntegerNode( ImageFile destImageFile, int64_t value = 0, int64_t minimum = INT64_MIN,
+                            int64_t maximum = INT64_MAX );
 
       int64_t value() const;
       int64_t minimum() const;
@@ -555,8 +593,8 @@ protected:                                                                      
    {
    public:
       FloatNode() = delete;
-      explicit FloatNode( ImageFile destImageFile, double value = 0.0, FloatPrecision precision = E57_DOUBLE,
-                          double minimum = E57_DOUBLE_MIN, double maximum = E57_DOUBLE_MAX );
+      explicit FloatNode( ImageFile destImageFile, double value = 0.0, FloatPrecision precision = PrecisionDouble,
+                          double minimum = DOUBLE_MIN, double maximum = DOUBLE_MAX );
 
       double value() const;
       FloatPrecision precision() const;
@@ -669,8 +707,8 @@ protected:                                                                      
    {
    public:
       ImageFile() = delete;
-      ImageFile( const ustring &fname, const ustring &mode, ReadChecksumPolicy checksumPolicy = ChecksumPolicy::All );
-      ImageFile( const char *input, uint64_t size, ReadChecksumPolicy checksumPolicy = ChecksumPolicy::All );
+      ImageFile( const ustring &fname, const ustring &mode, ReadChecksumPolicy checksumPolicy = ChecksumAll );
+      ImageFile( const char *input, uint64_t size, ReadChecksumPolicy checksumPolicy = ChecksumAll );
 
       StructureNode root() const;
       void close();

--- a/include/E57SimpleData.h
+++ b/include/E57SimpleData.h
@@ -120,12 +120,12 @@ namespace e57
    //! @brief Specifies an axis-aligned box in local cartesian coordinates.
    struct E57_DLL CartesianBounds
    {
-      double xMinimum = -E57_DOUBLE_MAX; //!< The minimum extent of the bounding box in the X direction
-      double xMaximum = E57_DOUBLE_MAX;  //!< The maximum extent of the bounding box in the X direction
-      double yMinimum = -E57_DOUBLE_MAX; //!< The minimum extent of the bounding box in the Y direction
-      double yMaximum = E57_DOUBLE_MAX;  //!< The maximum extent of the bounding box in the Y direction
-      double zMinimum = -E57_DOUBLE_MAX; //!< The minimum extent of the bounding box in the Z direction
-      double zMaximum = E57_DOUBLE_MAX;  //!< The maximum extent of the bounding box in the Z direction
+      double xMinimum = -DOUBLE_MAX; //!< The minimum extent of the bounding box in the X direction
+      double xMaximum = DOUBLE_MAX;  //!< The maximum extent of the bounding box in the X direction
+      double yMinimum = -DOUBLE_MAX; //!< The minimum extent of the bounding box in the Y direction
+      double yMaximum = DOUBLE_MAX;  //!< The maximum extent of the bounding box in the Y direction
+      double zMinimum = -DOUBLE_MAX; //!< The minimum extent of the bounding box in the Z direction
+      double zMaximum = DOUBLE_MAX;  //!< The maximum extent of the bounding box in the Z direction
 
       bool operator==( const CartesianBounds &rhs ) const
       {
@@ -320,11 +320,11 @@ namespace e57
 
       //! Indicates that the PointRecord cartesian and range fields should be configured with this minimum value e.g.
       //! E57_FLOAT_MIN or E57_DOUBLE_MIN. If using a ScaledIntegerNode then this needs to be a minimum range value.
-      double pointRangeMinimum = E57_DOUBLE_MIN;
+      double pointRangeMinimum = DOUBLE_MIN;
 
       //! Indicates that the PointRecord cartesian and range fields should be configured with this maximum value e.g.
       //! E57_FLOAT_MAX or E57_DOUBLE_MAX. If using a ScaledIntegerNode then this needs to be a maximum range value.
-      double pointRangeMaximum = E57_DOUBLE_MAX;
+      double pointRangeMaximum = DOUBLE_MAX;
 
       //! @brief Controls the type of Node used for the PointRecord cartesian and range fields
       //! @details The value determines which type of Node to use and whether to use floats or doubles.
@@ -337,11 +337,11 @@ namespace e57
 
       //! Indicates that the PointRecord angle fields should be configured with this minimum value E57_FLOAT_MIN or
       //! E57_DOUBLE_MIN. If using a ScaledIntegerNode then this needs to be a minimum angle value.
-      double angleMinimum = E57_DOUBLE_MIN;
+      double angleMinimum = DOUBLE_MIN;
 
       //! Indicates that the PointRecord angle fields should be configured with this maximum value e.g. E57_FLOAT_MAX or
       //! E57_DOUBLE_MAX. If using a ScaledIntegerNode then this needs to be a maximum angle value.
-      double angleMaximum = E57_DOUBLE_MAX;
+      double angleMaximum = DOUBLE_MAX;
 
       //! @brief Controls the type of Node used for the PointRecord angle fields
       //! @details The value determines which type of Node to use and whether to use floats or doubles.
@@ -356,18 +356,18 @@ namespace e57
 
       //! Indicates that the PointRecord @a rowIndex fields should be configured with this maximum value where the
       //! minimum will be set to 0.
-      uint32_t rowIndexMaximum = E57_UINT32_MAX;
+      uint32_t rowIndexMaximum = UINT32_MAX;
 
       bool columnIndexField = false; //!< Indicates that the PointRecord @a columnIndex field is active
 
       //! Indicates that the PointRecord @a columnIndex fields should be configured with this maximum value where the
       //! minimum will be set to 0.
-      uint32_t columnIndexMaximum = E57_UINT32_MAX;
+      uint32_t columnIndexMaximum = UINT32_MAX;
 
-      bool returnIndexField = false;         //!< Indicates that the PointRecord @a returnIndex field is active
-      bool returnCountField = false;         //!< Indicates that the PointRecord @a returnCount field is active
-      uint8_t returnMaximum = E57_UINT8_MAX; //!< Indicates that the PointRecord return fields should be configured
-                                             //!< with this maximum value where the minimum will be set to 0.
+      bool returnIndexField = false;     //!< Indicates that the PointRecord @a returnIndex field is active
+      bool returnCountField = false;     //!< Indicates that the PointRecord @a returnCount field is active
+      uint8_t returnMaximum = UINT8_MAX; //!< Indicates that the PointRecord return fields should be configured
+                                         //!< with this maximum value where the minimum will be set to 0.
 
       bool timeStampField = false;          //!< Indicates that the PointRecord @a timeStamp field is active
       bool isTimeStampInvalidField = false; //!< Indicates that the PointRecord @a isTimeStampInvalid field is active
@@ -375,11 +375,11 @@ namespace e57
       //! Indicates that the PointRecord @a timeStamp fields should be configured with this minimum value e.g.
       //! E57_UINT32_MIN, E57_DOUBLE_MIN or E57_DOUBLE_MIN. If using a ScaledIntegerNode then this needs to be a minimum
       //! time value.
-      double timeMinimum = E57_DOUBLE_MIN;
+      double timeMinimum = DOUBLE_MIN;
 
       //! Indicates that the PointRecord @a timeStamp fields should be configured with this maximum value. e.g.
       //! E57_UINT32_MAX, E57_DOUBLE_MAX or E57_DOUBLE_MAX.
-      double timeMaximum = E57_DOUBLE_MAX;
+      double timeMaximum = DOUBLE_MAX;
 
       //! @brief Controls the type of Node used for the PointRecord @a timeStamp fields
       //! @details The value determines which type of Node to use and whether to use floats or doubles.
@@ -433,15 +433,15 @@ namespace e57
                                      //!< data collection.
 
       //! The ambient temperature, measured at the sensor, at the time of data collection (in degrees Celsius).
-      float temperature = E57_FLOAT_MAX;
+      float temperature = FLOAT_MAX;
 
       //! The percentage relative humidity, measured at the sensor, at the time of data collection. Shall be in the
       //! interval [0, 100].
-      float relativeHumidity = E57_FLOAT_MAX;
+      float relativeHumidity = FLOAT_MAX;
 
       //! The atmospheric pressure, measured at the sensor, at the time of data collection (in Pascals). Shall be
       //! positive.
-      float atmosphericPressure = E57_FLOAT_MAX;
+      float atmosphericPressure = FLOAT_MAX;
 
       DateTime acquisitionStart; //!< The start date and time that the data was acquired.
       DateTime acquisitionEnd;   //!< The end date and time that the data was acquired.
@@ -716,19 +716,39 @@ namespace e57
    //! @brief Identifies the format representation for the image data
    enum Image2DType
    {
-      E57_NO_IMAGE = 0,      //!< No image data
-      E57_JPEG_IMAGE = 1,    //!< JPEG format image data.
-      E57_PNG_IMAGE = 2,     //!< PNG format image data.
-      E57_PNG_IMAGE_MASK = 3 //!< PNG format image mask.
+      ImageNone = 0,    //!< No image data
+      ImageJPEG = 1,    //!< JPEG format image data.
+      ImagePNG = 2,     //!< PNG format image data.
+      ImageMaskPNG = 3, //!< PNG format image mask.
+
+      /// @deprecated Will be removed in 4.0. Use e57::ImageNone.
+      E57_NO_IMAGE [[deprecated( "Will be removed in 4.0. Use ImageNone." )]] = ImageNone,
+      /// @deprecated Will be removed in 4.0. Use e57::ImageJPEG.
+      E57_JPEG_IMAGE [[deprecated( "Will be removed in 4.0. Use ImageJPEG." )]] = ImageJPEG,
+      /// @deprecated Will be removed in 4.0. Use e57::ImagePNG.
+      E57_PNG_IMAGE [[deprecated( "Will be removed in 4.0. Use ImagePNG." )]] = ImagePNG,
+      /// @deprecated Will be removed in 4.0. Use e57::ImageMaskPNG.
+      E57_PNG_IMAGE_MASK [[deprecated( "Will be removed in 4.0. Use ImageMaskPNG." )]] = ImageMaskPNG,
    };
 
    //! @brief Identifies the representation for the image data
    enum Image2DProjection
    {
-      E57_NO_PROJECTION = 0, //!< No representation for the image data is present
-      E57_VISUAL = 1,        //!< VisualReferenceRepresentation for the image data
-      E57_PINHOLE = 2,       //!< PinholeRepresentation for the image data
-      E57_SPHERICAL = 3,     //!< SphericalRepresentation for the image data
-      E57_CYLINDRICAL = 4    //!< CylindricalRepresentation for the image data
+      ProjectionNone = 0,        //!< No representation for the image data is present
+      ProjectionVisual = 1,      //!< VisualReferenceRepresentation for the image data
+      ProjectionPinhole = 2,     //!< PinholeRepresentation for the image data
+      ProjectionSpherical = 3,   //!< SphericalRepresentation for the image data
+      ProjectionCylindrical = 4, //!< CylindricalRepresentation for the image data
+
+      /// @deprecated Will be removed in 4.0. Use e57::ProjectionNone.
+      E57_NO_PROJECTION [[deprecated( "Will be removed in 4.0. Use ProjectionNone." )]] = ProjectionNone,
+      /// @deprecated Will be removed in 4.0. Use e57::ProjectionVisual.
+      E57_VISUAL [[deprecated( "Will be removed in 4.0. Use ProjectionVisual." )]] = ProjectionVisual,
+      /// @deprecated Will be removed in 4.0. Use e57::ProjectionPinhole.
+      E57_PINHOLE [[deprecated( "Will be removed in 4.0. Use ProjectionPinhole." )]] = ProjectionPinhole,
+      /// @deprecated Will be removed in 4.0. Use e57::ProjectionSpherical.
+      E57_SPHERICAL [[deprecated( "Will be removed in 4.0. Use ProjectionSpherical." )]] = ProjectionSpherical,
+      /// @deprecated Will be removed in 4.0. Use e57::ProjectionCylindrical.
+      E57_CYLINDRICAL [[deprecated( "Will be removed in 4.0. Use ProjectionCylindrical." )]] = ProjectionCylindrical,
    };
 } // end namespace e57

--- a/include/E57SimpleReader.h
+++ b/include/E57SimpleReader.h
@@ -43,7 +43,7 @@ namespace e57
    struct E57_DLL ReaderOptions
    {
       //! Set how frequently to verify the checksums (see ReadChecksumPolicy).
-      ReadChecksumPolicy checksumPolicy = ChecksumPolicy::All;
+      ReadChecksumPolicy checksumPolicy = ChecksumAll;
    };
 
    //! @brief Used for reading an E57 file using E57 Simple API.

--- a/src/BlobNode.cpp
+++ b/src/BlobNode.cpp
@@ -111,10 +111,10 @@ true).
 @pre     The @a destImageFile must have been opened in write mode (i.e.
 destImageFile.isWritable() must be true).
 @pre     byteCount >= 0
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_FILE_IS_READ_ONLY
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorFileReadOnly
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     Node, BlobNode::read, BlobNode::write
 */
 BlobNode::BlobNode( ImageFile destImageFile, int64_t byteCount ) :
@@ -170,8 +170,8 @@ bool BlobNode::isAttached() const
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  The declared size of the blob when it was created.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     BlobNode::read, BlobNode::write
 */
 int64_t BlobNode::byteCount() const
@@ -198,12 +198,12 @@ the Blob data can be read zero or more times.
 @pre     0 <= @a start < byteCount()
 @pre     0 <= count
 @pre     (@a start + @a count) < byteCount()
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_LSEEK_FAILED
-@throw   ::E57_ERROR_READ_FAILED
-@throw   ::E57_ERROR_BAD_CHECKSUM
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorSeekFailed
+@throw   ::ErrorReadFailed
+@throw   ::ErrorBadChecksum
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     BlobNode::byteCount, BlobNode::write
 */
 void BlobNode::read( uint8_t *buf, int64_t start, size_t count )
@@ -237,15 +237,15 @@ destImageFile().isWritable()).
 @pre     0 <= @a start < byteCount()
 @pre     0 <= count
 @pre     (@a start + @a count) < byteCount()
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_FILE_IS_READ_ONLY
-@throw   ::E57_ERROR_NODE_UNATTACHED
-@throw   ::E57_ERROR_LSEEK_FAILED
-@throw   ::E57_ERROR_READ_FAILED
-@throw   ::E57_ERROR_WRITE_FAILED
-@throw   ::E57_ERROR_BAD_CHECKSUM
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorFileReadOnly
+@throw   ::ErrorNodeUnattached
+@throw   ::ErrorSeekFailed
+@throw   ::ErrorReadFailed
+@throw   ::ErrorWriteFailed
+@throw   ::ErrorBadChecksum
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     BlobNode::byteCount, BlobNode::read
 */
 void BlobNode::write( uint8_t *buf, int64_t start, size_t count )
@@ -287,7 +287,7 @@ void BlobNode::checkInvariant( bool /*doRecurse*/, bool doUpcast )
 
    if ( byteCount() < 0 )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 }
 // endExample BlobNode::checkInvariant
@@ -315,14 +315,14 @@ exception is thrown. In designs that need to avoid the exception, use
 Node::type() to determine the actual type of the @a n before downcasting. This
 function must be explicitly called (c++ compiler cannot insert it
 automatically).
-@throw   ::E57_ERROR_BAD_NODE_DOWNCAST
+@throw   ::ErrorBadNodeDowncast
 @see     Node::type(), BlobNode::operator Node()
 */
 BlobNode::BlobNode( const Node &n )
 {
-   if ( n.type() != E57_BLOB )
+   if ( n.type() != TypeBlob )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_NODE_DOWNCAST, "nodeType=" + toString( n.type() ) );
+      throw E57_EXCEPTION2( ErrorBadNodeDowncast, "nodeType=" + toString( n.type() ) );
    }
 
    /// Set our shared_ptr to the downcast shared_ptr

--- a/src/BlobNodeImpl.cpp
+++ b/src/BlobNodeImpl.cpp
@@ -86,7 +86,7 @@ namespace e57
       // don't checkImageFileOpen, NodeImpl() will do it
 
       /// Same node type?
-      if ( ni->type() != E57_BLOB )
+      if ( ni->type() != TypeBlob )
       {
          return ( false );
       }
@@ -127,9 +127,9 @@ namespace e57
       checkImageFileOpen( __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) );
       if ( static_cast<uint64_t>( start ) + count > blobLogicalLength_ )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_API_ARGUMENT,
-                               "this->pathName=" + this->pathName() + " start=" + toString( start ) +
-                                  " count=" + toString( count ) + " length=" + toString( blobLogicalLength_ ) );
+         throw E57_EXCEPTION2( ErrorBadAPIArgument, "this->pathName=" + this->pathName() +
+                                                       " start=" + toString( start ) + " count=" + toString( count ) +
+                                                       " length=" + toString( blobLogicalLength_ ) );
       }
 
       ImageFileImplSharedPtr imf( destImageFile_ );
@@ -147,18 +147,18 @@ namespace e57
 
       if ( !destImageFile->isWriter() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_FILE_IS_READ_ONLY, "fileName=" + destImageFile->fileName() );
+         throw E57_EXCEPTION2( ErrorFileReadOnly, "fileName=" + destImageFile->fileName() );
       }
       if ( !isAttached() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_NODE_UNATTACHED, "fileName=" + destImageFile->fileName() );
+         throw E57_EXCEPTION2( ErrorNodeUnattached, "fileName=" + destImageFile->fileName() );
       }
 
       if ( static_cast<uint64_t>( start ) + count > blobLogicalLength_ )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_API_ARGUMENT,
-                               "this->pathName=" + this->pathName() + " start=" + toString( start ) +
-                                  " count=" + toString( count ) + " length=" + toString( blobLogicalLength_ ) );
+         throw E57_EXCEPTION2( ErrorBadAPIArgument, "this->pathName=" + this->pathName() +
+                                                       " start=" + toString( start ) + " count=" + toString( count ) +
+                                                       " length=" + toString( blobLogicalLength_ ) );
       }
 
       ImageFileImplSharedPtr imf( destImageFile_ );
@@ -175,7 +175,7 @@ namespace e57
       /// blobs? what exception get if try blob in compressedvector?
       if ( pathNames.find( relativePathName( origin ) ) == pathNames.end() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_NO_BUFFER_FOR_ELEMENT, "this->pathName=" + this->pathName() );
+         throw E57_EXCEPTION2( ErrorNoBufferForElement, "this->pathName=" + this->pathName() );
       }
    }
 

--- a/src/BlobNodeImpl.h
+++ b/src/BlobNodeImpl.h
@@ -39,7 +39,7 @@ namespace e57
 
       NodeType type() const override
       {
-         return E57_BLOB;
+         return TypeBlob;
       }
 
       bool isTypeEquivalent( NodeImplSharedPtr ni ) override;

--- a/src/CheckedFile.h
+++ b/src/CheckedFile.h
@@ -104,7 +104,7 @@ namespace e57
       uint64_t logicalLength_ = 0;
       uint64_t physicalLength_ = 0;
 
-      ReadChecksumPolicy checkSumPolicy_ = ChecksumPolicy::All;
+      ReadChecksumPolicy checkSumPolicy_ = ChecksumPolicy::ChecksumAll;
 
       int fd_ = -1;
       BufferView *bufView_ = nullptr;

--- a/src/CompressedVectorNode.cpp
+++ b/src/CompressedVectorNode.cpp
@@ -142,13 +142,13 @@ destImageFile.isWritable() must be true).
 codecs.isRoot())
 @post    prototype.isAttached()
 @post    codecs.isAttached()
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_FILE_IS_READ_ONLY
-@throw   ::E57_ERROR_BAD_PROTOTYPE
-@throw   ::E57_ERROR_BAD_CODECS
-@throw   ::E57_ERROR_ALREADY_HAS_PARENT
-@throw   ::E57_ERROR_DIFFERENT_DEST_IMAGEFILE
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorFileReadOnly
+@throw   ::ErrorBadPrototype
+@throw   ::ErrorBadCodecs
+@throw   ::ErrorAlreadyHasParent
+@throw   ::ErrorDifferentDestImageFile
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     SourceDestBuffer, Node, CompressedVectorNode::reader, CompressedVectorNode::writer
 */
 CompressedVectorNode::CompressedVectorNode( ImageFile destImageFile, const Node &prototype, const VectorNode &codecs ) :
@@ -211,8 +211,8 @@ number will reflect any writes completed.
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  Current number of records in CompressedVectorNode.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorNode::reader, CompressedVectorNode::writer
 */
 int64_t CompressedVectorNode::childCount() const
@@ -225,8 +225,8 @@ int64_t CompressedVectorNode::childCount() const
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  A smart Node handle referencing the root of the prototype tree.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorNode::CompressedVectorNode, SourceDestBuffer,
 CompressedVectorNode::reader, CompressedVectorNode::writer
 */
@@ -241,8 +241,8 @@ the CompressedVectorNode.
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  A smart VectorNode handle referencing the root of the codecs tree.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorNode::CompressedVectorNode, SourceDestBuffer,
 CompressedVectorNode::reader, CompressedVectorNode::writer
 */
@@ -289,19 +289,19 @@ void CompressedVectorNode::checkInvariant( bool doRecurse, bool doUpcast )
    // prototype attached state not same as this attached state
    if ( prototype().isAttached() != isAttached() )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // prototype not root
    if ( !prototype().isRoot() )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // prototype dest ImageFile not same as this dest ImageFile
    if ( prototype().destImageFile() != destImageFile() )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // Check codecs is good Node
@@ -310,19 +310,19 @@ void CompressedVectorNode::checkInvariant( bool doRecurse, bool doUpcast )
    // codecs attached state not same as this attached state
    if ( codecs().isAttached() != isAttached() )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // codecs not root
    if ( !codecs().isRoot() )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // codecs dest ImageFile not same as this dest ImageFile
    if ( codecs().destImageFile() != destImageFile() )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 }
 // endExample CompressedVectorNode::checkInvariant
@@ -350,14 +350,14 @@ otherwise an exception is thrown. In designs that need to avoid the exception,
 use Node::type() to determine the actual type of the @a n before downcasting.
 This function must be explicitly called (c++ compiler cannot insert it
 automatically).
-@throw   ::E57_ERROR_BAD_NODE_DOWNCAST
+@throw   ::ErrorBadNodeDowncast
 @see     Node::type(), CompressedVectorNode::operator, Node()
 */
 CompressedVectorNode::CompressedVectorNode( const Node &n )
 {
-   if ( n.type() != E57_COMPRESSED_VECTOR )
+   if ( n.type() != TypeCompressedVector )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_NODE_DOWNCAST, "nodeType=" + toString( n.type() ) );
+      throw E57_EXCEPTION2( ErrorBadNodeDowncast, "nodeType=" + toString( n.type() ) );
    }
 
    /// Set our shared_ptr to the downcast shared_ptr
@@ -401,18 +401,18 @@ destImageFile.isWritable()).
 0).
 @return  A smart CompressedVectorWriter handle referencing the underlying
 iterator object.
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_FILE_IS_READ_ONLY
-@throw   ::E57_ERROR_SET_TWICE
-@throw   ::E57_ERROR_TOO_MANY_WRITERS
-@throw   ::E57_ERROR_TOO_MANY_READERS
-@throw   ::E57_ERROR_NODE_UNATTACHED
-@throw   ::E57_ERROR_PATH_UNDEFINED
-@throw   ::E57_ERROR_BUFFER_SIZE_MISMATCH
-@throw   ::E57_ERROR_BUFFER_DUPLICATE_PATHNAME
-@throw   ::E57_ERROR_NO_BUFFER_FOR_ELEMENT
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorFileReadOnly
+@throw   ::ErrorSetTwice
+@throw   ::ErrorTooManyWriters
+@throw   ::ErrorTooManyReaders
+@throw   ::ErrorNodeUnattached
+@throw   ::ErrorPathUndefined
+@throw   ::ErrorBufferSizeMismatch
+@throw   ::ErrorBufferDuplicatePathName
+@throw   ::ErrorNoBufferForElement
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorWriter, SourceDestBuffer, CompressedVectorNode::CompressedVectorNode,
 CompressedVectorNode::prototype
 */
@@ -440,15 +440,15 @@ create a CompressedVectorReader for an empty CompressedVectorNode.
 @pre     This CompressedVectorNode must be attached (i.e. isAttached()).
 @return  A smart CompressedVectorReader handle referencing the underlying
 iterator object.
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_TOO_MANY_WRITERS
-@throw   ::E57_ERROR_NODE_UNATTACHED
-@throw   ::E57_ERROR_PATH_UNDEFINED
-@throw   ::E57_ERROR_BUFFER_SIZE_MISMATCH
-@throw   ::E57_ERROR_BUFFER_DUPLICATE_PATHNAME
-@throw   ::E57_ERROR_BAD_CV_HEADER
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorTooManyWriters
+@throw   ::ErrorNodeUnattached
+@throw   ::ErrorPathUndefined
+@throw   ::ErrorBufferSizeMismatch
+@throw   ::ErrorBufferDuplicatePathName
+@throw   ::ErrorBadCVHeader
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorReader, SourceDestBuffer, CompressedVectorNode::CompressedVectorNode,
 CompressedVectorNode::prototype
 */

--- a/src/CompressedVectorNodeImpl.cpp
+++ b/src/CompressedVectorNodeImpl.cpp
@@ -45,18 +45,18 @@ namespace e57
       // don't checkImageFileOpen, ctor did it
 
       //??? check ok for proto, no Blob CompressedVector, empty?
-      //??? throw E57_EXCEPTION2(E57_ERROR_BAD_PROTOTYPE)
+      //??? throw E57_EXCEPTION2(ErrorBadPrototype)
 
       /// Can't set prototype twice.
       if ( prototype_ )
       {
-         throw E57_EXCEPTION2( E57_ERROR_SET_TWICE, "this->pathName=" + this->pathName() );
+         throw E57_EXCEPTION2( ErrorSetTwice, "this->pathName=" + this->pathName() );
       }
 
       /// prototype can't have a parent (must be a root node)
       if ( !prototype->isRoot() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_ALREADY_HAS_PARENT,
+         throw E57_EXCEPTION2( ErrorAlreadyHasParent,
                                "this->pathName=" + this->pathName() + " prototype->pathName=" + prototype->pathName() );
       }
 
@@ -65,9 +65,9 @@ namespace e57
       ImageFileImplSharedPtr prototypeDest( prototype->destImageFile() );
       if ( thisDest != prototypeDest )
       {
-         throw E57_EXCEPTION2( E57_ERROR_DIFFERENT_DEST_IMAGEFILE, "this->destImageFile" + thisDest->fileName() +
-                                                                      " prototype->destImageFile" +
-                                                                      prototypeDest->fileName() );
+         throw E57_EXCEPTION2( ErrorDifferentDestImageFile, "this->destImageFile" + thisDest->fileName() +
+                                                               " prototype->destImageFile" +
+                                                               prototypeDest->fileName() );
       }
 
       //!!! check for incomplete CompressedVectors when closing file
@@ -94,13 +94,13 @@ namespace e57
       /// Can't set codecs twice.
       if ( codecs_ )
       {
-         throw E57_EXCEPTION2( E57_ERROR_SET_TWICE, "this->pathName=" + this->pathName() );
+         throw E57_EXCEPTION2( ErrorSetTwice, "this->pathName=" + this->pathName() );
       }
 
       /// codecs can't have a parent (must be a root node)
       if ( !codecs->isRoot() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_ALREADY_HAS_PARENT,
+         throw E57_EXCEPTION2( ErrorAlreadyHasParent,
                                "this->pathName=" + this->pathName() + " codecs->pathName=" + codecs->pathName() );
       }
 
@@ -109,9 +109,8 @@ namespace e57
       ImageFileImplSharedPtr codecsDest( codecs->destImageFile() );
       if ( thisDest != codecsDest )
       {
-         throw E57_EXCEPTION2( E57_ERROR_DIFFERENT_DEST_IMAGEFILE, "this->destImageFile" + thisDest->fileName() +
-                                                                      " codecs->destImageFile" +
-                                                                      codecsDest->fileName() );
+         throw E57_EXCEPTION2( ErrorDifferentDestImageFile, "this->destImageFile" + thisDest->fileName() +
+                                                               " codecs->destImageFile" + codecsDest->fileName() );
       }
 
       codecs_ = codecs;
@@ -133,7 +132,7 @@ namespace e57
       //??? is this test a good idea?
 
       /// Same node type?
-      if ( ni->type() != E57_COMPRESSED_VECTOR )
+      if ( ni->type() != TypeCompressedVector )
       {
          return ( false );
       }
@@ -161,7 +160,7 @@ namespace e57
 
    bool CompressedVectorNodeImpl::isDefined( const ustring &pathName )
    {
-      throw E57_EXCEPTION2( E57_ERROR_NOT_IMPLEMENTED, "this->pathName=" + this->pathName() + " pathName=" + pathName );
+      throw E57_EXCEPTION2( ErrorNotImplemented, "this->pathName=" + this->pathName() + " pathName=" + pathName );
    }
 
    void CompressedVectorNodeImpl::setAttachedRecursive()
@@ -194,7 +193,7 @@ namespace e57
 
       /// Since only called for prototype nodes, shouldn't be able to get here since
       /// CompressedVectors can't be in prototypes
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "this->pathName=" + this->pathName() );
+      throw E57_EXCEPTION2( ErrorInternal, "this->pathName=" + this->pathName() );
    }
 
    void CompressedVectorNodeImpl::writeXml( ImageFileImplSharedPtr imf, CheckedFile &cf, int indent,
@@ -267,33 +266,31 @@ namespace e57
       /// Check don't have any writers/readers open for this ImageFile
       if ( destImageFile->writerCount() > 0 )
       {
-         throw E57_EXCEPTION2( E57_ERROR_TOO_MANY_WRITERS,
-                               "fileName=" + destImageFile->fileName() +
-                                  " writerCount=" + toString( destImageFile->writerCount() ) +
-                                  " readerCount=" + toString( destImageFile->readerCount() ) );
+         throw E57_EXCEPTION2( ErrorTooManyWriters, "fileName=" + destImageFile->fileName() +
+                                                       " writerCount=" + toString( destImageFile->writerCount() ) +
+                                                       " readerCount=" + toString( destImageFile->readerCount() ) );
       }
       if ( destImageFile->readerCount() > 0 )
       {
-         throw E57_EXCEPTION2( E57_ERROR_TOO_MANY_READERS,
-                               "fileName=" + destImageFile->fileName() +
-                                  " writerCount=" + toString( destImageFile->writerCount() ) +
-                                  " readerCount=" + toString( destImageFile->readerCount() ) );
+         throw E57_EXCEPTION2( ErrorTooManyReaders, "fileName=" + destImageFile->fileName() +
+                                                       " writerCount=" + toString( destImageFile->writerCount() ) +
+                                                       " readerCount=" + toString( destImageFile->readerCount() ) );
       }
 
       /// sbufs can't be empty
       if ( sbufs.empty() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_API_ARGUMENT, "fileName=" + destImageFile->fileName() );
+         throw E57_EXCEPTION2( ErrorBadAPIArgument, "fileName=" + destImageFile->fileName() );
       }
 
       if ( !destImageFile->isWriter() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_FILE_IS_READ_ONLY, "fileName=" + destImageFile->fileName() );
+         throw E57_EXCEPTION2( ErrorFileReadOnly, "fileName=" + destImageFile->fileName() );
       }
 
       if ( !isAttached() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_NODE_UNATTACHED, "fileName=" + destImageFile->fileName() );
+         throw E57_EXCEPTION2( ErrorNodeUnattached, "fileName=" + destImageFile->fileName() );
       }
 
       /// Get pointer to me (really shared_ptr<CompressedVectorNodeImpl>)
@@ -316,29 +313,27 @@ namespace e57
       /// Check don't have any writers/readers open for this ImageFile
       if ( destImageFile->writerCount() > 0 )
       {
-         throw E57_EXCEPTION2( E57_ERROR_TOO_MANY_WRITERS,
-                               "fileName=" + destImageFile->fileName() +
-                                  " writerCount=" + toString( destImageFile->writerCount() ) +
-                                  " readerCount=" + toString( destImageFile->readerCount() ) );
+         throw E57_EXCEPTION2( ErrorTooManyWriters, "fileName=" + destImageFile->fileName() +
+                                                       " writerCount=" + toString( destImageFile->writerCount() ) +
+                                                       " readerCount=" + toString( destImageFile->readerCount() ) );
       }
       if ( destImageFile->readerCount() > 0 )
       {
-         throw E57_EXCEPTION2( E57_ERROR_TOO_MANY_READERS,
-                               "fileName=" + destImageFile->fileName() +
-                                  " writerCount=" + toString( destImageFile->writerCount() ) +
-                                  " readerCount=" + toString( destImageFile->readerCount() ) );
+         throw E57_EXCEPTION2( ErrorTooManyReaders, "fileName=" + destImageFile->fileName() +
+                                                       " writerCount=" + toString( destImageFile->writerCount() ) +
+                                                       " readerCount=" + toString( destImageFile->readerCount() ) );
       }
 
       /// dbufs can't be empty
       if ( dbufs.empty() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_API_ARGUMENT, "fileName=" + destImageFile->fileName() );
+         throw E57_EXCEPTION2( ErrorBadAPIArgument, "fileName=" + destImageFile->fileName() );
       }
 
       /// Can be read or write mode, but must be attached
       if ( !isAttached() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_NODE_UNATTACHED, "fileName=" + destImageFile->fileName() );
+         throw E57_EXCEPTION2( ErrorNodeUnattached, "fileName=" + destImageFile->fileName() );
       }
 
       /// Get pointer to me (really shared_ptr<CompressedVectorNodeImpl>)

--- a/src/CompressedVectorNodeImpl.h
+++ b/src/CompressedVectorNodeImpl.h
@@ -38,7 +38,7 @@ namespace e57
 
       NodeType type() const override
       {
-         return E57_COMPRESSED_VECTOR;
+         return TypeCompressedVector;
       }
 
       bool isTypeEquivalent( NodeImplSharedPtr ni ) override;

--- a/src/CompressedVectorReader.cpp
+++ b/src/CompressedVectorReader.cpp
@@ -113,29 +113,29 @@ destroyed.
 @pre     The associated ImageFile must be open.
 @pre     This CompressedVectorReader must be open (i.e isOpen())
 @return  The number of records read.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_READER_NOT_OPEN
-@throw   ::E57_ERROR_CONVERSION_REQUIRED            This CompressedVectorReader
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorReaderNotOpen
+@throw   ::ErrorConversionRequired            This CompressedVectorReader
 in undocumented state
-@throw   ::E57_ERROR_VALUE_NOT_REPRESENTABLE        This CompressedVectorReader
+@throw   ::ErrorValueNotRepresentable        This CompressedVectorReader
 in undocumented state
-@throw   ::E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE This CompressedVectorReader
+@throw   ::ErrorScaledValueNotRepresentable This CompressedVectorReader
 in undocumented state
-@throw   ::E57_ERROR_REAL64_TOO_LARGE               This CompressedVectorReader
+@throw   ::ErrorReal64TooLarge               This CompressedVectorReader
 in undocumented state
-@throw   ::E57_ERROR_EXPECTING_NUMERIC              This CompressedVectorReader
+@throw   ::ErrorExpectingNumeric              This CompressedVectorReader
 in undocumented state
-@throw   ::E57_ERROR_EXPECTING_USTRING              This CompressedVectorReader
+@throw   ::ErrorExpectingUString              This CompressedVectorReader
 in undocumented state
-@throw   ::E57_ERROR_BAD_CV_PACKET      This CompressedVectorReader, associated
+@throw   ::ErrorBadCVPacket      This CompressedVectorReader, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_LSEEK_FAILED       This CompressedVectorReader, associated
+@throw   ::ErrorSeekFailed       This CompressedVectorReader, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_READ_FAILED        This CompressedVectorReader, associated
+@throw   ::ErrorReadFailed        This CompressedVectorReader, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_BAD_CHECKSUM       This CompressedVectorReader, associated
+@throw   ::ErrorBadChecksum       This CompressedVectorReader, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorReader::read(std::vector<SourceDestBuffer>&),
 CompressedVectorNode::reader, SourceDestBuffer,
 CompressedVectorReader::read(std::vector<SourceDestBuffer>&)
@@ -182,32 +182,32 @@ destroyed.
 @pre     The associated ImageFile must be open.
 @pre     This CompressedVectorReader must be open (i.e isOpen())
 @return  The number of records read.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_READER_NOT_OPEN
-@throw   ::E57_ERROR_PATH_UNDEFINED
-@throw   ::E57_ERROR_BUFFER_SIZE_MISMATCH
-@throw   ::E57_ERROR_BUFFER_DUPLICATE_PATHNAME
-@throw   ::E57_ERROR_CONVERSION_REQUIRED            This CompressedVectorReader
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorReaderNotOpen
+@throw   ::ErrorPathUndefined
+@throw   ::ErrorBufferSizeMismatch
+@throw   ::ErrorBufferDuplicatePathName
+@throw   ::ErrorConversionRequired            This CompressedVectorReader
 in undocumented state
-@throw   ::E57_ERROR_VALUE_NOT_REPRESENTABLE        This CompressedVectorReader
+@throw   ::ErrorValueNotRepresentable        This CompressedVectorReader
 in undocumented state
-@throw   ::E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE This CompressedVectorReader
+@throw   ::ErrorScaledValueNotRepresentable This CompressedVectorReader
 in undocumented state
-@throw   ::E57_ERROR_REAL64_TOO_LARGE               This CompressedVectorReader
+@throw   ::ErrorReal64TooLarge               This CompressedVectorReader
 in undocumented state
-@throw   ::E57_ERROR_EXPECTING_NUMERIC              This CompressedVectorReader
+@throw   ::ErrorExpectingNumeric              This CompressedVectorReader
 in undocumented state
-@throw   ::E57_ERROR_EXPECTING_USTRING              This CompressedVectorReader
+@throw   ::ErrorExpectingUString              This CompressedVectorReader
 in undocumented state
-@throw   ::E57_ERROR_BAD_CV_PACKET      This CompressedVectorReader, associated
+@throw   ::ErrorBadCVPacket      This CompressedVectorReader, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_LSEEK_FAILED       This CompressedVectorReader, associated
+@throw   ::ErrorSeekFailed       This CompressedVectorReader, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_READ_FAILED        This CompressedVectorReader, associated
+@throw   ::ErrorReadFailed        This CompressedVectorReader, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_BAD_CHECKSUM       This CompressedVectorReader, associated
+@throw   ::ErrorBadChecksum       This CompressedVectorReader, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorReader::read(), CompressedVectorNode::reader, SourceDestBuffer
 */
 unsigned CompressedVectorReader::read( std::vector<SourceDestBuffer> &dbufs )
@@ -228,14 +228,14 @@ one record past end of CompressedVectorNode).
 @pre     @a recordNumber <= childCount() of CompressedVectorNode.
 @pre     The associated ImageFile must be open.
 @pre     This CompressedVectorReader must be open (i.e isOpen())
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_READER_NOT_OPEN
-@throw   ::E57_ERROR_BAD_CV_PACKET
-@throw   ::E57_ERROR_LSEEK_FAILED
-@throw   ::E57_ERROR_READ_FAILED
-@throw   ::E57_ERROR_BAD_CHECKSUM
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorReaderNotOpen
+@throw   ::ErrorBadCVPacket
+@throw   ::ErrorSeekFailed
+@throw   ::ErrorReadFailed
+@throw   ::ErrorBadChecksum
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorNode::reader
 */
 void CompressedVectorReader::seek( int64_t recordNumber )
@@ -252,7 +252,7 @@ CompressedVectorReader is already closed. This function will cause the
 CompressedVectorReader to enter the closed state, and any further transfers
 requests will fail.
 
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorReader::isOpen, CompressedVectorNode::reader
 */
 void CompressedVectorReader::close()
@@ -263,8 +263,8 @@ void CompressedVectorReader::close()
 /*!
 @brief   Test whether CompressedVectorReader is still open for reading.
 @pre     The associated ImageFile must be open.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorReader::close, CompressedVectorNode::reader
 */
 bool CompressedVectorReader::isOpen()
@@ -279,8 +279,8 @@ It is not an error if this CompressedVectorReader is closed.
 @pre     The associated ImageFile must be open.
 @return  A smart CompressedVectorNode handle referencing the underlying object
 being read from.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorReader::close, CompressedVectorNode::reader
 */
 CompressedVectorNode CompressedVectorReader::compressedVectorNode() const
@@ -310,8 +310,7 @@ sub-objects recursively.
 This function checks at least the assertions in the documented class invariant
 description (see class reference page for this object). Other internal
 invariants that are implementation-dependent may also be checked. If any
-invariant clause is violated, an E57Exception with errorCode of
-E57_ERROR_INVARIANCE_VIOLATION is thrown.
+invariant clause is violated, an ::ErrorInvarianceViolation E57Exception is thrown.
 @post    No visible state is modified.
 */
 // beginExample CompressedVectorReader::checkInvariant
@@ -337,19 +336,19 @@ void CompressedVectorReader::checkInvariant( bool /*doRecurse*/ )
    // Associated CompressedVectorNode must be attached to ImageFile
    if ( !cv.isAttached() )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // Dest ImageFile must have at least 1 reader (this one)
    if ( imf.readerCount() < 1 )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // Dest ImageFile can't have any writers
    if ( imf.writerCount() != 0 )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 }
 // endExample CompressedVectorReader::checkInvariant

--- a/src/CompressedVectorReaderImpl.cpp
+++ b/src/CompressedVectorReaderImpl.cpp
@@ -55,7 +55,7 @@ namespace e57
       /// Empty dbufs is an error
       if ( dbufs.empty() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_API_ARGUMENT,
+         throw E57_EXCEPTION2( ErrorBadAPIArgument,
                                "imageFileName=" + cVector_->imageFileName() + " cvPathName=" + cVector_->pathName() );
       }
 
@@ -81,7 +81,7 @@ namespace e57
          uint64_t bytestreamNumber = 0;
          if ( !proto_->findTerminalPosition( readNode, bytestreamNumber ) )
          {
-            throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "dbufIndex=" + toString( i ) );
+            throw E57_EXCEPTION2( ErrorInternal, "dbufIndex=" + toString( i ) );
          }
 
          channels_.emplace_back( dbufs.at( i ), decoder, static_cast<unsigned>( bytestreamNumber ),
@@ -106,7 +106,7 @@ namespace e57
          //??? should have caught this before got here, in XML read, get this if CV
          // wasn't written to
          // by writer.
-         throw E57_EXCEPTION2( E57_ERROR_INTERNAL,
+         throw E57_EXCEPTION2( ErrorInternal,
                                "imageFileName=" + cVector_->imageFileName() + " cvPathName=" + cVector_->pathName() );
       }
       imf->file_->seek( sectionLogicalStart, CheckedFile::Logical );
@@ -133,7 +133,7 @@ namespace e57
          /// Double check that have a data packet
          if ( dpkt->header.packetType != DATA_PACKET )
          {
-            throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "packetType=" + toString( dpkt->header.packetType ) );
+            throw E57_EXCEPTION2( ErrorBadCVPacket, "packetType=" + toString( dpkt->header.packetType ) );
          }
 
          /// Have good packet, initialize channels
@@ -187,7 +187,7 @@ namespace e57
       {
          if ( dbufs_.size() != dbufs.size() )
          {
-            throw E57_EXCEPTION2( E57_ERROR_BUFFERS_NOT_COMPATIBLE,
+            throw E57_EXCEPTION2( ErrorBuffersNotCompatible,
                                   "oldSize=" + toString( dbufs_.size() ) + " newSize=" + toString( dbufs.size() ) );
          }
          for ( size_t i = 0; i < dbufs_.size(); i++ )
@@ -248,7 +248,7 @@ namespace e57
          uint64_t earliestPacketLogicalOffset = earliestPacketNeededForInput();
 
          /// If nobody's hungry, we are done with the read
-         if ( earliestPacketLogicalOffset == E57_UINT64_MAX )
+         if ( earliestPacketLogicalOffset == UINT64_MAX )
          {
             break;
          }
@@ -270,8 +270,8 @@ namespace e57
          {
             if ( outputCount != chan->dbuf.impl()->nextIndex() )
             {
-               throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "outputCount=" + toString( outputCount ) + " nextIndex=" +
-                                                            toString( chan->dbuf.impl()->nextIndex() ) );
+               throw E57_EXCEPTION2( ErrorInternal, "outputCount=" + toString( outputCount ) +
+                                                       " nextIndex=" + toString( chan->dbuf.impl()->nextIndex() ) );
             }
          }
       }
@@ -282,7 +282,7 @@ namespace e57
 
    uint64_t CompressedVectorReaderImpl::earliestPacketNeededForInput() const
    {
-      uint64_t earliestPacketLogicalOffset = E57_UINT64_MAX;
+      uint64_t earliestPacketLogicalOffset = UINT64_MAX;
 #ifdef E57_MAX_VERBOSE
       unsigned earliestChannel = 0;
 #endif
@@ -341,13 +341,13 @@ namespace e57
       // Double check that have a data packet.  Should have already determined this.
       if ( dpkt->header.packetType != DATA_PACKET )
       {
-         throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "packetType=" + toString( dpkt->header.packetType ) );
+         throw E57_EXCEPTION2( ErrorInternal, "packetType=" + toString( dpkt->header.packetType ) );
       }
 
       // Read earliest packet into cache and send data to decoders with unblocked output
 
       bool anyChannelHasExhaustedPacket = false;
-      uint64_t nextPacketLogicalOffset = E57_UINT64_MAX;
+      uint64_t nextPacketLogicalOffset = UINT64_MAX;
 
       // Feed bytestreams to channels with unblocked output that are reading from this packet
       for ( DecodeChannel &channel : channels_ )
@@ -365,7 +365,7 @@ namespace e57
          // Double check we are not off end of buffer
          if ( channel.currentBytestreamBufferIndex > bsbLength )
          {
-            throw E57_EXCEPTION2( E57_ERROR_INTERNAL,
+            throw E57_EXCEPTION2( ErrorInternal,
                                   "currentBytestreamBufferIndex =" + toString( channel.currentBytestreamBufferIndex ) +
                                      " bsbLength=" + toString( bsbLength ) );
          }
@@ -376,8 +376,8 @@ namespace e57
 
          if ( &uneatenStart[uneatenLength] > &bsbStart[bsbLength] )
          {
-            throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "uneatenLength=" + toString( uneatenLength ) +
-                                                         " bsbLength=" + toString( bsbLength ) );
+            throw E57_EXCEPTION2( ErrorInternal, "uneatenLength=" + toString( uneatenLength ) +
+                                                    " bsbLength=" + toString( bsbLength ) );
          }
 
          // Feed into decoder
@@ -423,7 +423,7 @@ namespace e57
       // Some channel has exhausted this packet, so find next data packet and
       // update currentPacketLogicalOffset for all interested channels.
 
-      if ( nextPacketLogicalOffset < E57_UINT64_MAX )
+      if ( nextPacketLogicalOffset < UINT64_MAX )
       { //??? huh?
          // Get packet at nextPacketLogicalOffset into memory.
          dpkt = dataPacket( nextPacketLogicalOffset );
@@ -509,7 +509,7 @@ namespace e57
       }
 
       /// Ran off end of section, so return failure code.
-      return E57_UINT64_MAX;
+      return UINT64_MAX;
    }
 
    void CompressedVectorReaderImpl::seek( uint64_t /*recordNumber*/ )
@@ -517,7 +517,7 @@ namespace e57
       checkImageFileOpen( __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) );
 
       ///!!! implement
-      throw E57_EXCEPTION1( E57_ERROR_NOT_IMPLEMENTED );
+      throw E57_EXCEPTION1( ErrorNotImplemented );
    }
 
    bool CompressedVectorReaderImpl::isOpen() const
@@ -566,7 +566,7 @@ namespace e57
    {
       if ( !isOpen_ )
       {
-         throw E57Exception( E57_ERROR_READER_NOT_OPEN,
+         throw E57Exception( ErrorReaderNotOpen,
                              "imageFileName=" + cVector_->imageFileName() + " cvPathName=" + cVector_->pathName(),
                              srcFileName, srcLineNumber, srcFunctionName );
       }

--- a/src/CompressedVectorWriter.cpp
+++ b/src/CompressedVectorWriter.cpp
@@ -107,43 +107,43 @@ CompressedVectorNode will be lost (it will have zero children).
 
 @pre     The associated ImageFile must be open.
 @pre     This CompressedVectorWriter must be open (i.e isOpen())
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_WRITER_NOT_OPEN
-@throw   ::E57_ERROR_PATH_UNDEFINED
-@throw   ::E57_ERROR_NO_BUFFER_FOR_ELEMENT
-@throw   ::E57_ERROR_BUFFER_SIZE_MISMATCH
-@throw   ::E57_ERROR_BUFFER_DUPLICATE_PATHNAME
-@throw   ::E57_ERROR_CONVERSION_REQUIRED     This CompressedVectorWriter in
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorWriterNotOpen
+@throw   ::ErrorPathUndefined
+@throw   ::ErrorNoBufferForElement
+@throw   ::ErrorBufferSizeMismatch
+@throw   ::ErrorBufferDuplicatePathName
+@throw   ::ErrorConversionRequired     This CompressedVectorWriter in
 undocumented state, associated CompressedVectorNode modified but consistent,
 associated ImageFile modified but consistent.
-@throw   ::E57_ERROR_VALUE_OUT_OF_BOUNDS     This CompressedVectorWriter in
+@throw   ::ErrorValueOutOfBounds     This CompressedVectorWriter in
 undocumented state, associated CompressedVectorNode modified but consistent,
 associated ImageFile modified but consistent.
-@throw   ::E57_ERROR_VALUE_NOT_REPRESENTABLE This CompressedVectorWriter in
+@throw   ::ErrorValueNotRepresentable This CompressedVectorWriter in
 undocumented state, associated CompressedVectorNode modified but consistent,
 associated ImageFile modified but consistent.
-@throw   ::E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE This CompressedVectorWriter
+@throw   ::ErrorScaledValueNotRepresentable This CompressedVectorWriter
 in undocumented state, associated CompressedVectorNode modified but consistent,
 associated ImageFile modified but consistent.
-@throw   ::E57_ERROR_REAL64_TOO_LARGE   This CompressedVectorWriter in
+@throw   ::ErrorReal64TooLarge   This CompressedVectorWriter in
 undocumented state, associated CompressedVectorNode modified but consistent,
 associated ImageFile modified but consistent.
-@throw   ::E57_ERROR_EXPECTING_NUMERIC  This CompressedVectorWriter in
+@throw   ::ErrorExpectingNumeric  This CompressedVectorWriter in
 undocumented state, associated CompressedVectorNode modified but consistent,
 associated ImageFile modified but consistent.
-@throw   ::E57_ERROR_EXPECTING_USTRING  This CompressedVectorWriter in
+@throw   ::ErrorExpectingUString  This CompressedVectorWriter in
 undocumented state, associated CompressedVectorNode modified but consistent,
 associated ImageFile modified but consistent.
-@throw   ::E57_ERROR_LSEEK_FAILED       This CompressedVectorWriter, associated
+@throw   ::ErrorSeekFailed       This CompressedVectorWriter, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_READ_FAILED        This CompressedVectorWriter, associated
+@throw   ::ErrorReadFailed        This CompressedVectorWriter, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_WRITE_FAILED       This CompressedVectorWriter, associated
+@throw   ::ErrorWriteFailed       This CompressedVectorWriter, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_BAD_CHECKSUM       This CompressedVectorWriter, associated
+@throw   ::ErrorBadChecksum       This CompressedVectorWriter, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorWriter::write(std::vector<SourceDestBuffer>&,unsigned),
 CompressedVectorNode::writer, CompressedVectorWriter::close, SourceDestBuffer,
 E57Exception
@@ -185,36 +185,36 @@ CompressedVectorNode will be lost (it will have zero children).
 
 @pre     The associated ImageFile must be open.
 @pre     This CompressedVectorWriter must be open (i.e isOpen())
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_WRITER_NOT_OPEN
-@throw   ::E57_ERROR_PATH_UNDEFINED
-@throw   ::E57_ERROR_NO_BUFFER_FOR_ELEMENT
-@throw   ::E57_ERROR_BUFFER_SIZE_MISMATCH
-@throw   ::E57_ERROR_BUFFER_DUPLICATE_PATHNAME
-@throw   ::E57_ERROR_CONVERSION_REQUIRED     This CompressedVectorWriter in
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorWriterNotOpen
+@throw   ::ErrorPathUndefined
+@throw   ::ErrorNoBufferForElement
+@throw   ::ErrorBufferSizeMismatch
+@throw   ::ErrorBufferDuplicatePathName
+@throw   ::ErrorConversionRequired     This CompressedVectorWriter in
 undocumented state, associated ImageFile modified but consistent.
-@throw   ::E57_ERROR_VALUE_OUT_OF_BOUNDS     This CompressedVectorWriter in
+@throw   ::ErrorValueOutOfBounds     This CompressedVectorWriter in
 undocumented state, associated ImageFile modified but consistent.
-@throw   ::E57_ERROR_VALUE_NOT_REPRESENTABLE This CompressedVectorWriter in
+@throw   ::ErrorValueNotRepresentable This CompressedVectorWriter in
 undocumented state, associated ImageFile modified but consistent.
-@throw   ::E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE This CompressedVectorWriter
+@throw   ::ErrorScaledValueNotRepresentable This CompressedVectorWriter
 in undocumented state, associated ImageFile modified but consistent.
-@throw   ::E57_ERROR_REAL64_TOO_LARGE   This CompressedVectorWriter in
+@throw   ::ErrorReal64TooLarge   This CompressedVectorWriter in
 undocumented state, associated ImageFile modified but consistent.
-@throw   ::E57_ERROR_EXPECTING_NUMERIC  This CompressedVectorWriter in
+@throw   ::ErrorExpectingNumeric  This CompressedVectorWriter in
 undocumented state, associated ImageFile modified but consistent.
-@throw   ::E57_ERROR_EXPECTING_USTRING  This CompressedVectorWriter in
+@throw   ::ErrorExpectingUString  This CompressedVectorWriter in
 undocumented state, associated ImageFile modified but consistent.
-@throw   ::E57_ERROR_LSEEK_FAILED       This CompressedVectorWriter, associated
+@throw   ::ErrorSeekFailed       This CompressedVectorWriter, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_READ_FAILED        This CompressedVectorWriter, associated
+@throw   ::ErrorReadFailed        This CompressedVectorWriter, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_WRITE_FAILED       This CompressedVectorWriter, associated
+@throw   ::ErrorWriteFailed       This CompressedVectorWriter, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_BAD_CHECKSUM       This CompressedVectorWriter, associated
+@throw   ::ErrorBadChecksum       This CompressedVectorWriter, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorWriter::write(unsigned), CompressedVectorNode::writer,
 CompressedVectorWriter::close, SourceDestBuffer, E57Exception
 */
@@ -239,16 +239,16 @@ destructor is invoked, all writes to the CompressedVectorNode will be lost (it
 will have zero children).
 @pre     The associated ImageFile must be open.
 @post    This CompressedVectorWriter is closed (i.e !isOpen())
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_LSEEK_FAILED       This CompressedVectorWriter, associated
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorSeekFailed       This CompressedVectorWriter, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_READ_FAILED        This CompressedVectorWriter, associated
+@throw   ::ErrorReadFailed        This CompressedVectorWriter, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_WRITE_FAILED       This CompressedVectorWriter, associated
+@throw   ::ErrorWriteFailed       This CompressedVectorWriter, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_BAD_CHECKSUM       This CompressedVectorWriter, associated
+@throw   ::ErrorBadChecksum       This CompressedVectorWriter, associated
 ImageFile in undocumented state
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorWriter::isOpen
 */
 void CompressedVectorWriter::close()
@@ -259,8 +259,8 @@ void CompressedVectorWriter::close()
 /*!
 @brief   Test whether CompressedVectorWriter is still open for writing.
 @pre     The associated ImageFile must be open.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorWriter::close, CompressedVectorNode::writer
 */
 bool CompressedVectorWriter::isOpen()
@@ -273,8 +273,8 @@ bool CompressedVectorWriter::isOpen()
 @pre     The associated ImageFile must be open.
 @return  A smart CompressedVectorNode handle referencing the underlying object
 being written to.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorNode::writer
 */
 CompressedVectorNode CompressedVectorWriter::compressedVectorNode() const
@@ -321,25 +321,25 @@ void CompressedVectorWriter::checkInvariant( bool /*doRecurse*/ )
    // Associated CompressedVectorNode must be attached to ImageFile
    if ( !cv.isAttached() )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // Dest ImageFile must be writable
    if ( !imf.isWritable() )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // Dest ImageFile must have exactly 1 writer (this one)
    if ( imf.writerCount() != 1 )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // Dest ImageFile can't have any readers
    if ( imf.readerCount() != 0 )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 }
 // endExample CompressedVectorWriter::checkInvariant

--- a/src/CompressedVectorWriterImpl.cpp
+++ b/src/CompressedVectorWriterImpl.cpp
@@ -56,7 +56,7 @@ namespace e57
       /// Empty sbufs is an error
       if ( sbufs.empty() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_API_ARGUMENT,
+         throw E57_EXCEPTION2( ErrorBadAPIArgument,
                                "imageFileName=" + cVector_->imageFileName() + " cvPathName=" + cVector_->pathName() );
       }
 
@@ -83,7 +83,7 @@ namespace e57
          uint64_t bytestreamNumber = 0;
          if ( !proto_->findTerminalPosition( readNode, bytestreamNumber ) )
          {
-            throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "sbufIndex=" + toString( i ) );
+            throw E57_EXCEPTION2( ErrorInternal, "sbufIndex=" + toString( i ) );
          }
 
          /// EncoderFactory picks the appropriate encoder to match type declared in
@@ -101,8 +101,8 @@ namespace e57
       {
          if ( bytestreams_.at( i )->bytestreamNumber() != i )
          {
-            throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "bytestreamIndex=" + toString( i ) + " bytestreamNumber=" +
-                                                         toString( bytestreams_.at( i )->bytestreamNumber() ) );
+            throw E57_EXCEPTION2( ErrorInternal, "bytestreamIndex=" + toString( i ) + " bytestreamNumber=" +
+                                                    toString( bytestreams_.at( i )->bytestreamNumber() ) );
          }
       }
 #endif
@@ -242,7 +242,7 @@ namespace e57
       {
          if ( sbufs_.size() != sbufs.size() )
          {
-            throw E57_EXCEPTION2( E57_ERROR_BUFFERS_NOT_COMPATIBLE,
+            throw E57_EXCEPTION2( ErrorBuffersNotCompatible,
                                   "oldSize=" + toString( sbufs_.size() ) + " newSize=" + toString( sbufs.size() ) );
          }
 
@@ -284,10 +284,10 @@ namespace e57
       /// Check that requestedRecordCount is not larger than the sbufs
       if ( requestedRecordCount > sbufs_.at( 0 ).impl()->capacity() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_API_ARGUMENT,
-                               "requested=" + toString( requestedRecordCount ) +
-                                  " capacity=" + toString( sbufs_.at( 0 ).impl()->capacity() ) + " imageFileName=" +
-                                  cVector_->imageFileName() + " cvPathName=" + cVector_->pathName() );
+         throw E57_EXCEPTION2( ErrorBadAPIArgument, "requested=" + toString( requestedRecordCount ) +
+                                                       " capacity=" + toString( sbufs_.at( 0 ).impl()->capacity() ) +
+                                                       " imageFileName=" + cVector_->imageFileName() +
+                                                       " cvPathName=" + cVector_->pathName() );
       }
 
       /// Rewind all sbufs so start reading from beginning
@@ -462,8 +462,8 @@ namespace e57
 
       if ( totalByteCount > packetMaxPayloadBytes )
       {
-         throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "totalByteCount=" + toString( totalByteCount ) +
-                                                      " packetMaxPayloadBytes=" + toString( packetMaxPayloadBytes ) );
+         throw E57_EXCEPTION2( ErrorInternal, "totalByteCount=" + toString( totalByteCount ) +
+                                                 " packetMaxPayloadBytes=" + toString( packetMaxPayloadBytes ) );
       }
 #endif
 
@@ -510,7 +510,7 @@ namespace e57
          /// vector<char>
          if ( &p[n] > &packet[DATA_PACKET_MAX] )
          {
-            throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "n=" + toString( n ) );
+            throw E57_EXCEPTION2( ErrorInternal, "n=" + toString( n ) );
          }
 #endif
 
@@ -531,9 +531,9 @@ namespace e57
       /// Double check that packetLength is what we expect
       if ( packetLength != sizeof( DataPacketHeader ) + bytestreams_.size() * sizeof( uint16_t ) + totalByteCount )
       {
-         throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "packetLength=" + toString( packetLength ) + " bytestreamSize=" +
-                                                      toString( bytestreams_.size() * sizeof( uint16_t ) ) +
-                                                      " totalByteCount=" + toString( totalByteCount ) );
+         throw E57_EXCEPTION2( ErrorInternal, "packetLength=" + toString( packetLength ) + " bytestreamSize=" +
+                                                 toString( bytestreams_.size() * sizeof( uint16_t ) ) +
+                                                 " totalByteCount=" + toString( totalByteCount ) );
       }
 #endif
 
@@ -544,7 +544,7 @@ namespace e57
          /// vector<char>
          if ( p >= &packet[DATA_PACKET_MAX - 1] )
          {
-            throw E57_EXCEPTION1( E57_ERROR_INTERNAL );
+            throw E57_EXCEPTION1( ErrorInternal );
          }
          *p++ = 0;
          packetLength++;
@@ -609,7 +609,7 @@ namespace e57
    {
       if ( !isOpen_ )
       {
-         throw E57Exception( E57_ERROR_WRITER_NOT_OPEN,
+         throw E57Exception( ErrorWriterNotOpen,
                              "imageFileName=" + cVector_->imageFileName() + " cvPathName=" + cVector_->pathName(),
                              srcFileName, srcLineNumber, srcFunctionName );
       }

--- a/src/Decoder.cpp
+++ b/src/Decoder.cpp
@@ -59,7 +59,7 @@ std::shared_ptr<Decoder> Decoder::DecoderFactory( unsigned bytestreamNumber, //!
 
    switch ( decodeNode->type() )
    {
-      case E57_INTEGER:
+      case TypeInteger:
       {
          std::shared_ptr<IntegerNodeImpl> ini =
             std::static_pointer_cast<IntegerNodeImpl>( decodeNode ); // downcast to correct type
@@ -107,7 +107,7 @@ std::shared_ptr<Decoder> Decoder::DecoderFactory( unsigned bytestreamNumber, //!
          return decoder;
       }
 
-      case E57_SCALED_INTEGER:
+      case TypeScaledInteger:
       {
          std::shared_ptr<ScaledIntegerNodeImpl> sini =
             std::static_pointer_cast<ScaledIntegerNodeImpl>( decodeNode ); // downcast to correct type
@@ -160,7 +160,7 @@ std::shared_ptr<Decoder> Decoder::DecoderFactory( unsigned bytestreamNumber, //!
          return decoder;
       }
 
-      case E57_FLOAT:
+      case TypeFloat:
       {
          std::shared_ptr<FloatNodeImpl> fni =
             std::static_pointer_cast<FloatNodeImpl>( decodeNode ); // downcast to correct type
@@ -170,7 +170,7 @@ std::shared_ptr<Decoder> Decoder::DecoderFactory( unsigned bytestreamNumber, //!
          return decoder;
       }
 
-      case E57_STRING:
+      case TypeString:
       {
          std::shared_ptr<Decoder> decoder(
             new BitpackStringDecoder( bytestreamNumber, dbufs.at( 0 ), maxRecordCount ) );
@@ -180,7 +180,7 @@ std::shared_ptr<Decoder> Decoder::DecoderFactory( unsigned bytestreamNumber, //!
 
       default:
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_PROTOTYPE, "nodeType=" + toString( decodeNode->type() ) );
+         throw E57_EXCEPTION2( ErrorBadPrototype, "nodeType=" + toString( decodeNode->type() ) );
       }
    }
 }
@@ -202,7 +202,7 @@ void BitpackDecoder::destBufferSetNew( std::vector<SourceDestBuffer> &dbufs )
 {
    if ( dbufs.size() != 1 )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "dbufsSize=" + toString( dbufs.size() ) );
+      throw E57_EXCEPTION2( ErrorInternal, "dbufsSize=" + toString( dbufs.size() ) );
    }
 
    destBuffer_ = dbufs.at( 0 ).impl();
@@ -271,9 +271,8 @@ size_t BitpackDecoder::inputProcess( const char *source, const size_t availableB
 #ifdef E57_DEBUG
       if ( bitsEaten > endBit - inBufferFirstBit_ )
       {
-         throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "bitsEaten=" + toString( bitsEaten ) +
-                                                      " endBit=" + toString( endBit ) +
-                                                      " inBufferFirstBit=" + toString( inBufferFirstBit_ ) );
+         throw E57_EXCEPTION2( ErrorInternal, "bitsEaten=" + toString( bitsEaten ) + " endBit=" + toString( endBit ) +
+                                                 " inBufferFirstBit=" + toString( inBufferFirstBit_ ) );
       }
 #endif
       inBufferFirstBit_ += bitsEaten;
@@ -306,8 +305,8 @@ void BitpackDecoder::inBufferShiftDown()
 #ifdef E57_DEBUG
    if ( firstNaturalByte > inBufferEndByte_ )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "firstNaturalByte=" + toString( firstNaturalByte ) +
-                                                   " inBufferEndByte=" + toString( inBufferEndByte_ ) );
+      throw E57_EXCEPTION2( ErrorInternal, "firstNaturalByte=" + toString( firstNaturalByte ) +
+                                              " inBufferEndByte=" + toString( inBufferEndByte_ ) );
    }
 #endif
    size_t byteCount = inBufferEndByte_ - firstNaturalByte;
@@ -353,7 +352,7 @@ void BitpackDecoder::dump( int indent, std::ostream &os )
 
 BitpackFloatDecoder::BitpackFloatDecoder( unsigned bytestreamNumber, SourceDestBuffer &dbuf, FloatPrecision precision,
                                           uint64_t maxRecordCount ) :
-   BitpackDecoder( bytestreamNumber, dbuf, ( precision == E57_SINGLE ) ? sizeof( float ) : sizeof( double ),
+   BitpackDecoder( bytestreamNumber, dbuf, ( precision == PrecisionSingle ) ? sizeof( float ) : sizeof( double ),
                    maxRecordCount ),
    precision_( precision )
 {
@@ -370,14 +369,14 @@ size_t BitpackFloatDecoder::inputProcessAligned( const char *inbuf, const size_t
 
    size_t n = destBuffer_->capacity() - destBuffer_->nextIndex();
 
-   size_t typeSize = ( precision_ == E57_SINGLE ) ? sizeof( float ) : sizeof( double );
+   size_t typeSize = ( precision_ == PrecisionSingle ) ? sizeof( float ) : sizeof( double );
 
 #ifdef E57_DEBUG
 #if 0 // I know no way to do this portably <rs>
    // Deactivate for now until a better solution is found.
    /// Verify that inbuf is naturally aligned to correct boundary (4 or 8 bytes).  Base class should be doing this for us.
    if (reinterpret_cast<unsigned>(inbuf) % typeSize) {
-      throw E57_EXCEPTION2(E57_ERROR_INTERNAL,
+      throw E57_EXCEPTION2(ErrorInternal,
                            "inbuf=" + toString(reinterpret_cast<unsigned>(inbuf))
                            + " typeSize=" + toString(typeSize));
    }
@@ -385,7 +384,7 @@ size_t BitpackFloatDecoder::inputProcessAligned( const char *inbuf, const size_t
    /// Verify first bit is zero
    if ( firstBit != 0 )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "firstBit=" + toString( firstBit ) );
+      throw E57_EXCEPTION2( ErrorInternal, "firstBit=" + toString( firstBit ) );
    }
 #endif
 
@@ -408,7 +407,7 @@ size_t BitpackFloatDecoder::inputProcessAligned( const char *inbuf, const size_t
    std::cout << "  n:" << n << std::endl; //???
 #endif
 
-   if ( precision_ == E57_SINGLE )
+   if ( precision_ == PrecisionSingle )
    {
       /// Form the starting address for first data location in inBuffer
       auto inp = reinterpret_cast<const float *>( inbuf );
@@ -426,7 +425,7 @@ size_t BitpackFloatDecoder::inputProcessAligned( const char *inbuf, const size_t
       }
    }
    else
-   { /// E57_DOUBLE precision
+   { /// Double precision
       /// Form the starting address for first data location in inBuffer
       auto inp = reinterpret_cast<const double *>( inbuf );
 
@@ -454,13 +453,13 @@ size_t BitpackFloatDecoder::inputProcessAligned( const char *inbuf, const size_t
 void BitpackFloatDecoder::dump( int indent, std::ostream &os )
 {
    BitpackDecoder::dump( indent, os );
-   if ( precision_ == E57_SINGLE )
+   if ( precision_ == PrecisionSingle )
    {
-      os << space( indent ) << "precision:                E57_SINGLE" << std::endl;
+      os << space( indent ) << "precision:                Single" << std::endl;
    }
    else
    {
-      os << space( indent ) << "precision:                E57_DOUBLE" << std::endl;
+      os << space( indent ) << "precision:                Double" << std::endl;
    }
 }
 #endif
@@ -486,7 +485,7 @@ size_t BitpackStringDecoder::inputProcessAligned( const char *inbuf, const size_
    /// Verify first bit is zero (always byte-aligned)
    if ( firstBit != 0 )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "firstBit=" + toString( firstBit ) );
+      throw E57_EXCEPTION2( ErrorInternal, "firstBit=" + toString( firstBit ) );
    }
 #endif
 
@@ -673,12 +672,12 @@ size_t BitpackIntegerDecoder<RegisterT>::inputProcessAligned( const char *inbuf,
    // Deactivate for now until a better solution is found.
    /// Verify that inbuf is naturally aligned to RegisterT boundary (1, 2, 4,or 8 bytes).  Base class is doing this for us.
    if ((reinterpret_cast<unsigned>(inbuf)) % sizeof(RegisterT))
-      throw E57_EXCEPTION2(E57_ERROR_INTERNAL, "inbuf=" + toString(reinterpret_cast<unsigned>(inbuf)));
+      throw E57_EXCEPTION2(ErrorInternal, "inbuf=" + toString(reinterpret_cast<unsigned>(inbuf)));
 #endif
    /// Verify first bit is in first word
    if ( firstBit >= 8 * sizeof( RegisterT ) )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "firstBit=" + toString( firstBit ) );
+      throw E57_EXCEPTION2( ErrorInternal, "firstBit=" + toString( firstBit ) );
    }
 #endif
 
@@ -836,7 +835,7 @@ void ConstantIntegerDecoder::destBufferSetNew( std::vector<SourceDestBuffer> &db
 {
    if ( dbufs.size() != 1 )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "dbufsSize=" + toString( dbufs.size() ) );
+      throw E57_EXCEPTION2( ErrorInternal, "dbufsSize=" + toString( dbufs.size() ) );
    }
 
    destBuffer_ = dbufs.at( 0 ).impl();

--- a/src/Decoder.h
+++ b/src/Decoder.h
@@ -108,7 +108,7 @@ namespace e57
       void dump( int indent = 0, std::ostream &os = std::cout ) override;
 #endif
    protected:
-      FloatPrecision precision_ = E57_SINGLE;
+      FloatPrecision precision_ = PrecisionSingle;
    };
 
    class BitpackStringDecoder : public BitpackDecoder

--- a/src/E57Exception.cpp
+++ b/src/E57Exception.cpp
@@ -53,7 +53,7 @@ namespace e57
    API functions to communicate success or failure of the requested command. In
    contrast, the E57 API uses the C++ exception mechanism to communicate failure
    (success is communicated by the return of the function without exception).
-   E57Exception(E57_SUCCESS) is never thrown. The API ErrorCode is packaged inside
+   ::Success is never thrown. The API ErrorCode is packaged inside
    the E57Exception. The documentation for each function in the API declares which
    ErrorCode values (inside an E57Exception) can possibly be thrown by the
    function. Some API functions do not throw any E57Exceptions, and this is
@@ -81,17 +81,17 @@ namespace e57
    thing to do is to call their destructors.
 
    Almost all of the API functions can throw the following two ErrorCodes:
-   E57_ERROR_IMAGEFILE_NOT_OPEN and E57_ERROR_INTERNAL. In some E57
+   ::ErrorImageFileNotOpen and ::ErrorInternal. In some E57
    implementations, the tree information may be stored on disk rather than in
    memory. If the disk file is closed, even the most basic information may not be
    available about nodes in the tree. So if the ImageFile is closed (by calling
    ImageFile::close), the API user must be ready for many of the API functions to
-   throw E57Exception(E57_ERROR_IMAGEFILE_NOT_OPEN). Secondly, regarding the
-   E57_ERROR_INTERNAL error, there is a lot of consistency checking in the
+   throw ::ErrorImageFileNotOpen. Secondly, regarding the
+   ErrorInternal error, there is a lot of consistency checking in the
    Reference Implementation, and there may be much more added. Even if some API
-   routines do not now throw E57_ERROR_INTERNAL, they could some time in the
+   routines do not now throw ::ErrorInternal, they could some time in the
    future, or in different implementations. So the right to throw
-   E57_ERROR_INTERNAL is reserved for every API function (except those that by
+   ::ErrorInternal is reserved for every API function (except those that by
    design can't throw E57Exceptions).
 
    It is strongly recommended that catch statements in user code that call API
@@ -102,8 +102,6 @@ namespace e57
    Exceptions other that E57Exception may be thrown by calls to API functions (e.g.
    std::bad_alloc). Production code will likely have catch handlers for these
    exceptions as well.
-
-   @see     HelloWorld.cpp example
    */
 
    //! @cond documentNonPublic   The following isn't part of the API, and isn't
@@ -123,7 +121,6 @@ namespace e57
    @post    No visible state is modified.
    @return  The string description of exception category.
    @throw   No E57Exceptions.
-   @see     E57ExceptionsFunctions.cpp example
    */
    const char *E57Exception::what() const noexcept
    {
@@ -145,7 +142,7 @@ namespace e57
    implementation was built with debugging enabled.
    @post    No visible state is modified.
    @throw   No E57Exceptions.
-   @see     E57ExceptionFunctions.cpp example, ErrorCode, HelloWorld.cpp example
+   @see     ErrorCode
    */
    void E57Exception::report( const char *reportingFileName, int reportingLineNumber, const char *reportingFunctionName,
                               std::ostream &os ) const noexcept
@@ -205,7 +202,6 @@ namespace e57
    @post    No visible state is modified.
    @return  The human-readable string that describes the context of the error.
    @throw   No E57Exceptions.
-   @see     E57ExceptionsFunctions.cpp example
    */
    std::string E57Exception::context() const noexcept
    {
@@ -221,7 +217,6 @@ namespace e57
    @post    No visible state is modified.
    @return  The name of source file where exception occurred, for debugging.
    @throw   No E57Exceptions.
-   @see     E57ExceptionsFunctions.cpp example
    */
    const char *E57Exception::sourceFileName() const noexcept
    {
@@ -307,154 +302,153 @@ namespace e57
       {
          // N.B.  *** When changing error strings here, remember to update the
          // Doxygen strings in E57Exception.h ****
-         case E57_SUCCESS:
-            return "operation was successful (E57_SUCCESS)";
-         case E57_ERROR_BAD_CV_HEADER:
+         case Success:
+            return "operation was successful (Success)";
+         case ErrorBadCVHeader:
             return "a CompressedVector binary header was bad "
-                   "(E57_ERROR_BAD_CV_HEADER)";
-         case E57_ERROR_BAD_CV_PACKET:
+                   "(ErrorBadCVHeader)";
+         case ErrorBadCVPacket:
             return "a CompressedVector binary packet was bad "
-                   "(E57_ERROR_BAD_CV_PACKET)";
-         case E57_ERROR_CHILD_INDEX_OUT_OF_BOUNDS:
+                   "(ErrorBadCVPacket)";
+         case ErrorChildIndexOutOfBounds:
             return "a numerical index identifying a child was out of bounds "
-                   "(E57_ERROR_CHILD_INDEX_OUT_OF_BOUNDS)";
-         case E57_ERROR_SET_TWICE:
+                   "(ErrorChildIndexOutOfBounds)";
+         case ErrorSetTwice:
             return "attempted to set an existing child element to a new value "
-                   "(E57_ERROR_SET_TWICE)";
-         case E57_ERROR_HOMOGENEOUS_VIOLATION:
+                   "(ErrorSetTwice)";
+         case ErrorHomogeneousViolation:
             return "attempted to add an E57 Element that would have made the "
                    "children of a "
                    "homogeneous Vector have different types "
                    "(E57_ERROR_HOMOGENEOUS_VIOLATION)";
-         case E57_ERROR_VALUE_NOT_REPRESENTABLE:
+         case ErrorValueNotRepresentable:
             return "a value could not be represented in the requested type "
-                   "(E57_ERROR_VALUE_NOT_REPRESENTABLE)";
-         case E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE:
+                   "(ErrorValueNotRepresentable)";
+         case ErrorScaledValueNotRepresentable:
             return "after scaling the result could not be represented in the "
                    "requested type "
-                   "(E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE)";
-         case E57_ERROR_REAL64_TOO_LARGE:
+                   "(ErrorScaledValueNotRepresentable)";
+         case ErrorReal64TooLarge:
             return "a 64 bit IEEE float was too large to store in a 32 bit IEEE "
                    "float "
-                   "(E57_ERROR_REAL64_TOO_LARGE)";
-         case E57_ERROR_EXPECTING_NUMERIC:
+                   "(ErrorReal64TooLarge)";
+         case ErrorExpectingNumeric:
             return "Expecting numeric representation in user's buffer, found "
                    "ustring "
-                   "(E57_ERROR_EXPECTING_NUMERIC)";
-         case E57_ERROR_EXPECTING_USTRING:
+                   "(ErrorExpectingNumeric)";
+         case ErrorExpectingUString:
             return "Expecting string representation in user's buffer, found "
                    "numeric "
-                   "(E57_ERROR_EXPECTING_USTRING)";
-         case E57_ERROR_INTERNAL:
+                   "(ErrorExpectingUString)";
+         case ErrorInternal:
             return "An unrecoverable inconsistent internal state was detected "
-                   "(E57_ERROR_INTERNAL)";
-         case E57_ERROR_BAD_XML_FORMAT:
+                   "(ErrorInternal)";
+         case ErrorBadXMLFormat:
             return "E57 primitive not encoded in XML correctly "
-                   "(E57_ERROR_BAD_XML_FORMAT)";
-         case E57_ERROR_XML_PARSER:
-            return "XML not well formed (E57_ERROR_XML_PARSER)";
-         case E57_ERROR_BAD_API_ARGUMENT:
+                   "(ErrorBadXMLFormat)";
+         case ErrorXMLParser:
+            return "XML not well formed (ErrorXMLParser)";
+         case ErrorBadAPIArgument:
             return "bad API function argument provided by user "
-                   "(E57_ERROR_BAD_API_ARGUMENT)";
-         case E57_ERROR_FILE_IS_READ_ONLY:
-            return "can't modify read only file (E57_ERROR_FILE_IS_READ_ONLY)";
-         case E57_ERROR_BAD_CHECKSUM:
-            return "checksum mismatch, file is corrupted (E57_ERROR_BAD_CHECKSUM)";
-         case E57_ERROR_OPEN_FAILED:
-            return "open() failed (E57_ERROR_OPEN_FAILED)";
-         case E57_ERROR_CLOSE_FAILED:
-            return "close() failed (E57_ERROR_CLOSE_FAILED)";
-         case E57_ERROR_READ_FAILED:
-            return "read() failed (E57_ERROR_READ_FAILED)";
-         case E57_ERROR_WRITE_FAILED:
-            return "write() failed (E57_ERROR_WRITE_FAILED)";
-         case E57_ERROR_LSEEK_FAILED:
-            return "lseek() failed (E57_ERROR_LSEEK_FAILED)";
-         case E57_ERROR_PATH_UNDEFINED:
+                   "(ErrorBadAPIArgument)";
+         case ErrorFileReadOnly:
+            return "can't modify read only file (ErrorFileReadOnly)";
+         case ErrorBadChecksum:
+            return "checksum mismatch, file is corrupted (ErrorBadChecksum)";
+         case ErrorOpenFailed:
+            return "open() failed (ErrorOpenFailed)";
+         case ErrorCloseFailed:
+            return "close() failed (ErrorCloseFailed)";
+         case ErrorReadFailed:
+            return "read() failed (ErrorReadFailed)";
+         case ErrorWriteFailed:
+            return "write() failed (ErrorWriteFailed)";
+         case ErrorSeekFailed:
+            return "lseek() failed (ErrorSeekFailed)";
+         case ErrorPathUndefined:
             return "E57 element path well formed but not defined "
-                   "(E57_ERROR_PATH_UNDEFINED)";
-         case E57_ERROR_BAD_BUFFER:
-            return "bad SourceDestBuffer (E57_ERROR_BAD_BUFFER)";
-         case E57_ERROR_NO_BUFFER_FOR_ELEMENT:
+                   "(ErrorPathUndefined)";
+         case ErrorBadBuffer:
+            return "bad SourceDestBuffer (ErrorBadBuffer)";
+         case ErrorNoBufferForElement:
             return "no buffer specified for an element in CompressedVectorNode "
                    "during write "
-                   "(E57_ERROR_NO_BUFFER_FOR_ELEMENT)";
-         case E57_ERROR_BUFFER_SIZE_MISMATCH:
+                   "(ErrorNoBufferForElement)";
+         case ErrorBufferSizeMismatch:
             return "SourceDestBuffers not all same size "
-                   "(E57_ERROR_BUFFER_SIZE_MISMATCH)";
-         case E57_ERROR_BUFFER_DUPLICATE_PATHNAME:
+                   "(ErrorBufferSizeMismatch)";
+         case ErrorBufferDuplicatePathName:
             return "duplicate pathname in CompressedVectorNode read/write "
-                   "(E57_ERROR_BUFFER_DUPLICATE_PATHNAME)";
-         case E57_ERROR_BAD_FILE_SIGNATURE:
+                   "(ErrorBufferDuplicatePathName)";
+         case ErrorBadFileSignature:
             return "file signature not "
                    "ASTM-E57"
-                   " (E57_ERROR_BAD_FILE_SIGNATURE)";
-         case E57_ERROR_UNKNOWN_FILE_VERSION:
-            return "incompatible file version (E57_ERROR_UNKNOWN_FILE_VERSION)";
-         case E57_ERROR_BAD_FILE_LENGTH:
+                   " (ErrorBadFileSignature)";
+         case ErrorUnknownFileVersion:
+            return "incompatible file version (ErrorUnknownFileVersion)";
+         case ErrorBadFileLength:
             return "size in file header not same as actual "
-                   "(E57_ERROR_BAD_FILE_LENGTH)";
-         case E57_ERROR_XML_PARSER_INIT:
-            return "XML parser failed to initialize (E57_ERROR_XML_PARSER_INIT)";
-         case E57_ERROR_DUPLICATE_NAMESPACE_PREFIX:
+                   "(ErrorBadFileLength)";
+         case ErrorXMLParserInit:
+            return "XML parser failed to initialize (ErrorXMLParserInit)";
+         case ErrorDuplicateNamespacePrefix:
             return "namespace prefix already defined "
-                   "(E57_ERROR_DUPLICATE_NAMESPACE_PREFIX)";
-         case E57_ERROR_DUPLICATE_NAMESPACE_URI:
+                   "(ErrorDuplicateNamespacePrefix)";
+         case ErrorDuplicateNamespaceURI:
             return "namespace URI already defined "
-                   "(E57_ERROR_DUPLICATE_NAMESPACE_URI)";
-         case E57_ERROR_BAD_PROTOTYPE:
+                   "(ErrorDuplicateNamespaceURI)";
+         case ErrorBadPrototype:
             return "bad prototype in CompressedVectorNode "
-                   "(E57_ERROR_BAD_PROTOTYPE)";
-         case E57_ERROR_BAD_CODECS:
-            return "bad codecs in CompressedVectorNode (E57_ERROR_BAD_CODECS)";
-         case E57_ERROR_VALUE_OUT_OF_BOUNDS:
+                   "(ErrorBadPrototype)";
+         case ErrorBadCodecs:
+            return "bad codecs in CompressedVectorNode (ErrorBadCodecs)";
+         case ErrorValueOutOfBounds:
             return "element value out of min/max bounds "
-                   "(E57_ERROR_VALUE_OUT_OF_BOUNDS)";
-         case E57_ERROR_CONVERSION_REQUIRED:
+                   "(ErrorValueOutOfBounds)";
+         case ErrorConversionRequired:
             return "conversion required to assign element value, but not "
                    "requested "
-                   "(E57_ERROR_CONVERSION_REQUIRED)";
-         case E57_ERROR_BAD_PATH_NAME:
-            return "E57 path name is not well formed (E57_ERROR_BAD_PATH_NAME)";
-         case E57_ERROR_NOT_IMPLEMENTED:
-            return "functionality not implemented (E57_ERROR_NOT_IMPLEMENTED)";
-         case E57_ERROR_BAD_NODE_DOWNCAST:
+                   "(ErrorConversionRequired)";
+         case ErrorBadPathName:
+            return "E57 path name is not well formed (ErrorBadPathName)";
+         case ErrorNotImplemented:
+            return "functionality not implemented (ErrorNotImplemented)";
+         case ErrorBadNodeDowncast:
             return "bad downcast from Node to specific node type "
-                   "(E57_ERROR_BAD_NODE_DOWNCAST)";
-         case E57_ERROR_WRITER_NOT_OPEN:
+                   "(ErrorBadNodeDowncast)";
+         case ErrorWriterNotOpen:
             return "CompressedVectorWriter is no longer open "
-                   "(E57_ERROR_WRITER_NOT_OPEN)";
-         case E57_ERROR_READER_NOT_OPEN:
+                   "(ErrorWriterNotOpen)";
+         case ErrorReaderNotOpen:
             return "CompressedVectorReader is no longer open "
-                   "(E57_ERROR_READER_NOT_OPEN)";
-         case E57_ERROR_NODE_UNATTACHED:
+                   "(ErrorReaderNotOpen)";
+         case ErrorNodeUnattached:
             return "node is not yet attached to tree of ImageFile "
-                   "(E57_ERROR_NODE_UNATTACHED)";
-         case E57_ERROR_ALREADY_HAS_PARENT:
-            return "node already has a parent (E57_ERROR_ALREADY_HAS_PARENT)";
-         case E57_ERROR_DIFFERENT_DEST_IMAGEFILE:
+                   "(ErrorNodeUnattached)";
+         case ErrorAlreadyHasParent:
+            return "node already has a parent (ErrorAlreadyHasParent)";
+         case ErrorDifferentDestImageFile:
             return "nodes were constructed with different destImageFiles "
-                   "(E57_ERROR_DIFFERENT_DEST_IMAGEFILE)";
-         case E57_ERROR_IMAGEFILE_NOT_OPEN:
+                   "(ErrorDifferentDestImageFile)";
+         case ErrorImageFileNotOpen:
             return "destImageFile is no longer open "
-                   "(E57_ERROR_IMAGEFILE_NOT_OPEN)";
-         case E57_ERROR_BUFFERS_NOT_COMPATIBLE:
+                   "(ErrorImageFileNotOpen)";
+         case ErrorBuffersNotCompatible:
             return "SourceDestBuffers not compatible with previously given ones "
-                   "(E57_ERROR_BUFFERS_NOT_COMPATIBLE)";
-         case E57_ERROR_TOO_MANY_WRITERS:
+                   "(ErrorBuffersNotCompatible)";
+         case ErrorTooManyWriters:
             return "too many open CompressedVectorWriters of an ImageFile "
-                   "(E57_ERROR_TOO_MANY_WRITERS)";
-         case E57_ERROR_TOO_MANY_READERS:
+                   "(ErrorTooManyWriters)";
+         case ErrorTooManyReaders:
             return "too many open CompressedVectorReaders of an ImageFile "
-                   "(E57_ERROR_TOO_MANY_READERS)";
-         case E57_ERROR_BAD_CONFIGURATION:
-            return "bad configuration string (E57_ERROR_BAD_CONFIGURATION)";
-         case E57_ERROR_INVARIANCE_VIOLATION:
+                   "(ErrorTooManyReaders)";
+         case ErrorBadConfiguration:
+            return "bad configuration string (ErrorBadConfiguration)";
+         case ErrorInvarianceViolation:
             return "class invariance constraint violation in debug mode "
-                   "(E57_ERROR_INVARIANCE_VIOLATION)";
+                   "(ErrorInvarianceViolation)";
          default:
             return "unknown error (" + std::to_string( ecode ) + ")";
       }
    }
-
 }

--- a/src/E57SimpleData.cpp
+++ b/src/E57SimpleData.cpp
@@ -18,7 +18,7 @@ namespace e57
    SphericalBounds::SphericalBounds()
    {
       rangeMinimum = 0.;
-      rangeMaximum = E57_DOUBLE_MAX;
+      rangeMaximum = DOUBLE_MAX;
       azimuthStart = -M_PI;
       azimuthEnd = M_PI;
 
@@ -35,18 +35,18 @@ namespace e57
 
       if ( cPointCount < 1 )
       {
-         throw E57_EXCEPTION2( E57_ERROR_VALUE_OUT_OF_BOUNDS, "pointCount=" + toString( cPointCount ) + " minimum=1" );
+         throw E57_EXCEPTION2( ErrorValueOutOfBounds, "pointCount=" + toString( cPointCount ) + " minimum=1" );
       }
 
       // We need to adjust min/max for floats.
       if ( std::is_same<COORDTYPE, float>::value )
       {
-         data3D.pointFields.pointRangeMinimum = E57_FLOAT_MIN;
-         data3D.pointFields.pointRangeMaximum = E57_FLOAT_MAX;
-         data3D.pointFields.angleMinimum = E57_FLOAT_MIN;
-         data3D.pointFields.angleMaximum = E57_FLOAT_MAX;
-         data3D.pointFields.timeMinimum = E57_FLOAT_MIN;
-         data3D.pointFields.timeMaximum = E57_FLOAT_MAX;
+         data3D.pointFields.pointRangeMinimum = FLOAT_MIN;
+         data3D.pointFields.pointRangeMaximum = FLOAT_MAX;
+         data3D.pointFields.angleMinimum = FLOAT_MIN;
+         data3D.pointFields.angleMaximum = FLOAT_MAX;
+         data3D.pointFields.timeMinimum = FLOAT_MIN;
+         data3D.pointFields.timeMaximum = FLOAT_MAX;
       }
 
       if ( data3D.pointFields.cartesianXField )

--- a/src/E57SimpleWriter.cpp
+++ b/src/E57SimpleWriter.cpp
@@ -31,7 +31,7 @@
 #include "E57SimpleWriter.h"
 #include "WriterImpl.h"
 
-namespace e57
+namespace
 {
    /// Fill in missing min/max data in the Data3D header for the following:
    ///   - cartesian points
@@ -39,7 +39,7 @@ namespace e57
    ///   - intensity
    ///   - time stamps
    template <typename COORDTYPE>
-   static void _fillMinMaxData( Data3D &ioData3DHeader, const Data3DPointsData_t<COORDTYPE> &inBuffers )
+   static void _fillMinMaxData( e57::Data3D &ioData3DHeader, const e57::Data3DPointsData_t<COORDTYPE> &inBuffers )
    {
       static_assert( std::is_floating_point<COORDTYPE>::value, "Floating point type required." );
 
@@ -73,7 +73,8 @@ namespace e57
       float intensityMinimum = std::numeric_limits<float>::max();
       float intensityMaximum = std::numeric_limits<float>::lowest();
 
-      const bool writeIntensity = pointFields.intensityField && ( ioData3DHeader.intensityLimits == IntensityLimits{} );
+      const bool writeIntensity =
+         pointFields.intensityField && ( ioData3DHeader.intensityLimits == e57::IntensityLimits{} );
 
       // IF we are using scaled ints for timestamps
       // AND we haven't set either min or max
@@ -153,9 +154,12 @@ namespace e57
          pointFields.timeMaximum = timeMaximum;
       }
    }
-   template void _fillMinMaxData( Data3D &ioData3DHeader, const Data3DPointsData &inBuffers );
-   template void _fillMinMaxData( Data3D &ioData3DHeader, const Data3DPointsData_d &inBuffers );
+   template void _fillMinMaxData( e57::Data3D &ioData3DHeader, const e57::Data3DPointsData &inBuffers );
+   template void _fillMinMaxData( e57::Data3D &ioData3DHeader, const e57::Data3DPointsData_d &inBuffers );
+}
 
+namespace e57
+{
    Writer::Writer( const ustring &filePath, const WriterOptions &options ) :
       impl_( new WriterImpl( filePath, options ) )
    {

--- a/src/E57XmlParser.cpp
+++ b/src/E57XmlParser.cpp
@@ -249,15 +249,14 @@ void E57XmlParser::init()
    catch ( const XMLException &ex )
    {
       /// Turn parser exception into E57Exception
-      throw E57_EXCEPTION2( E57_ERROR_XML_PARSER_INIT,
-                            "parserMessage=" + ustring( XMLString::transcode( ex.getMessage() ) ) );
+      throw E57_EXCEPTION2( ErrorXMLParserInit, "parserMessage=" + ustring( XMLString::transcode( ex.getMessage() ) ) );
    }
 
    xmlReader = XMLReaderFactory::createXMLReader(); //??? auto_ptr?
 
    if ( xmlReader == nullptr )
    {
-      throw E57_EXCEPTION2( E57_ERROR_XML_PARSER_INIT, "could not create the xml reader" );
+      throw E57_EXCEPTION2( ErrorXMLParserInit, "could not create the xml reader" );
    }
 
    //??? check these are right
@@ -309,7 +308,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       std::cout << "got a Integer" << std::endl;
 #endif
       //??? check validity of numeric strings
-      pi.nodeType = E57_INTEGER;
+      pi.nodeType = TypeInteger;
 
       if ( isAttributeDefined( attributes, att_minimum ) )
       {
@@ -320,7 +319,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       else
       {
          /// Not defined defined in XML, so defaults to E57_INT64_MIN
-         pi.minimum = E57_INT64_MIN;
+         pi.minimum = INT64_MIN;
       }
 
       if ( isAttributeDefined( attributes, att_maximum ) )
@@ -332,7 +331,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       else
       {
          /// Not defined defined in XML, so defaults to E57_INT64_MAX
-         pi.maximum = E57_INT64_MAX;
+         pi.maximum = INT64_MAX;
       }
 
       /// Push info so far onto stack
@@ -343,7 +342,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
 #ifdef E57_MAX_VERBOSE
       std::cout << "got a ScaledInteger" << std::endl;
 #endif
-      pi.nodeType = E57_SCALED_INTEGER;
+      pi.nodeType = TypeScaledInteger;
 
       //??? check validity of numeric strings
       if ( isAttributeDefined( attributes, att_minimum ) )
@@ -355,7 +354,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       else
       {
          /// Not defined defined in XML, so defaults to E57_INT64_MIN
-         pi.minimum = E57_INT64_MIN;
+         pi.minimum = INT64_MIN;
       }
 
       if ( isAttributeDefined( attributes, att_maximum ) )
@@ -367,7 +366,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       else
       {
          /// Not defined defined in XML, so defaults to E57_INT64_MAX
-         pi.maximum = E57_INT64_MAX;
+         pi.maximum = INT64_MAX;
       }
 
       if ( isAttributeDefined( attributes, att_scale ) )
@@ -400,31 +399,31 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
 #ifdef E57_MAX_VERBOSE
       std::cout << "got a Float" << std::endl;
 #endif
-      pi.nodeType = E57_FLOAT;
+      pi.nodeType = TypeFloat;
 
       if ( isAttributeDefined( attributes, att_precision ) )
       {
          ustring precision_str = lookupAttribute( attributes, att_precision );
          if ( precision_str == "single" )
          {
-            pi.precision = E57_SINGLE;
+            pi.precision = PrecisionSingle;
          }
          else if ( precision_str == "double" )
          {
-            pi.precision = E57_DOUBLE;
+            pi.precision = PrecisionDouble;
          }
          else
          {
-            throw E57_EXCEPTION2( E57_ERROR_BAD_XML_FORMAT,
-                                  "precisionString=" + precision_str + " fileName=" + imf_->fileName() +
-                                     " uri=" + toUString( uri ) + " localName=" + toUString( localName ) +
-                                     " qName=" + toUString( qName ) );
+            throw E57_EXCEPTION2( ErrorBadXMLFormat, "precisionString=" + precision_str +
+                                                        " fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
+                                                        " localName=" + toUString( localName ) +
+                                                        " qName=" + toUString( qName ) );
          }
       }
       else
       {
          /// Not defined defined in XML, so defaults to double
-         pi.precision = E57_DOUBLE;
+         pi.precision = PrecisionDouble;
       }
 
       if ( isAttributeDefined( attributes, att_minimum ) )
@@ -436,13 +435,13 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       {
          /// Not defined defined in XML, so defaults to E57_FLOAT_MIN or
          /// E57_DOUBLE_MIN
-         if ( pi.precision == E57_SINGLE )
+         if ( pi.precision == PrecisionSingle )
          {
-            pi.floatMinimum = E57_FLOAT_MIN;
+            pi.floatMinimum = FLOAT_MIN;
          }
          else
          {
-            pi.floatMinimum = E57_DOUBLE_MIN;
+            pi.floatMinimum = DOUBLE_MIN;
          }
       }
 
@@ -454,13 +453,13 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       else
       {
          /// Not defined defined in XML, so defaults to FLOAT_MAX or DOUBLE_MAX
-         if ( pi.precision == E57_SINGLE )
+         if ( pi.precision == PrecisionSingle )
          {
-            pi.floatMaximum = E57_FLOAT_MAX;
+            pi.floatMaximum = FLOAT_MAX;
          }
          else
          {
-            pi.floatMaximum = E57_DOUBLE_MAX;
+            pi.floatMaximum = DOUBLE_MAX;
          }
       }
 
@@ -472,7 +471,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
 #ifdef E57_MAX_VERBOSE
       std::cout << "got a String" << std::endl;
 #endif
-      pi.nodeType = E57_STRING;
+      pi.nodeType = TypeString;
 
       /// Push info so far onto stack
       stack_.push( pi );
@@ -482,7 +481,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
 #ifdef E57_MAX_VERBOSE
       std::cout << "got a Blob" << std::endl;
 #endif
-      pi.nodeType = E57_BLOB;
+      pi.nodeType = TypeBlob;
 
       //??? check validity of numeric strings
 
@@ -504,7 +503,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
 #ifdef E57_MAX_VERBOSE
       std::cout << "got a Structure" << std::endl;
 #endif
-      pi.nodeType = E57_STRUCTURE;
+      pi.nodeType = TypeStructure;
 
       /// Read name space decls, if e57Root element
       if ( toUString( localName ) == "e57Root" )
@@ -538,9 +537,9 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
          /// If didn't declare a default namespace, have error
          if ( !gotDefault )
          {
-            throw E57_EXCEPTION2( E57_ERROR_BAD_XML_FORMAT,
-                                  "fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
-                                     " localName=" + toUString( localName ) + " qName=" + toUString( qName ) );
+            throw E57_EXCEPTION2( ErrorBadXMLFormat, "fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
+                                                        " localName=" + toUString( localName ) +
+                                                        " qName=" + toUString( qName ) );
          }
       }
 
@@ -563,7 +562,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
 #ifdef E57_MAX_VERBOSE
       std::cout << "got a Vector" << std::endl;
 #endif
-      pi.nodeType = E57_VECTOR;
+      pi.nodeType = TypeVector;
 
       if ( isAttributeDefined( attributes, att_allowHeterogeneousChildren ) )
       {
@@ -581,10 +580,10 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
          }
          else
          {
-            throw E57_EXCEPTION2( E57_ERROR_BAD_XML_FORMAT,
-                                  "allowHeterogeneousChildren=" + toString( i64 ) + "fileName=" + imf_->fileName() +
-                                     " uri=" + toUString( uri ) + " localName=" + toUString( localName ) +
-                                     " qName=" + toUString( qName ) );
+            throw E57_EXCEPTION2( ErrorBadXMLFormat, "allowHeterogeneousChildren=" + toString( i64 ) +
+                                                        "fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
+                                                        " localName=" + toUString( localName ) +
+                                                        " qName=" + toUString( qName ) );
          }
       }
       else
@@ -605,7 +604,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
 #ifdef E57_MAX_VERBOSE
       std::cout << "got a CompressedVector" << std::endl;
 #endif
-      pi.nodeType = E57_COMPRESSED_VECTOR;
+      pi.nodeType = TypeCompressedVector;
 
       /// fileOffset is required to be defined
       ustring fileOffset_str = lookupAttribute( attributes, att_fileOffset );
@@ -629,9 +628,9 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
    }
    else
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_XML_FORMAT,
-                            "nodeType=" + node_type + " fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
-                               " localName=" + toUString( localName ) + " qName=" + toUString( qName ) );
+      throw E57_EXCEPTION2( ErrorBadXMLFormat, "nodeType=" + node_type + " fileName=" + imf_->fileName() +
+                                                  " uri=" + toUString( uri ) + " localName=" + toUString( localName ) +
+                                                  " qName=" + toUString( qName ) );
    }
 #ifdef E57_MAX_VERBOSE
    pi.dump( 4 );
@@ -656,18 +655,18 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
 
    switch ( pi.nodeType )
    {
-      case E57_STRUCTURE:
-      case E57_VECTOR:
+      case TypeStructure:
+      case TypeVector:
          current_ni = pi.container_ni;
          break;
-      case E57_COMPRESSED_VECTOR:
+      case TypeCompressedVector:
       {
          /// Verify that both prototype and codecs child elements were defined
          /// ???
          current_ni = pi.container_ni;
       }
       break;
-      case E57_INTEGER:
+      case TypeInteger:
       {
          /// Convert child text (if any) to value, else default to 0.0
          int64_t intValue;
@@ -683,7 +682,7 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
          current_ni = i_ni;
       }
       break;
-      case E57_SCALED_INTEGER:
+      case TypeScaledInteger:
       {
          /// Convert child text (if any) to value, else default to 0.0
          int64_t intValue;
@@ -700,7 +699,7 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
          current_ni = si_ni;
       }
       break;
-      case E57_FLOAT:
+      case TypeFloat:
       {
          /// Convert child text (if any) to value, else default to 0.0
          double floatValue;
@@ -717,23 +716,22 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
          current_ni = f_ni;
       }
       break;
-      case E57_STRING:
+      case TypeString:
       {
          std::shared_ptr<StringNodeImpl> s_ni( new StringNodeImpl( imf_, pi.childText ) );
          current_ni = s_ni;
       }
       break;
-      case E57_BLOB:
+      case TypeBlob:
       {
          std::shared_ptr<BlobNodeImpl> b_ni( new BlobNodeImpl( imf_, pi.fileOffset, pi.length ) );
          current_ni = b_ni;
       }
       break;
       default:
-         throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "nodeType=" + toString( pi.nodeType ) +
-                                                      " fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
-                                                      " localName=" + toUString( localName ) +
-                                                      " qName=" + toUString( qName ) );
+         throw E57_EXCEPTION2( ErrorInternal, "nodeType=" + toString( pi.nodeType ) + " fileName=" + imf_->fileName() +
+                                                 " uri=" + toUString( uri ) + " localName=" + toUString( localName ) +
+                                                 " qName=" + toUString( qName ) );
    }
 #ifdef E57_MAX_VERBOSE
    current_ni->dump( 4 );
@@ -743,12 +741,12 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
    if ( stack_.empty() )
    {
       /// Top level should be Structure
-      if ( current_ni->type() != E57_STRUCTURE )
+      if ( current_ni->type() != TypeStructure )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_XML_FORMAT,
-                               "currentType=" + toString( current_ni->type() ) + " fileName=" + imf_->fileName() +
-                                  " uri=" + toUString( uri ) + " localName=" + toUString( localName ) +
-                                  " qName=" + toUString( qName ) );
+         throw E57_EXCEPTION2( ErrorBadXMLFormat, "currentType=" + toString( current_ni->type() ) +
+                                                     " fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
+                                                     " localName=" + toUString( localName ) +
+                                                     " qName=" + toUString( qName ) );
       }
       imf_->root_ = std::static_pointer_cast<StructureNodeImpl>( current_ni );
       return;
@@ -760,15 +758,15 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
 
    if ( !parent_ni )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_XML_FORMAT, "fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
-                                                         " localName=" + toUString( localName ) +
-                                                         " qName=" + toUString( qName ) );
+      throw E57_EXCEPTION2( ErrorBadXMLFormat, "fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
+                                                  " localName=" + toUString( localName ) +
+                                                  " qName=" + toUString( qName ) );
    }
 
    /// Add current node into parent at top of stack
    switch ( parent_ni->type() )
    {
-      case E57_STRUCTURE:
+      case TypeStructure:
       {
          std::shared_ptr<StructureNodeImpl> struct_ni = std::static_pointer_cast<StructureNodeImpl>( parent_ni );
 
@@ -776,7 +774,7 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
          struct_ni->set( toUString( qName ), current_ni );
       }
       break;
-      case E57_VECTOR:
+      case TypeVector:
       {
          std::shared_ptr<VectorNodeImpl> vector_ni = std::static_pointer_cast<VectorNodeImpl>( parent_ni );
 
@@ -784,7 +782,7 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
          vector_ni->append( current_ni );
       }
       break;
-      case E57_COMPRESSED_VECTOR:
+      case TypeCompressedVector:
       {
          std::shared_ptr<CompressedVectorNodeImpl> cv_ni =
             std::static_pointer_cast<CompressedVectorNodeImpl>( parent_ni );
@@ -797,9 +795,9 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
          }
          else if ( uQName == "codecs" )
          {
-            if ( current_ni->type() != E57_VECTOR )
+            if ( current_ni->type() != TypeVector )
             {
-               throw E57_EXCEPTION2( E57_ERROR_BAD_XML_FORMAT,
+               throw E57_EXCEPTION2( ErrorBadXMLFormat,
                                      "currentType=" + toString( current_ni->type() ) + " fileName=" + imf_->fileName() +
                                         " uri=" + toUString( uri ) + " localName=" + toUString( localName ) +
                                         " qName=" + toUString( qName ) );
@@ -809,7 +807,7 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
             /// Check VectorNode is hetero
             if ( !vi->allowHeteroChildren() )
             {
-               throw E57_EXCEPTION2( E57_ERROR_BAD_XML_FORMAT,
+               throw E57_EXCEPTION2( ErrorBadXMLFormat,
                                      "currentType=" + toString( current_ni->type() ) + " fileName=" + imf_->fileName() +
                                         " uri=" + toUString( uri ) + " localName=" + toUString( localName ) +
                                         " qName=" + toUString( qName ) );
@@ -821,18 +819,18 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
          {
             /// Found unknown XML child element of CompressedVector, not
             /// prototype or codecs
-            throw E57_EXCEPTION2( E57_ERROR_BAD_XML_FORMAT,
-                                  +"fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
-                                     " localName=" + toUString( localName ) + " qName=" + toUString( qName ) );
+            throw E57_EXCEPTION2( ErrorBadXMLFormat, +"fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
+                                                        " localName=" + toUString( localName ) +
+                                                        " qName=" + toUString( qName ) );
          }
       }
       break;
       default:
          /// Have bad XML nesting, parent should have been a container.
-         throw E57_EXCEPTION2( E57_ERROR_BAD_XML_FORMAT,
-                               "parentType=" + toString( parent_ni->type() ) + " fileName=" + imf_->fileName() +
-                                  " uri=" + toUString( uri ) + " localName=" + toUString( localName ) +
-                                  " qName=" + toUString( qName ) );
+         throw E57_EXCEPTION2( ErrorBadXMLFormat, "parentType=" + toString( parent_ni->type() ) +
+                                                     " fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
+                                                     " localName=" + toUString( localName ) +
+                                                     " qName=" + toUString( qName ) );
    }
 }
 
@@ -848,16 +846,16 @@ void E57XmlParser::characters( const XMLCh *const chars, const XMLSize_t length 
    /// Check if child text is allowed for current E57 element type
    switch ( pi.nodeType )
    {
-      case E57_STRUCTURE:
-      case E57_VECTOR:
-      case E57_COMPRESSED_VECTOR:
-      case E57_BLOB:
+      case TypeStructure:
+      case TypeVector:
+      case TypeCompressedVector:
+      case TypeBlob:
       {
          /// If characters aren't whitespace, have an error, else ignore
          ustring s = toUString( chars );
          if ( s.find_first_not_of( " \t\n\r" ) != std::string::npos )
          {
-            throw E57_EXCEPTION2( E57_ERROR_BAD_XML_FORMAT, "chars=" + toUString( chars ) );
+            throw E57_EXCEPTION2( ErrorBadXMLFormat, "chars=" + toUString( chars ) );
          }
       }
       break;
@@ -869,18 +867,18 @@ void E57XmlParser::characters( const XMLCh *const chars, const XMLSize_t length 
 
 void E57XmlParser::error( const SAXParseException &ex )
 {
-   throw E57_EXCEPTION2( E57_ERROR_XML_PARSER, "systemId=" + ustring( XMLString::transcode( ex.getSystemId() ) ) +
-                                                  " xmlLine=" + toString( ex.getLineNumber() ) +
-                                                  " xmlColumn=" + toString( ex.getColumnNumber() ) + " parserMessage=" +
-                                                  ustring( XMLString::transcode( ex.getMessage() ) ) );
+   throw E57_EXCEPTION2( ErrorXMLParser, "systemId=" + ustring( XMLString::transcode( ex.getSystemId() ) ) +
+                                            " xmlLine=" + toString( ex.getLineNumber() ) +
+                                            " xmlColumn=" + toString( ex.getColumnNumber() ) +
+                                            " parserMessage=" + ustring( XMLString::transcode( ex.getMessage() ) ) );
 }
 
 void E57XmlParser::fatalError( const SAXParseException &ex )
 {
-   throw E57_EXCEPTION2( E57_ERROR_XML_PARSER, "systemId=" + ustring( XMLString::transcode( ex.getSystemId() ) ) +
-                                                  " xmlLine=" + toString( ex.getLineNumber() ) +
-                                                  " xmlColumn=" + toString( ex.getColumnNumber() ) + " parserMessage=" +
-                                                  ustring( XMLString::transcode( ex.getMessage() ) ) );
+   throw E57_EXCEPTION2( ErrorXMLParser, "systemId=" + ustring( XMLString::transcode( ex.getSystemId() ) ) +
+                                            " xmlLine=" + toString( ex.getLineNumber() ) +
+                                            " xmlColumn=" + toString( ex.getColumnNumber() ) +
+                                            " parserMessage=" + ustring( XMLString::transcode( ex.getMessage() ) ) );
 }
 
 void E57XmlParser::warning( const SAXParseException &ex )
@@ -909,7 +907,7 @@ ustring E57XmlParser::lookupAttribute( const Attributes &attributes, const XMLCh
    XMLSize_t attr_index;
    if ( !attributes.getIndex( attribute_name, attr_index ) )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_XML_FORMAT, "attributeName=" + toUString( attribute_name ) );
+      throw E57_EXCEPTION2( ErrorBadXMLFormat, "attributeName=" + toUString( attribute_name ) );
    }
    return ( toUString( attributes.getValue( attr_index ) ) );
 }

--- a/src/E57XmlParser.h
+++ b/src/E57XmlParser.h
@@ -80,17 +80,17 @@ namespace e57
          /// Needed because not all info is available at one time to create the
          /// node.
          NodeType nodeType;               // used by all types
-         int64_t minimum;                 // used in E57_INTEGER, E57_SCALED_INTEGER
-         int64_t maximum;                 // used in E57_INTEGER, E57_SCALED_INTEGER
-         double scale;                    // used in E57_SCALED_INTEGER
-         double offset;                   // used in E57_SCALED_INTEGER
-         FloatPrecision precision;        // used in E57_FLOAT
-         double floatMinimum;             // used in E57_FLOAT
-         double floatMaximum;             // used in E57_FLOAT
-         int64_t fileOffset;              // used in E57_BLOB, E57_COMPRESSED_VECTOR
-         int64_t length;                  // used in E57_BLOB
-         bool allowHeterogeneousChildren; // used in E57_VECTOR
-         int64_t recordCount;             // used in E57_COMPRESSED_VECTOR
+         int64_t minimum;                 // used in Integer, ScaledInteger
+         int64_t maximum;                 // used in Integer, ScaledInteger
+         double scale;                    // used in ScaledInteger
+         double offset;                   // used in ScaledInteger
+         FloatPrecision precision;        // used in Float
+         double floatMinimum;             // used in Float
+         double floatMaximum;             // used in Float
+         int64_t fileOffset;              // used in Blob, CompressedVector
+         int64_t length;                  // used in Blob
+         bool allowHeterogeneousChildren; // used in Vector
+         int64_t recordCount;             // used in CompressedVector
          ustring childText;               // used by all types, accumulates all child text between tags
 
          /// Holds node for Structure, Vector, and CompressedVector so can append

--- a/src/FloatNode.cpp
+++ b/src/FloatNode.cpp
@@ -44,13 +44,13 @@ floating point value, and minimum/maximum bounds. The precision of the floating
 point value and attributes may be either single or double precision. Once the
 FloatNode value and attributes are set at creation, they may not be modified.
 
-If the precision option of the FloatNode is E57_SINGLE:
+If the precision option of the FloatNode is Single:
 The minimum attribute may be a number in the interval
 [-3.402823466e+38, 3.402823466e+38]. The maximum attribute may be a number in
 the interval [maximum, 3.402823466e+38]. The value may be a number in the
 interval [minimum, maximum].
 
-If the precision option of the FloatNode is E57_DOUBLE:
+If the precision option of the FloatNode is Double:
 The minimum attribute may be a number in the interval
 [-1.7976931348623158e+308, 1.7976931348623158e+308]. The maximum attribute may
 be a number in the interval [maximum, 1.7976931348623158e+308]. The value may be
@@ -75,14 +75,10 @@ invariant is violated:
 */
 
 /*!
-@brief   Create an E57 element for storing an double precision IEEE floating
-point number.
-@param   [in] destImageFile   The ImageFile where the new node will eventually
-be stored.
-@param   [in] value     The double precision IEEE floating point value of the
-element.
-@param   [in] precision The precision of IEEE floating point to use. May be
-E57_SINGLE or E57_DOUBLE.
+@brief   Create an E57 element for storing an double precision IEEE floating point number.
+@param   [in] destImageFile   The ImageFile where the new node will eventually be stored.
+@param   [in] value     The double precision IEEE floating point value of the element.
+@param   [in] precision The precision of IEEE floating point to use. May be ::PrecisionSingle or ::PrecisionDouble.
 @param   [in] minimum   The smallest value that the value may take.
 @param   [in] maximum   The largest value that the value may take.
 @details
@@ -96,8 +92,8 @@ predefined root of the ImageFile (gotten from ImageFile::root). It is not an
 error to fail to attach the FloatNode to the @a destImageFile. It is an error to
 attempt to attach the FloatNode to a different ImageFile.
 
-There is only one FloatNode constructor that handles both E57_SINGLE and
-E57_DOUBLE precision cases. If @a precision = E57_SINGLE, then the object will
+There is only one FloatNode constructor that handles both ::PrecisionSingle and
+::PrecisionDouble precision cases. If @a precision = ::PrecisionSingle, then the object will
 silently round the double precision @a value to the nearest representable single
 precision value. In this case, the lower bits will be lost, and if the value is
 outside the representable range of a single precision number, the exponent may
@@ -113,11 +109,11 @@ true).
 @pre     The @a destImageFile must have been opened in write mode (i.e.
 destImageFile.isWritable() must be true).
 @pre     minimum <= value <= maximum
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_FILE_IS_READ_ONLY
-@throw   ::E57_ERROR_VALUE_OUT_OF_BOUNDS
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorFileReadOnly
+@throw   ::ErrorValueOutOfBounds
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     FloatPrecision, FloatNode::value, Node, CompressedVectorNode, CompressedVectorNode::prototype
 */
 FloatNode::FloatNode( ImageFile destImageFile, double value, FloatPrecision precision, double minimum,
@@ -172,13 +168,13 @@ bool FloatNode::isAttached() const
 /*!
 @brief   Get IEEE floating point value stored.
 @details
-If precision is E57_SINGLE, the single precision value is returned as a double.
-If precision is E57_DOUBLE, the double precision value is returned as a double.
+If precision is ::PrecisionSingle, the single precision value is returned as a double. If precision is
+::PrecisionDouble, the double precision value is returned as a double.
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  The IEEE floating point value stored, represented as a double.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     FloatNode::minimum, FloatNode::maximum
 */
 double FloatNode::value() const
@@ -190,10 +186,9 @@ double FloatNode::value() const
 @brief   Get declared precision of the floating point number.
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
-@return  The declared precision of the floating point number, either
-::E57_SINGLE or ::E57_DOUBLE.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@return  The declared precision of the floating point number, either ::PrecisionSingle or ::PrecisionDouble.
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     FloatPrecision
 */
 FloatPrecision FloatNode::precision() const
@@ -204,14 +199,13 @@ FloatPrecision FloatNode::precision() const
 /*!
 @brief   Get the declared minimum that the value may take.
 @details
-If precision is E57_SINGLE, the single precision minimum is returned as a
-double. If precision is E57_DOUBLE, the double precision minimum is returned as
-a double.
+If precision is ::PrecisionSingle, the single precision minimum is returned as a double. If precision is
+::PrecisionDouble, the double precision minimum is returned as a double.
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  The declared minimum that the value may take.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     FloatNode::maximum, FloatNode::value
 */
 double FloatNode::minimum() const
@@ -222,14 +216,13 @@ double FloatNode::minimum() const
 /*!
 @brief   Get the declared maximum that the value may take.
 @details
-If precision is E57_SINGLE, the single precision maximum is returned as a
-double. If precision is E57_DOUBLE, the double precision maximum is returned as
-a double.
+If precision is ::PrecisionSingle, the single precision maximum is returned as a double. If precision is
+::PrecisionDouble, the double precision maximum is returned as a double.
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  The declared maximum that the value may take.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     FloatNode::minimum, FloatNode::value
 */
 double FloatNode::maximum() const
@@ -269,18 +262,18 @@ void FloatNode::checkInvariant( bool /*doRecurse*/, bool doUpcast )
       static_cast<Node>( *this ).checkInvariant( false, false );
    }
 
-   if ( precision() == E57_SINGLE )
+   if ( precision() == PrecisionSingle )
    {
-      if ( static_cast<float>( minimum() ) < E57_FLOAT_MIN || static_cast<float>( maximum() ) > E57_FLOAT_MAX )
+      if ( static_cast<float>( minimum() ) < FLOAT_MIN || static_cast<float>( maximum() ) > FLOAT_MAX )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
    }
 
    // If value is out of bounds
    if ( value() < minimum() || value() > maximum() )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 }
 // endExample FloatNode::checkInvariant
@@ -308,14 +301,14 @@ exception is thrown. In designs that need to avoid the exception, use
 Node::type() to determine the actual type of the @a n before downcasting. This
 function must be explicitly called (c++ compiler cannot insert it
 automatically).
-@throw   ::E57_ERROR_BAD_NODE_DOWNCAST
+@throw   ::ErrorBadNodeDowncast
 @see     Node::type(), FloatNode::operator Node()
 */
 FloatNode::FloatNode( const Node &n )
 {
-   if ( n.type() != E57_FLOAT )
+   if ( n.type() != TypeFloat )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_NODE_DOWNCAST, "nodeType=" + toString( n.type() ) );
+      throw E57_EXCEPTION2( ErrorBadNodeDowncast, "nodeType=" + toString( n.type() ) );
    }
 
    /// Set our shared_ptr to the downcast shared_ptr

--- a/src/FloatNodeImpl.cpp
+++ b/src/FloatNodeImpl.cpp
@@ -41,22 +41,22 @@ namespace e57
       /// Since this ctor also used to construct single precision, and defaults for
       /// minimum/maximum are for double precision, adjust bounds smaller if
       /// single.
-      if ( precision_ == E57_SINGLE )
+      if ( precision_ == PrecisionSingle )
       {
-         if ( minimum_ < E57_FLOAT_MIN )
+         if ( minimum_ < FLOAT_MIN )
          {
-            minimum_ = E57_FLOAT_MIN;
+            minimum_ = FLOAT_MIN;
          }
-         if ( maximum_ > E57_FLOAT_MAX )
+         if ( maximum_ > FLOAT_MAX )
          {
-            maximum_ = E57_FLOAT_MAX;
+            maximum_ = FLOAT_MAX;
          }
       }
 
       /// Enforce the given bounds on raw value
       if ( value < minimum || maximum < value )
       {
-         throw E57_EXCEPTION2( E57_ERROR_VALUE_OUT_OF_BOUNDS,
+         throw E57_EXCEPTION2( ErrorValueOutOfBounds,
                                "this->pathName=" + this->pathName() + " value=" + toString( value ) +
                                   " minimum=" + toString( minimum ) + " maximum=" + toString( maximum ) );
       }
@@ -67,7 +67,7 @@ namespace e57
       // don't checkImageFileOpen
 
       /// Same node type?
-      if ( ni->type() != E57_FLOAT )
+      if ( ni->type() != TypeFloat )
       {
          return ( false );
       }
@@ -140,7 +140,7 @@ namespace e57
       if ( pathNames.find( relativePathName( origin ) ) == pathNames.end() &&
            pathNames.find( pathName() ) == pathNames.end() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_NO_BUFFER_FOR_ELEMENT, "this->pathName=" + this->pathName() );
+         throw E57_EXCEPTION2( ErrorNoBufferForElement, "this->pathName=" + this->pathName() );
       }
    }
 
@@ -160,16 +160,16 @@ namespace e57
       }
 
       cf << space( indent ) << "<" << fieldName << " type=\"Float\"";
-      if ( precision_ == E57_SINGLE )
+      if ( precision_ == PrecisionSingle )
       {
          cf << " precision=\"single\"";
 
          /// Don't need to write if are default values
-         if ( minimum_ > E57_FLOAT_MIN )
+         if ( minimum_ > FLOAT_MIN )
          {
             cf << " minimum=\"" << static_cast<float>( minimum_ ) << "\"";
          }
-         if ( maximum_ < E57_FLOAT_MAX )
+         if ( maximum_ < FLOAT_MAX )
          {
             cf << " maximum=\"" << static_cast<float>( maximum_ ) << "\"";
          }
@@ -189,11 +189,11 @@ namespace e57
          /// Don't need to write precision="double", because that's the default
 
          /// Don't need to write if are default values
-         if ( minimum_ > E57_DOUBLE_MIN )
+         if ( minimum_ > DOUBLE_MIN )
          {
             cf << " minimum=\"" << minimum_ << "\"";
          }
-         if ( maximum_ < E57_DOUBLE_MAX )
+         if ( maximum_ < DOUBLE_MAX )
          {
             cf << " maximum=\"" << maximum_ << "\"";
          }
@@ -218,7 +218,7 @@ namespace e57
          << " (" << type() << ")" << std::endl;
       NodeImpl::dump( indent, os );
       os << space( indent ) << "precision:   ";
-      if ( precision() == E57_SINGLE )
+      if ( precision() == PrecisionSingle )
       {
          os << "single" << std::endl;
       }

--- a/src/FloatNodeImpl.h
+++ b/src/FloatNodeImpl.h
@@ -34,13 +34,13 @@ namespace e57
    {
    public:
       explicit FloatNodeImpl( ImageFileImplWeakPtr destImageFile, double value = 0,
-                              FloatPrecision precision = E57_DOUBLE, double minimum = E57_DOUBLE_MIN,
-                              double maximum = E57_DOUBLE_MAX );
+                              FloatPrecision precision = PrecisionDouble, double minimum = DOUBLE_MIN,
+                              double maximum = DOUBLE_MAX );
       ~FloatNodeImpl() override = default;
 
       NodeType type() const override
       {
-         return E57_FLOAT;
+         return TypeFloat;
       }
 
       bool isTypeEquivalent( NodeImplSharedPtr ni ) override;

--- a/src/ImageFile.cpp
+++ b/src/ImageFile.cpp
@@ -151,20 +151,20 @@ existing E57 data file.
 
 @post    Resulting ImageFile is in @c open state if constructor succeeds (no
 exception thrown).
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_OPEN_FAILED
-@throw   ::E57_ERROR_LSEEK_FAILED
-@throw   ::E57_ERROR_READ_FAILED
-@throw   ::E57_ERROR_WRITE_FAILED
-@throw   ::E57_ERROR_BAD_CHECKSUM
-@throw   ::E57_ERROR_BAD_FILE_SIGNATURE
-@throw   ::E57_ERROR_UNKNOWN_FILE_VERSION
-@throw   ::E57_ERROR_BAD_FILE_LENGTH
-@throw   ::E57_ERROR_XML_PARSER_INIT
-@throw   ::E57_ERROR_XML_PARSER
-@throw   ::E57_ERROR_BAD_XML_FORMAT
-@throw   ::E57_ERROR_BAD_CONFIGURATION
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorOpenFailed
+@throw   ::ErrorSeekFailed
+@throw   ::ErrorReadFailed
+@throw   ::ErrorWriteFailed
+@throw   ::ErrorBadChecksum
+@throw   ::ErrorBadFileSignature
+@throw   ::ErrorUnknownFileVersion
+@throw   ::ErrorBadFileLength
+@throw   ::ErrorXMLParserInit
+@throw   ::ErrorXMLParser
+@throw   ::ErrorBadXMLFormat
+@throw   ::ErrorBadConfiguration
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     IntegerNode, ScaledIntegerNode, FloatNode,
 StringNode, BlobNode, StructureNode, VectorNode, CompressedVectorNode,
 E57Exception, E57Utilities::E57Utilities
@@ -188,8 +188,8 @@ ImageFile::ImageFile( const char *input, const uint64_t size, ReadChecksumPolicy
 StructureNode. The root node is empty in a newly created write mode ImageFile.
 @pre     This ImageFile must be open (i.e. isOpen()).
 @return  A smart StructureNode handle referencing the underlying object.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     StructureNode.
 */
 StructureNode ImageFile::root() const
@@ -220,12 +220,12 @@ destroyed.
 
 It is not an error if ImageFile is already closed.
 @post    ImageFile is in @c closed state.
-@throw   ::E57_ERROR_LSEEK_FAILED
-@throw   ::E57_ERROR_READ_FAILED
-@throw   ::E57_ERROR_WRITE_FAILED
-@throw   ::E57_ERROR_CLOSE_FAILED
-@throw   ::E57_ERROR_BAD_CHECKSUM
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorSeekFailed
+@throw   ::ErrorReadFailed
+@throw   ::ErrorWriteFailed
+@throw   ::ErrorCloseFailed
+@throw   ::ErrorBadChecksum
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ImageFile::cancel, ImageFile::isOpen
 */
 void ImageFile::close()
@@ -297,8 +297,8 @@ CompressedVectorNode::writer function.
 @post    No visible state is modified.
 @return  The current number of open CompressedVectorWriter objects writing to
 ImageFile.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorNode::writer, CompressedVectorWriter
 */
 int ImageFile::writerCount() const
@@ -317,8 +317,8 @@ CompressedVectorNode::reader function.
 @post    No visible state is modified.
 @return  The current number of open CompressedVectorReader objects reading from
 ImageFile.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVectorNode::reader, CompressedVectorReader
 */
 int ImageFile::readerCount() const
@@ -360,12 +360,12 @@ namespaces.
 @pre     ImageFile must have been opened in write mode (i.e. isWritable()).
 @pre     prefix != ""
 @pre     uri != ""
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_FILE_IS_READ_ONLY
-@throw   ::E57_ERROR_DUPLICATE_NAMESPACE_PREFIX
-@throw   ::E57_ERROR_DUPLICATE_NAMESPACE_URI
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorFileReadOnly
+@throw   ::ErrorDuplicateNamespacePrefix
+@throw   ::ErrorDuplicateNamespaceURI
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ImageFile::extensionsCount, ImageFile::extensionsLookupPrefix, ImageFile::extensionsLookupUri
 */
 void ImageFile::extensionsAdd( const ustring &prefix, const ustring &uri )
@@ -382,9 +382,9 @@ contains an illegal character combination for E57 namespace prefixes.
 @pre     This ImageFile must be open (i.e. isOpen()).
 @post    No visible state is modified.
 @return  true if prefix is declared in the ImageFile.
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ImageFile::extensionsLookupUri
 */
 bool ImageFile::extensionsLookupPrefix( const ustring &prefix ) const
@@ -407,9 +407,9 @@ is not an error if @a prefix is well-formed, but not defined in the ImageFile
 @pre     This ImageFile must be open (i.e. isOpen()).
 @post    No visible state is modified.
 @return  true if prefix is declared in the ImageFile.
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ImageFile::extensionsLookupUri
 */
 bool ImageFile::extensionsLookupPrefix( const ustring &prefix, ustring &uri ) const
@@ -432,9 +432,9 @@ false).
 @pre     uri != ""
 @post    No visible state is modified.
 @return  true if URI is declared in the ImageFile.
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ImageFile::extensionsLookupPrefix
 */
 bool ImageFile::extensionsLookupUri( const ustring &uri, ustring &prefix ) const
@@ -449,8 +449,8 @@ The default E57 namespace does not count as an extension.
 @pre     This ImageFile must be open (i.e. isOpen()).
 @post    No visible state is modified.
 @return  The number of E57 extensions defined in the ImageFile.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ImageFile::extensionsPrefix, ImageFile::extensionsUri
 */
 size_t ImageFile::extensionsCount() const
@@ -469,9 +469,9 @@ order. The default E57 namespace is not counted as an extension.
 @pre     0 <= index < extensionsCount()
 @post    No visible state is modified.
 @return  The E57 extension prefix at the given index.
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ImageFile::extensionsCount, ImageFile::extensionsUri
 */
 ustring ImageFile::extensionsPrefix( const size_t index ) const
@@ -490,9 +490,9 @@ default E57 namespace is not counted as an extension.
 @pre     0 <= index < extensionsCount()
 @post    No visible state is modified.
 @return  The E57 extension URI at the given index.
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ImageFile::extensionsCount, ImageFile::extensionsPrefix
 */
 ustring ImageFile::extensionsUri( const size_t index ) const
@@ -528,8 +528,8 @@ where ID is a string whose first character is in {a-z,A-Z,_} followed by zero or
 more characters in {a-z,A-Z,_,0-9,-,.}. If in prefixed form, the prefix does not
 have to be declared in the ImageFile.
 @post    No visible state is modified.
-@throw   ::E57_ERROR_BAD_PATH_NAME
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadPathName
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ImageFile::isElementNameExtended
 */
 void ImageFile::elementNameParse( const ustring &elementName, ustring &prefix, ustring &localPart ) const
@@ -562,12 +562,12 @@ This function checks at least the assertions in the documented class invariant
 description (see class reference page for this object). Other internal
 invariants that are implementation-dependent may also be checked. If any
 invariant clause is violated, an E57Exception with errorCode of
-E57_ERROR_INVARIANCE_VIOLATION is thrown.
+ErrorInvarianceViolation is thrown.
 
 Checking the invariant recursively may be expensive if the tree is large, so
 should be used judiciously, in debug versions of the application.
 @post    No visible state is modified.
-@throw   ::E57_ERROR_INVARIANCE_VIOLATION or any other E57 ErrorCode
+@throw   ::ErrorInvarianceViolation or any other E57 ErrorCode
 @see     Node::checkInvariant
 */
 // beginExample ImageFile::checkInvariant
@@ -583,13 +583,13 @@ void ImageFile::checkInvariant( bool doRecurse ) const
    // root() node must be a root node
    if ( !root().isRoot() )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // Can't have empty fileName
    if ( fileName().empty() )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    int wCount = writerCount();
@@ -598,19 +598,19 @@ void ImageFile::checkInvariant( bool doRecurse ) const
    // Can't have negative number of readers
    if ( rCount < 0 )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // Can't have negative number of writers
    if ( wCount < 0 )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // Can't have more than one writer
    if ( 1 < wCount )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // If have writer
@@ -619,13 +619,13 @@ void ImageFile::checkInvariant( bool doRecurse ) const
       // Must be in write-mode
       if ( !isWritable() )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
 
       // Can't have any readers
       if ( rCount > 0 )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
    }
 
@@ -637,11 +637,11 @@ void ImageFile::checkInvariant( bool doRecurse ) const
       {
          if ( extensionsPrefix( i ) == extensionsPrefix( j ) )
          {
-            throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+            throw E57_EXCEPTION1( ErrorInvarianceViolation );
          }
          if ( extensionsUri( i ) == extensionsUri( j ) )
          {
-            throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+            throw E57_EXCEPTION1( ErrorInvarianceViolation );
          }
       }
    }
@@ -655,19 +655,19 @@ void ImageFile::checkInvariant( bool doRecurse ) const
       ustring uri;
       if ( !extensionsLookupPrefix( goodPrefix, uri ) )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
       if ( uri != goodUri )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
       if ( !extensionsLookupUri( goodUri, prefix ) )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
       if ( prefix != goodPrefix )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
    }
 

--- a/src/ImageFileImpl.cpp
+++ b/src/ImageFileImpl.cpp
@@ -102,7 +102,7 @@ namespace e57
 
       if ( !isWriter_ && ( mode != "r" ) )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_API_ARGUMENT, "mode=" + ustring( mode ) );
+         throw E57_EXCEPTION2( ErrorBadAPIArgument, "mode=" + ustring( mode ) );
       }
 
       file_ = nullptr;
@@ -256,9 +256,8 @@ namespace e57
 #ifdef E57_MAX_DEBUG
       if ( writerCount_ < 0 )
       {
-         throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "fileName=" + fileName_ +
-                                                      " writerCount=" + toString( writerCount_ ) +
-                                                      " readerCount=" + toString( readerCount_ ) );
+         throw E57_EXCEPTION2( ErrorInternal, "fileName=" + fileName_ + " writerCount=" + toString( writerCount_ ) +
+                                                 " readerCount=" + toString( readerCount_ ) );
       }
 #endif
    }
@@ -274,9 +273,8 @@ namespace e57
 #ifdef E57_MAX_DEBUG
       if ( readerCount_ < 0 )
       {
-         throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "fileName=" + fileName_ +
-                                                      " writerCount=" + toString( writerCount_ ) +
-                                                      " readerCount=" + toString( readerCount_ ) );
+         throw E57_EXCEPTION2( ErrorInternal, "fileName=" + fileName_ + " writerCount=" + toString( writerCount_ ) +
+                                                 " readerCount=" + toString( readerCount_ ) );
       }
 #endif
    }
@@ -447,12 +445,12 @@ namespace e57
 
       if ( extensionsLookupPrefix( prefix, dummy ) )
       {
-         throw E57_EXCEPTION2( E57_ERROR_DUPLICATE_NAMESPACE_PREFIX, "prefix=" + prefix + " uri=" + uri );
+         throw E57_EXCEPTION2( ErrorDuplicateNamespacePrefix, "prefix=" + prefix + " uri=" + uri );
       }
 
       if ( extensionsLookupUri( uri, dummy ) )
       {
-         throw E57_EXCEPTION2( E57_ERROR_DUPLICATE_NAMESPACE_URI, "prefix=" + prefix + " uri=" + uri );
+         throw E57_EXCEPTION2( ErrorDuplicateNamespaceURI, "prefix=" + prefix + " uri=" + uri );
          ;
       }
 
@@ -605,7 +603,7 @@ namespace e57
 
       if ( prefix.length() > 0 && !extensionsLookupPrefix( prefix, uri ) )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_PATH_NAME, "elementName=" + elementName + " prefix=" + prefix );
+         throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName + " prefix=" + prefix );
       }
    }
 
@@ -621,7 +619,7 @@ namespace e57
       /// Empty name is bad
       if ( len == 0 )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_PATH_NAME, "elementName=" + elementName );
+         throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName );
       }
 
       unsigned char c = elementName[0];
@@ -636,7 +634,7 @@ namespace e57
 
             if ( !( '0' <= c && c <= '9' ) )
             {
-               throw E57_EXCEPTION2( E57_ERROR_BAD_PATH_NAME, "elementName=" + elementName );
+               throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName );
             }
          }
 
@@ -648,7 +646,7 @@ namespace e57
       /// Don't allow ':' as first char.
       if ( c < 128 && !( ( 'a' <= c && c <= 'z' ) || ( 'A' <= c && c <= 'Z' ) || c == '_' ) )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_PATH_NAME, "elementName=" + elementName );
+         throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName );
       }
 
       /// If each following char is ASCII (<128), check for legality
@@ -660,7 +658,7 @@ namespace e57
          if ( c < 128 && !( ( 'a' <= c && c <= 'z' ) || ( 'A' <= c && c <= 'Z' ) || c == '_' || c == ':' ||
                             ( '0' <= c && c <= '9' ) || c == '-' || c == '.' ) )
          {
-            throw E57_EXCEPTION2( E57_ERROR_BAD_PATH_NAME, "elementName=" + elementName );
+            throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName );
          }
       }
 
@@ -672,7 +670,7 @@ namespace e57
          /// Check doesn't have two colons
          if ( elementName.find_first_of( ':', found + 1 ) != std::string::npos )
          {
-            throw E57_EXCEPTION2( E57_ERROR_BAD_PATH_NAME, "elementName=" + elementName );
+            throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName );
          }
 
          /// Split element name at the colon
@@ -682,7 +680,7 @@ namespace e57
 
          if ( prefix.length() == 0 || localPart.length() == 0 )
          {
-            throw E57_EXCEPTION2( E57_ERROR_BAD_PATH_NAME,
+            throw E57_EXCEPTION2( ErrorBadPathName,
                                   "elementName=" + elementName + " prefix=" + prefix + " localPart=" + localPart );
          }
       }
@@ -743,7 +741,7 @@ namespace e57
 
          if ( !isElementNameLegal( elementName ) )
          {
-            throw E57_EXCEPTION2( E57_ERROR_BAD_PATH_NAME, "pathName=" + pathName + " elementName=" + elementName );
+            throw E57_EXCEPTION2( ErrorBadPathName, "pathName=" + pathName + " elementName=" + elementName );
          }
 
          /// Add to list
@@ -769,7 +767,7 @@ namespace e57
       /// Empty relative path is not allowed
       if ( isRelative && fields.empty() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_PATH_NAME, "pathName=" + pathName );
+         throw E57_EXCEPTION2( ErrorBadPathName, "pathName=" + pathName );
       }
 
 #ifdef E57_MAX_VERBOSE
@@ -821,16 +819,15 @@ namespace e57
       /// Check signature
       if ( strncmp( header.fileSignature, "ASTM-E57", 8 ) != 0 )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_FILE_SIGNATURE, "fileName=" + file->fileName() );
+         throw E57_EXCEPTION2( ErrorBadFileSignature, "fileName=" + file->fileName() );
       }
 
       /// Check file version compatibility
       if ( header.majorVersion > E57_FORMAT_MAJOR )
       {
-         throw E57_EXCEPTION2( E57_ERROR_UNKNOWN_FILE_VERSION,
-                               "fileName=" + file->fileName() +
-                                  " header.majorVersion=" + toString( header.majorVersion ) +
-                                  " header.minorVersion=" + toString( header.minorVersion ) );
+         throw E57_EXCEPTION2( ErrorUnknownFileVersion, "fileName=" + file->fileName() +
+                                                           " header.majorVersion=" + toString( header.majorVersion ) +
+                                                           " header.minorVersion=" + toString( header.minorVersion ) );
       }
 
       /// If is a prototype version (majorVersion==0), then minorVersion has to
@@ -838,16 +835,15 @@ namespace e57
       /// should be able to handle any minor version.
       if ( header.majorVersion == E57_FORMAT_MAJOR && header.minorVersion > E57_FORMAT_MINOR )
       {
-         throw E57_EXCEPTION2( E57_ERROR_UNKNOWN_FILE_VERSION,
-                               "fileName=" + file->fileName() +
-                                  " header.majorVersion=" + toString( header.majorVersion ) +
-                                  " header.minorVersion=" + toString( header.minorVersion ) );
+         throw E57_EXCEPTION2( ErrorUnknownFileVersion, "fileName=" + file->fileName() +
+                                                           " header.majorVersion=" + toString( header.majorVersion ) +
+                                                           " header.minorVersion=" + toString( header.minorVersion ) );
       }
 
       /// Check if file length matches actual physical length
       if ( header.filePhysicalLength != file->length( CheckedFile::Physical ) )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_FILE_LENGTH,
+         throw E57_EXCEPTION2( ErrorBadFileLength,
                                "fileName=" + file->fileName() +
                                   " header.filePhysicalLength=" + toString( header.filePhysicalLength ) +
                                   " file->length=" + toString( file->length( CheckedFile::Physical ) ) );
@@ -856,7 +852,7 @@ namespace e57
       /// Check that page size is correct constant
       if ( header.majorVersion != 0 && header.pageSize != CheckedFile::physicalPageSize )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_FILE_LENGTH, "fileName=" + file->fileName() );
+         throw E57_EXCEPTION2( ErrorBadFileLength, "fileName=" + file->fileName() );
       }
    }
 
@@ -865,7 +861,7 @@ namespace e57
    {
       if ( !isOpen() )
       {
-         throw E57Exception( E57_ERROR_IMAGEFILE_NOT_OPEN, "fileName=" + fileName(), srcFileName, srcLineNumber,
+         throw E57Exception( ErrorImageFileNotOpen, "fileName=" + fileName(), srcFileName, srcLineNumber,
                              srcFunctionName );
       }
    }

--- a/src/IntegerNode.cpp
+++ b/src/IntegerNode.cpp
@@ -93,11 +93,11 @@ true).
 @pre     The @a destImageFile must have been opened in write mode (i.e.
 destImageFile.isWritable() must be true).
 @pre     minimum <= value <= maximum
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_FILE_IS_READ_ONLY
-@throw   ::E57_ERROR_VALUE_OUT_OF_BOUNDS
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorFileReadOnly
+@throw   ::ErrorValueOutOfBounds
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     IntegerNode::value, Node, CompressedVectorNode, CompressedVectorNode::prototype
 */
 IntegerNode::IntegerNode( ImageFile destImageFile, int64_t value, int64_t minimum, int64_t maximum ) :
@@ -153,8 +153,8 @@ bool IntegerNode::isAttached() const
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  integer value stored.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     IntegerNode::minimum, IntegerNode::maximum
 */
 int64_t IntegerNode::value() const
@@ -167,8 +167,8 @@ int64_t IntegerNode::value() const
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  The declared minimum that the value may take.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     IntegerCreate.cpp example, IntegerNode::value
 */
 int64_t IntegerNode::minimum() const
@@ -181,8 +181,8 @@ int64_t IntegerNode::minimum() const
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  The declared maximum that the value may take.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     IntegerNode::value
 */
 int64_t IntegerNode::maximum() const
@@ -214,13 +214,12 @@ class.
 This function checks at least the assertions in the documented class invariant
 description (see class reference page for this object). Other internal
 invariants that are implementation-dependent may also be checked. If any
-invariant clause is violated, an E57Exception with errorCode of
-E57_ERROR_INVARIANCE_VIOLATION is thrown.
+invariant clause is violated, an ::ErrorInvarianceViolation E57Exception is thrown.
 
 Checking the invariant recursively may be expensive if the tree is large, so
 should be used judiciously, in debug versions of the application.
 @post    No visible state is modified.
-@throw   ::E57_ERROR_INVARIANCE_VIOLATION or any other E57 ErrorCode
+@throw   ::ErrorInvarianceViolation or any other E57 ErrorCode
 */
 // beginExample IntegerNode::checkInvariant
 void IntegerNode::checkInvariant( bool /*doRecurse*/, bool doUpcast )
@@ -240,7 +239,7 @@ void IntegerNode::checkInvariant( bool /*doRecurse*/, bool doUpcast )
 
    if ( value() < minimum() || value() > maximum() )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 }
 // endExample IntegerNode::checkInvariant
@@ -268,14 +267,14 @@ exception is thrown. In designs that need to avoid the exception, use
 Node::type() to determine the actual type of the @a n before downcasting. This
 function must be explicitly called (c++ compiler cannot insert it
 automatically).
-@throw   ::E57_ERROR_BAD_NODE_DOWNCAST
+@throw   ::ErrorBadNodeDowncast
 @see     Node::type(), IntegerNode::operator Node()
 */
 IntegerNode::IntegerNode( const Node &n )
 {
-   if ( n.type() != E57_INTEGER )
+   if ( n.type() != TypeInteger )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_NODE_DOWNCAST, "nodeType=" + toString( n.type() ) );
+      throw E57_EXCEPTION2( ErrorBadNodeDowncast, "nodeType=" + toString( n.type() ) );
    }
 
    /// Set our shared_ptr to the downcast shared_ptr

--- a/src/IntegerNodeImpl.cpp
+++ b/src/IntegerNodeImpl.cpp
@@ -41,7 +41,7 @@ namespace e57
       /// Enforce the given bounds
       if ( value < minimum || maximum < value )
       {
-         throw E57_EXCEPTION2( E57_ERROR_VALUE_OUT_OF_BOUNDS,
+         throw E57_EXCEPTION2( ErrorValueOutOfBounds,
                                "this->pathName=" + this->pathName() + " value=" + toString( value ) +
                                   " minimum=" + toString( minimum ) + " maximum=" + toString( maximum ) );
       }
@@ -52,7 +52,7 @@ namespace e57
       // don't checkImageFileOpen
 
       /// Same node type?
-      if ( ni->type() != E57_INTEGER )
+      if ( ni->type() != TypeInteger )
       {
          return ( false );
       }
@@ -111,7 +111,7 @@ namespace e57
       /// We are a leaf node, so verify that we are listed in set.
       if ( pathNames.find( relativePathName( origin ) ) == pathNames.end() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_NO_BUFFER_FOR_ELEMENT, "this->pathName=" + this->pathName() );
+         throw E57_EXCEPTION2( ErrorNoBufferForElement, "this->pathName=" + this->pathName() );
       }
    }
 
@@ -133,11 +133,11 @@ namespace e57
       cf << space( indent ) << "<" << fieldName << " type=\"Integer\"";
 
       /// Don't need to write if are default values
-      if ( minimum_ != E57_INT64_MIN )
+      if ( minimum_ != INT64_MIN )
       {
          cf << " minimum=\"" << minimum_ << "\"";
       }
-      if ( maximum_ != E57_INT64_MAX )
+      if ( maximum_ != INT64_MAX )
       {
          cf << " maximum=\"" << maximum_ << "\"";
       }

--- a/src/IntegerNodeImpl.h
+++ b/src/IntegerNodeImpl.h
@@ -39,7 +39,7 @@ namespace e57
 
       NodeType type() const override
       {
-         return E57_INTEGER;
+         return TypeInteger;
       }
 
       bool isTypeEquivalent( NodeImplSharedPtr ni ) override;

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -79,7 +79,7 @@ The conversion from a general handle type to a specific handle type is called
 IntegerNode::IntegerNode(const Node&) for example). If a downcast is requested
 to an incorrect type (e.g. taking a Node handle that is actually a FloatNode and
 trying to downcast it to a IntegerNode), an E57Exception is thrown with an
-ErrorCode of E57_ERROR_BAD_NODE_DOWNCAST. Depending on the program design,
+ErrorCode of ::ErrorBadNodeDowncast. Depending on the program design,
 throwing a bad downcast exception might be acceptable, if an element must be a
 specific type and no recovery is possible. If a standard requires an element be
 one several types, then Node::type() should be used to interrogate the type in
@@ -120,11 +120,9 @@ ScaledIntegerNode, FloatNode, StringNode, BlobNode
 @details This function allows the actual node type to be interrogated before
 upcasting the handle to the actual node type (see Upcasting and Downcasting
 section in Node).
-@return  The NodeType of a generic Node, which may be one of the following
-NodeType enumeration values:
-::E57_STRUCTURE, ::E57_VECTOR, ::E57_COMPRESSED_VECTOR, ::E57_INTEGER,
-::E57_SCALED_INTEGER,
-::E57_FLOAT, ::E57_STRING, ::E57_BLOB.
+@return  The NodeType of a generic Node, which may be one of the following NodeType enumeration values:
+::TypeStructure, ::TypeVector, ::TypeCompressedVector, ::TypeInteger, ::TypeScaledInteger, ::TypeFloat, ::TypeString,
+::TypeBlob.
 @post    No visible state is modified.
 @see     NodeType, upcast/downcast discussion in Node
 */
@@ -147,8 +145,8 @@ CompressedVectorNode::CompressedVectorNode for more details).
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  true if this node is a root node.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     Node::parent, Node::isAttached, CompressedVectorNode::CompressedVectorNode
 */
 bool Node::isRoot() const
@@ -166,7 +164,7 @@ In the API, if a node has zero parents it is represented by having itself as a
 parent. Due to the set-once design of the API, a parent-child relationship
 cannot be modified once established. A child node can be any of the 8 node
 types, but a parent node can only be one of the 3 container node types
-(E57_STRUCTURE, E57_VECTOR, and E57_COMPRESSED_VECTOR). Each parent-child link
+(::TypeStructure, ::TypeVector, and ::TypeCompressedVector). Each parent-child link
 has a string name (the elementName) associated with it (See Node::elementName
 for more details). More than one tree can be formed at any given time. Typically
 small trees are temporarily constructed before attachment to an ImageFile so
@@ -179,8 +177,8 @@ Node::isRoot to avoid infinite loops or infinite recursion.
 @post    No visible state is modified.
 @return  A smart Node handle referencing the parent node or this node if is a
 root node.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     Node::isRoot, Node::isAttached, CompressedVectorNode::CompressedVectorNode, Node::elementName
 */
 Node Node::parent() const
@@ -212,8 +210,8 @@ as its elementName.
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  The absolute path name of the node.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     Node::elementName, Node::parent, Node::isRoot
 */
 ustring Node::pathName() const
@@ -242,8 +240,8 @@ is not stored in the file and is deduced by the position of the child.
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  The element name of the node, or "" if a root node.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     Node::pathName, Node::parent, Node::isRoot
 */
 ustring Node::elementName() const
@@ -287,8 +285,8 @@ to create nodes that are not eventually attached to the ImageFile.
 @post    No visible object state is modified.
 @return  @c true if node is child of (or in codecs or prototype of a child
 CompressedVectorNode of) the root node of an ImageFile.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     Node::destImageFile, ImageFile::root
 */
 bool Node::isAttached() const
@@ -336,14 +334,14 @@ This function checks at least the assertions in the documented class invariant
 description (see class reference page for this object). Other internal
 invariants that are implementation-dependent may also be checked. If any
 invariant clause is violated, an E57Exception with errorCode of
-E57_ERROR_INVARIANCE_VIOLATION is thrown.
+ErrorInvarianceViolation is thrown.
 
 Specifying doRecurse=true only makes sense if doDowncast=true is also specified
 (the generic Node has no way to access any children). Checking the invariant
 recursively may be expensive if the tree is large, so should be used
 judiciously, in debug versions of the application.
 @post    No visible state is modified.
-@throw   ::E57_ERROR_INVARIANCE_VIOLATION or any other E57 ErrorCode
+@throw   ::ErrorInvarianceViolation or any other E57 ErrorCode
 @see     Class Invariant section in Node,
 IntegerNode::checkInvariant, ScaledIntegerNode::checkInvariant,
 FloatNode::checkInvariant, BlobNode::checkInvariant,
@@ -365,13 +363,13 @@ void Node::checkInvariant( bool doRecurse, bool doDowncast )
    // Parent attachment state is same as this attachment state
    if ( isAttached() != parent().isAttached() )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // Parent destination ImageFile is same as this
    if ( imf != parent().destImageFile() )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // If this is the ImageFile root node
@@ -380,13 +378,13 @@ void Node::checkInvariant( bool doRecurse, bool doDowncast )
       // Must be attached
       if ( !isAttached() )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
 
       // Must be is a root node
       if ( !isRoot() )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
    }
 
@@ -396,13 +394,13 @@ void Node::checkInvariant( bool doRecurse, bool doDowncast )
       // Absolute pathName is "/"
       if ( pathName() != "/" )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
 
       // parent() returns this node
       if ( *this != parent() )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
    }
    else
@@ -410,7 +408,7 @@ void Node::checkInvariant( bool doRecurse, bool doDowncast )
       // Non-root can't be own parent
       if ( *this == parent() )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
 
       // pathName is concatenation of parent pathName and this elementName
@@ -418,53 +416,53 @@ void Node::checkInvariant( bool doRecurse, bool doDowncast )
       {
          if ( pathName() != "/" + elementName() )
          {
-            throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+            throw E57_EXCEPTION1( ErrorInvarianceViolation );
          }
       }
       else
       {
          if ( pathName() != parent().pathName() + "/" + elementName() )
          {
-            throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+            throw E57_EXCEPTION1( ErrorInvarianceViolation );
          }
       }
 
       // Non-root nodes must be children of either a VectorNode or StructureNode
-      if ( parent().type() == E57_VECTOR )
+      if ( parent().type() == TypeVector )
       {
          VectorNode v = static_cast<VectorNode>( parent() );
 
          // Must be defined in parent VectorNode with this elementName
          if ( !v.isDefined( elementName() ) )
          {
-            throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+            throw E57_EXCEPTION1( ErrorInvarianceViolation );
          }
 
          // Getting child of parent with this elementName must return this
          if ( v.get( elementName() ) != *this )
          {
-            throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+            throw E57_EXCEPTION1( ErrorInvarianceViolation );
          }
       }
-      else if ( parent().type() == E57_STRUCTURE )
+      else if ( parent().type() == TypeStructure )
       {
          StructureNode s = static_cast<StructureNode>( parent() );
 
          // Must be defined in parent VectorNode with this elementName
          if ( !s.isDefined( elementName() ) )
          {
-            throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+            throw E57_EXCEPTION1( ErrorInvarianceViolation );
          }
 
          // Getting child of parent with this elementName must return this
          if ( s.get( elementName() ) != *this )
          {
-            throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+            throw E57_EXCEPTION1( ErrorInvarianceViolation );
          }
       }
       else
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
    }
 
@@ -484,13 +482,13 @@ void Node::checkInvariant( bool doRecurse, bool doDowncast )
          // pathName must be defined
          if ( !imf.root().isDefined( pathName() ) )
          {
-            throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+            throw E57_EXCEPTION1( ErrorInvarianceViolation );
          }
 
          // Getting by absolute pathName must be this
          if ( imf.root().get( pathName() ) != *this )
          {
-            throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+            throw E57_EXCEPTION1( ErrorInvarianceViolation );
          }
       }
    }
@@ -500,49 +498,49 @@ void Node::checkInvariant( bool doRecurse, bool doDowncast )
    {
       switch ( type() )
       {
-         case E57_STRUCTURE:
+         case TypeStructure:
          {
             StructureNode s( *this );
             s.checkInvariant( doRecurse, false );
          }
          break;
-         case E57_VECTOR:
+         case TypeVector:
          {
             VectorNode v( *this );
             v.checkInvariant( doRecurse, false );
          }
          break;
-         case E57_COMPRESSED_VECTOR:
+         case TypeCompressedVector:
          {
             CompressedVectorNode cv( *this );
             cv.checkInvariant( doRecurse, false );
          }
          break;
-         case E57_INTEGER:
+         case TypeInteger:
          {
             IntegerNode i( *this );
             i.checkInvariant( doRecurse, false );
          }
          break;
-         case E57_SCALED_INTEGER:
+         case TypeScaledInteger:
          {
             ScaledIntegerNode si( *this );
             si.checkInvariant( doRecurse, false );
          }
          break;
-         case E57_FLOAT:
+         case TypeFloat:
          {
             FloatNode f( *this );
             f.checkInvariant( doRecurse, false );
          }
          break;
-         case E57_STRING:
+         case TypeString:
          {
             StringNode s( *this );
             s.checkInvariant( doRecurse, false );
          }
          break;
-         case E57_BLOB:
+         case TypeBlob:
          {
             BlobNode b( *this );
             b.checkInvariant( doRecurse, false );

--- a/src/NodeImpl.cpp
+++ b/src/NodeImpl.cpp
@@ -45,8 +45,8 @@ void NodeImpl::checkImageFileOpen( const char *srcFileName, int srcLineNumber, c
    ImageFileImplSharedPtr destImageFile( destImageFile_ );
    if ( !destImageFile->isOpen() )
    {
-      throw E57Exception( E57_ERROR_IMAGEFILE_NOT_OPEN, "fileName=" + destImageFile->fileName(), srcFileName,
-                          srcLineNumber, srcFunctionName );
+      throw E57Exception( ErrorImageFileNotOpen, "fileName=" + destImageFile->fileName(), srcFileName, srcLineNumber,
+                          srcFunctionName );
    }
 }
 
@@ -102,7 +102,7 @@ ustring NodeImpl::relativePathName( const NodeImplSharedPtr &origin, ustring chi
    if ( isRoot() )
    {
       /// Got to top and didn't find origin, must be error
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL,
+      throw E57_EXCEPTION2( ErrorInternal,
                             "this->elementName=" + this->elementName() + " childPathName=" + childPathName );
    }
 
@@ -158,7 +158,7 @@ void NodeImpl::setParent( NodeImplSharedPtr parent, const ustring &elementName )
    /// don't checkImageFileOpen
 
    /// First check if our parent_ is already set, throw
-   /// E57_ERROR_ALREADY_HAS_PARENT The isAttached_ condition is to catch two
+   /// ErrorAlreadyHasParent The isAttached_ condition is to catch two
    /// errors:
    ///    1) if user attempts to use the ImageFile root as a child (e.g.
    ///    root.set("x", root)) 2) if user attempts to reuse codecs or prototype
@@ -168,7 +168,7 @@ void NodeImpl::setParent( NodeImplSharedPtr parent, const ustring &elementName )
    {
       /// ??? does caller do setParent first, so state is not messed up when
       /// throw?
-      throw E57_EXCEPTION2( E57_ERROR_ALREADY_HAS_PARENT,
+      throw E57_EXCEPTION2( ErrorAlreadyHasParent,
                             "this->pathName=" + this->pathName() + " newParent->pathName=" + parent->pathName() );
    }
 
@@ -209,7 +209,7 @@ bool NodeImpl::isTypeConstrained()
 
       switch ( p->type() )
       {
-         case E57_VECTOR:
+         case TypeVector:
          {
             /// Downcast to shared_ptr<VectorNodeImpl>
             std::shared_ptr<VectorNodeImpl> ai( std::static_pointer_cast<VectorNodeImpl>( p ) );
@@ -222,7 +222,7 @@ bool NodeImpl::isTypeConstrained()
             }
          }
          break;
-         case E57_COMPRESSED_VECTOR:
+         case TypeCompressedVector:
             /// Can't make any type changes to CompressedVector prototype.  ???
             /// what if hasn't been written to yet
             return ( true );
@@ -274,7 +274,7 @@ void NodeImpl::set( const StringList & /*fields*/, unsigned /*level*/, NodeImplS
 {
    /// If get here, then tried to call set(fields...) on NodeImpl that wasn't a
    /// StructureNodeImpl, so that's an error
-   throw E57_EXCEPTION1( E57_ERROR_BAD_PATH_NAME ); //???
+   throw E57_EXCEPTION1( ErrorBadPathName ); //???
 }
 
 void NodeImpl::checkBuffers( const std::vector<SourceDestBuffer> &sdbufs,
@@ -293,7 +293,7 @@ void NodeImpl::checkBuffers( const std::vector<SourceDestBuffer> &sdbufs,
       /// Check that all buffers are same size
       if ( sdbufs.at( i ).impl()->capacity() != sdbufs.at( 0 ).impl()->capacity() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BUFFER_SIZE_MISMATCH,
+         throw E57_EXCEPTION2( ErrorBufferSizeMismatch,
                                "this->pathName=" + this->pathName() + " sdbuf.pathName=" + pathName +
                                   " firstCapacity=" + toString( sdbufs.at( 0 ).impl()->capacity() ) +
                                   " secondCapacity=" + toString( sdbufs.at( i ).impl()->capacity() ) );
@@ -303,14 +303,14 @@ void NodeImpl::checkBuffers( const std::vector<SourceDestBuffer> &sdbufs,
       /// pathName in sdbufs)
       if ( !pathNames.insert( pathName ).second )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BUFFER_DUPLICATE_PATHNAME,
+         throw E57_EXCEPTION2( ErrorBufferDuplicatePathName,
                                "this->pathName=" + this->pathName() + " sdbuf.pathName=" + pathName );
       }
 
       /// Check no bad fields in sdbufs
       if ( !isDefined( pathName ) )
       {
-         throw E57_EXCEPTION2( E57_ERROR_PATH_UNDEFINED,
+         throw E57_EXCEPTION2( ErrorPathUndefined,
                                "this->pathName=" + this->pathName() + " sdbuf.pathName=" + pathName );
       }
    }
@@ -334,7 +334,7 @@ bool NodeImpl::findTerminalPosition( const NodeImplSharedPtr &target, uint64_t &
 
    switch ( type() )
    {
-      case E57_STRUCTURE:
+      case TypeStructure:
       {
          auto sni = static_cast<StructureNodeImpl *>( this );
 
@@ -350,7 +350,7 @@ bool NodeImpl::findTerminalPosition( const NodeImplSharedPtr &target, uint64_t &
       }
       break;
 
-      case E57_VECTOR:
+      case TypeVector:
       {
          auto vni = static_cast<VectorNodeImpl *>( this );
 
@@ -366,14 +366,14 @@ bool NodeImpl::findTerminalPosition( const NodeImplSharedPtr &target, uint64_t &
       }
       break;
 
-      case E57_COMPRESSED_VECTOR:
+      case TypeCompressedVector:
          break; //??? for now, don't search into contents of compressed vector
 
-      case E57_INTEGER:
-      case E57_SCALED_INTEGER:
-      case E57_FLOAT:
-      case E57_STRING:
-      case E57_BLOB:
+      case TypeInteger:
+      case TypeScaledInteger:
+      case TypeFloat:
+      case TypeString:
+      case TypeBlob:
          countFromLeft++;
          break;
    }
@@ -405,7 +405,7 @@ bool NodeImpl::_verifyPathNameAbsolute( const ustring &inPathName )
    /// If not an absolute path name, have error
    if ( isRelative )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_PATH_NAME, "this->pathName=" + this->pathName() + " pathName=" + inPathName );
+      throw E57_EXCEPTION2( ErrorBadPathName, "this->pathName=" + this->pathName() + " pathName=" + inPathName );
    }
 
    return isRelative;
@@ -421,11 +421,11 @@ NodeImplSharedPtr NodeImpl::_verifyAndGetRoot()
    /// overflow).
    switch ( root->type() )
    {
-      case E57_STRUCTURE:
-      case E57_VECTOR: //??? COMPRESSED_VECTOR?
+      case TypeStructure:
+      case TypeVector: //??? COMPRESSED_VECTOR?
          break;
       default:
-         throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "root invalid for this->pathName=" + this->pathName() );
+         throw E57_EXCEPTION2( ErrorInternal, "root invalid for this->pathName=" + this->pathName() );
    }
 
    return root;

--- a/src/Packet.cpp
+++ b/src/Packet.cpp
@@ -79,7 +79,7 @@ PacketReadCache::PacketReadCache( CheckedFile *cFile, unsigned packetCount ) : c
 {
    if ( packetCount == 0 )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "packetCount=" + toString( packetCount ) );
+      throw E57_EXCEPTION2( ErrorInternal, "packetCount=" + toString( packetCount ) );
    }
 }
 
@@ -92,13 +92,13 @@ std::unique_ptr<PacketLock> PacketReadCache::lock( uint64_t packetLogicalOffset,
    /// Only allow one locked packet at a time.
    if ( lockCount_ > 0 )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "lockCount=" + toString( lockCount_ ) );
+      throw E57_EXCEPTION2( ErrorInternal, "lockCount=" + toString( lockCount_ ) );
    }
 
    /// Offset can't be 0
    if ( packetLogicalOffset == 0 )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "packetLogicalOffset=" + toString( packetLogicalOffset ) );
+      throw E57_EXCEPTION2( ErrorInternal, "packetLogicalOffset=" + toString( packetLogicalOffset ) );
    }
 
    /// Linear scan for matching packet offset in cache
@@ -171,7 +171,7 @@ void PacketReadCache::unlock( unsigned cacheIndex )
 
    if ( lockCount_ != 1 )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "lockCount=" + toString( lockCount_ ) );
+      throw E57_EXCEPTION2( ErrorInternal, "lockCount=" + toString( lockCount_ ) );
    }
 
    --lockCount_;
@@ -198,7 +198,7 @@ void PacketReadCache::readPacket( unsigned oldestEntry, uint64_t packetLogicalOf
    /// Be paranoid about packetLength before read
    if ( packetLength > DATA_PACKET_MAX )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "packetLength=" + toString( packetLength ) );
+      throw E57_EXCEPTION2( ErrorBadCVPacket, "packetLength=" + toString( packetLength ) );
    }
 
    auto &entry = entries_.at( oldestEntry );
@@ -244,7 +244,7 @@ void PacketReadCache::readPacket( unsigned oldestEntry, uint64_t packetLogicalOf
       }
       break;
       default:
-         throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "packetType=" + toString( header.packetType ) );
+         throw E57_EXCEPTION2( ErrorInternal, "packetType=" + toString( header.packetType ) );
    }
 
    entry.logicalOffset_ = packetLogicalOffset;
@@ -290,7 +290,7 @@ void PacketReadCache::dump( int indent, std::ostream &os )
             break;
             default:
                throw E57_EXCEPTION2(
-                  E57_ERROR_INTERNAL,
+                  ErrorInternal,
                   "packetType=" +
                      toString( reinterpret_cast<EmptyPacketHeader *>( entries_.at( i ).buffer_ )->packetType ) );
          }
@@ -347,7 +347,7 @@ void DataPacketHeader::verify( unsigned bufferLength ) const
    /// Verify that packet is correct type
    if ( packetType != DATA_PACKET )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "packetType=" + toString( packetType ) );
+      throw E57_EXCEPTION2( ErrorBadCVPacket, "packetType=" + toString( packetType ) );
    }
 
    /// ??? check reserved flags zero?
@@ -356,19 +356,19 @@ void DataPacketHeader::verify( unsigned bufferLength ) const
    unsigned packetLength = packetLogicalLengthMinus1 + 1;
    if ( packetLength < sizeof( *this ) )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "packetLength=" + toString( packetLength ) );
+      throw E57_EXCEPTION2( ErrorBadCVPacket, "packetLength=" + toString( packetLength ) );
    }
 
    /// Check packet length is multiple of 4
    if ( packetLength % 4 )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "packetLength=" + toString( packetLength ) );
+      throw E57_EXCEPTION2( ErrorBadCVPacket, "packetLength=" + toString( packetLength ) );
    }
 
    /// Check actual packet length is large enough.
    if ( bufferLength > 0 && packetLength > bufferLength )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET,
+      throw E57_EXCEPTION2( ErrorBadCVPacket,
                             "packetLength=" + toString( packetLength ) + " bufferLength=" + toString( bufferLength ) );
    }
 
@@ -376,14 +376,14 @@ void DataPacketHeader::verify( unsigned bufferLength ) const
    /// allowed?
    if ( bytestreamCount == 0 )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "bytestreamCount=" + toString( bytestreamCount ) );
+      throw E57_EXCEPTION2( ErrorBadCVPacket, "bytestreamCount=" + toString( bytestreamCount ) );
    }
 
    /// Check packet is at least long enough to hold bytestreamBufferLength array
    if ( sizeof( DataPacketHeader ) + 2 * bytestreamCount > packetLength )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "packetLength=" + toString( packetLength ) +
-                                                        " bytestreamCount=" + toString( bytestreamCount ) );
+      throw E57_EXCEPTION2( ErrorBadCVPacket, "packetLength=" + toString( packetLength ) +
+                                                 " bytestreamCount=" + toString( bytestreamCount ) );
    }
 }
 
@@ -437,7 +437,7 @@ void DataPacket::verify( unsigned bufferLength ) const
    /// If needed is not with 3 bytes of actual packet size, have an error
    if ( needed > packetLength || needed + 3 < packetLength )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET,
+      throw E57_EXCEPTION2( ErrorBadCVPacket,
                             "needed=" + toString( needed ) + "packetLength=" + toString( packetLength ) );
    }
 
@@ -446,7 +446,7 @@ void DataPacket::verify( unsigned bufferLength ) const
    {
       if ( reinterpret_cast<const char *>( this )[i] != 0 )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "i=" + toString( i ) );
+         throw E57_EXCEPTION2( ErrorBadCVPacket, "i=" + toString( i ) );
       }
    }
 }
@@ -460,14 +460,14 @@ char *DataPacket::getBytestream( unsigned bytestreamNumber, unsigned &byteCount 
    /// Verify that packet is correct type
    if ( header.packetType != DATA_PACKET )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "packetType=" + toString( header.packetType ) );
+      throw E57_EXCEPTION2( ErrorBadCVPacket, "packetType=" + toString( header.packetType ) );
    }
 
    /// Check bytestreamNumber in bounds
    if ( bytestreamNumber >= header.bytestreamCount )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "bytestreamNumber=" + toString( bytestreamNumber ) +
-                                                   "bytestreamCount=" + toString( header.bytestreamCount ) );
+      throw E57_EXCEPTION2( ErrorInternal, "bytestreamNumber=" + toString( bytestreamNumber ) +
+                                              "bytestreamCount=" + toString( header.bytestreamCount ) );
    }
 
    /// Calc positions in packet
@@ -487,10 +487,10 @@ char *DataPacket::getBytestream( unsigned bytestreamNumber, unsigned &byteCount 
    if ( sizeof( DataPacketHeader ) + 2 * header.bytestreamCount + totalPreceeding + byteCount >
         header.packetLogicalLengthMinus1 + 1U )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL,
-                            "bytestreamCount=" + toString( header.bytestreamCount ) + " totalPreceeding=" +
-                               toString( totalPreceeding ) + " byteCount=" + toString( byteCount ) +
-                               " packetLogicalLengthMinus1=" + toString( header.packetLogicalLengthMinus1 ) );
+      throw E57_EXCEPTION2(
+         ErrorInternal, "bytestreamCount=" + toString( header.bytestreamCount ) +
+                           " totalPreceeding=" + toString( totalPreceeding ) + " byteCount=" + toString( byteCount ) +
+                           " packetLogicalLengthMinus1=" + toString( header.packetLogicalLengthMinus1 ) );
    }
 
    /// Return start of buffer
@@ -510,7 +510,7 @@ void DataPacket::dump( int indent, std::ostream &os ) const
 {
    if ( header.packetType != DATA_PACKET )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "packetType=" + toString( header.packetType ) );
+      throw E57_EXCEPTION2( ErrorInternal, "packetType=" + toString( header.packetType ) );
    }
 
    reinterpret_cast<const DataPacketHeader *>( this )->dump( indent, os );
@@ -532,8 +532,7 @@ void DataPacket::dump( int indent, std::ostream &os ) const
       p += bsbLength[i];
       if ( p - reinterpret_cast<const uint8_t *>( this ) > DATA_PACKET_MAX )
       {
-         throw E57_EXCEPTION2( E57_ERROR_INTERNAL,
-                               "size=" + toString( p - reinterpret_cast<const uint8_t *>( this ) ) );
+         throw E57_EXCEPTION2( ErrorInternal, "size=" + toString( p - reinterpret_cast<const uint8_t *>( this ) ) );
       }
    }
 }
@@ -551,40 +550,40 @@ void IndexPacket::verify( unsigned bufferLength, uint64_t totalRecordCount, uint
    /// Verify that packet is correct type
    if ( packetType != INDEX_PACKET )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "packetType=" + toString( packetType ) );
+      throw E57_EXCEPTION2( ErrorBadCVPacket, "packetType=" + toString( packetType ) );
    }
 
    /// Check packetLength is at least large enough to hold header
    unsigned packetLength = packetLogicalLengthMinus1 + 1;
    if ( packetLength < sizeof( *this ) )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "packetLength=" + toString( packetLength ) );
+      throw E57_EXCEPTION2( ErrorBadCVPacket, "packetLength=" + toString( packetLength ) );
    }
 
    /// Check packet length is multiple of 4
    if ( packetLength % 4 )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "packetLength=" + toString( packetLength ) );
+      throw E57_EXCEPTION2( ErrorBadCVPacket, "packetLength=" + toString( packetLength ) );
    }
 
    /// Make sure there is at least one entry in packet  ??? 0 record cvect
    /// allowed?
    if ( entryCount == 0 )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "entryCount=" + toString( entryCount ) );
+      throw E57_EXCEPTION2( ErrorBadCVPacket, "entryCount=" + toString( entryCount ) );
    }
 
    /// Have to have <= 2048 entries
    if ( entryCount > MAX_ENTRIES )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "entryCount=" + toString( entryCount ) );
+      throw E57_EXCEPTION2( ErrorBadCVPacket, "entryCount=" + toString( entryCount ) );
    }
 
    /// Index level should be <= 5.  Because (5+1)* 11 bits = 66 bits, which will
    /// cover largest number of chunks possible.
    if ( indexLevel > 5 )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "indexLevel=" + toString( indexLevel ) );
+      throw E57_EXCEPTION2( ErrorBadCVPacket, "indexLevel=" + toString( indexLevel ) );
    }
 
    /// Index packets above level 0 must have at least two entries (otherwise no
@@ -592,7 +591,7 @@ void IndexPacket::verify( unsigned bufferLength, uint64_t totalRecordCount, uint
    ///??? check that this is in spec
    if ( indexLevel > 0 && entryCount < 2 )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET,
+      throw E57_EXCEPTION2( ErrorBadCVPacket,
                             "indexLevel=" + toString( indexLevel ) + " entryCount=" + toString( entryCount ) );
    }
 
@@ -602,14 +601,14 @@ void IndexPacket::verify( unsigned bufferLength, uint64_t totalRecordCount, uint
    {
       if ( reserved1[i] != 0 )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "i=" + toString( i ) );
+         throw E57_EXCEPTION2( ErrorBadCVPacket, "i=" + toString( i ) );
       }
    }
 
    /// Check actual packet length is large enough.
    if ( bufferLength > 0 && packetLength > bufferLength )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET,
+      throw E57_EXCEPTION2( ErrorBadCVPacket,
                             "packetLength=" + toString( packetLength ) + " bufferLength=" + toString( bufferLength ) );
    }
 
@@ -617,7 +616,7 @@ void IndexPacket::verify( unsigned bufferLength, uint64_t totalRecordCount, uint
    unsigned neededLength = 16 + 8 * entryCount;
    if ( packetLength < neededLength )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET,
+      throw E57_EXCEPTION2( ErrorBadCVPacket,
                             "packetLength=" + toString( packetLength ) + " neededLength=" + toString( neededLength ) );
    }
 
@@ -628,7 +627,7 @@ void IndexPacket::verify( unsigned bufferLength, uint64_t totalRecordCount, uint
    {
       if ( p[i] != 0 )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "i=" + toString( i ) );
+         throw E57_EXCEPTION2( ErrorBadCVPacket, "i=" + toString( i ) );
       }
    }
 
@@ -638,15 +637,15 @@ void IndexPacket::verify( unsigned bufferLength, uint64_t totalRecordCount, uint
       /// Check chunkRecordNumber is in bounds
       if ( totalRecordCount > 0 && entries[i].chunkRecordNumber >= totalRecordCount )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET,
-                               "i=" + toString( i ) + " chunkRecordNumber=" + toString( entries[i].chunkRecordNumber ) +
-                                  " totalRecordCount=" + toString( totalRecordCount ) );
+         throw E57_EXCEPTION2( ErrorBadCVPacket, "i=" + toString( i ) +
+                                                    " chunkRecordNumber=" + toString( entries[i].chunkRecordNumber ) +
+                                                    " totalRecordCount=" + toString( totalRecordCount ) );
       }
 
       /// Check record numbers are strictly increasing
       if ( i > 0 && entries[i - 1].chunkRecordNumber >= entries[i].chunkRecordNumber )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET,
+         throw E57_EXCEPTION2( ErrorBadCVPacket,
                                "i=" + toString( i ) +
                                   " prevChunkRecordNumber=" + toString( entries[i - 1].chunkRecordNumber ) +
                                   " currentChunkRecordNumber=" + toString( entries[i].chunkRecordNumber ) );
@@ -655,15 +654,15 @@ void IndexPacket::verify( unsigned bufferLength, uint64_t totalRecordCount, uint
       /// Check chunkPhysicalOffset is in bounds
       if ( fileSize > 0 && entries[i].chunkPhysicalOffset >= fileSize )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "i=" + toString( i ) + " chunkPhysicalOffset=" +
-                                                           toString( entries[i].chunkPhysicalOffset ) +
-                                                           " fileSize=" + toString( fileSize ) );
+         throw E57_EXCEPTION2( ErrorBadCVPacket, "i=" + toString( i ) + " chunkPhysicalOffset=" +
+                                                    toString( entries[i].chunkPhysicalOffset ) +
+                                                    " fileSize=" + toString( fileSize ) );
       }
 
       /// Check chunk offsets are strictly increasing
       if ( i > 0 && entries[i - 1].chunkPhysicalOffset >= entries[i].chunkPhysicalOffset )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET,
+         throw E57_EXCEPTION2( ErrorBadCVPacket,
                                "i=" + toString( i ) +
                                   " prevChunkPhysicalOffset=" + toString( entries[i - 1].chunkPhysicalOffset ) +
                                   " currentChunkPhysicalOffset=" + toString( entries[i].chunkPhysicalOffset ) );
@@ -702,26 +701,26 @@ void EmptyPacketHeader::verify( unsigned bufferLength ) const
    /// Verify that packet is correct type
    if ( packetType != EMPTY_PACKET )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "packetType=" + toString( packetType ) );
+      throw E57_EXCEPTION2( ErrorBadCVPacket, "packetType=" + toString( packetType ) );
    }
 
    /// Check packetLength is at least large enough to hold header
    unsigned packetLength = packetLogicalLengthMinus1 + 1;
    if ( packetLength < sizeof( *this ) )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "packetLength=" + toString( packetLength ) );
+      throw E57_EXCEPTION2( ErrorBadCVPacket, "packetLength=" + toString( packetLength ) );
    }
 
    /// Check packet length is multiple of 4
    if ( packetLength % 4 )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET, "packetLength=" + toString( packetLength ) );
+      throw E57_EXCEPTION2( ErrorBadCVPacket, "packetLength=" + toString( packetLength ) );
    }
 
    /// Check actual packet length is large enough.
    if ( bufferLength > 0 && packetLength > bufferLength )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_CV_PACKET,
+      throw E57_EXCEPTION2( ErrorBadCVPacket,
                             "packetLength=" + toString( packetLength ) + " bufferLength=" + toString( bufferLength ) );
    }
 }

--- a/src/ReaderImpl.cpp
+++ b/src/ReaderImpl.cpp
@@ -44,10 +44,10 @@ namespace e57
 
       switch ( imageType )
       {
-         case E57_NO_IMAGE:
+         case ImageNone:
             return 0;
 
-         case E57_JPEG_IMAGE:
+         case ImageJPEG:
             if ( image.isDefined( "jpegImage" ) )
             {
                BlobNode jpegImage( image.get( "jpegImage" ) );
@@ -56,7 +56,7 @@ namespace e57
             }
             break;
 
-         case E57_PNG_IMAGE:
+         case ImagePNG:
             if ( image.isDefined( "pngImage" ) )
             {
                BlobNode pngImage( image.get( "pngImage" ) );
@@ -65,7 +65,7 @@ namespace e57
             }
             break;
 
-         case E57_PNG_IMAGE_MASK:
+         case ImageMaskPNG:
             if ( image.isDefined( "imageMask" ) )
             {
                BlobNode imageMask( image.get( "imageMask" ) );
@@ -92,8 +92,8 @@ namespace e57
       imageWidth = 0;
       imageHeight = 0;
       imageSize = 0;
-      imageType = E57_NO_IMAGE;
-      imageMaskType = E57_NO_IMAGE;
+      imageType = ImageNone;
+      imageMaskType = ImageNone;
 
       if ( image.isDefined( "imageWidth" ) )
       {
@@ -116,23 +116,23 @@ namespace e57
       if ( image.isDefined( "jpegImage" ) )
       {
          imageSize = BlobNode( image.get( "jpegImage" ) ).byteCount();
-         imageType = E57_JPEG_IMAGE;
+         imageType = ImageJPEG;
       }
       else if ( image.isDefined( "pngImage" ) )
       {
          imageSize = BlobNode( image.get( "pngImage" ) ).byteCount();
-         imageType = E57_PNG_IMAGE;
+         imageType = ImagePNG;
       }
 
       if ( image.isDefined( "imageMask" ) )
       {
-         if ( imageType == E57_NO_IMAGE )
+         if ( imageType == ImageNone )
          {
             imageSize = BlobNode( image.get( "imageMask" ) ).byteCount();
-            imageType = E57_PNG_IMAGE_MASK;
+            imageType = ImageMaskPNG;
          }
 
-         imageMaskType = E57_PNG_IMAGE_MASK;
+         imageMaskType = ImageMaskPNG;
       }
 
       return true;
@@ -145,14 +145,14 @@ namespace e57
       {
          const auto colourProto = proto.get( protoName );
 
-         if ( colourProto.type() == E57_INTEGER )
+         if ( colourProto.type() == TypeInteger )
          {
             const IntegerNode integerColour( colourProto );
 
             colourMin = static_cast<uint16_t>( integerColour.minimum() );
             colourMax = static_cast<uint16_t>( integerColour.maximum() );
          }
-         else if ( colourProto.type() == E57_SCALED_INTEGER )
+         else if ( colourProto.type() == TypeScaledInteger )
          {
             const ScaledIntegerNode scaledColour( colourProto );
             const double scale = scaledColour.scale();
@@ -163,7 +163,7 @@ namespace e57
             colourMin = static_cast<uint16_t>( minimum ) * scale + offset;
             colourMax = static_cast<uint16_t>( maximum ) * scale + offset;
          }
-         else if ( colourProto.type() == E57_FLOAT )
+         else if ( colourProto.type() == TypeFloat )
          {
             const FloatNode floatColour( colourProto );
 
@@ -475,10 +475,10 @@ namespace e57
          return false;
       }
 
-      imageProjection = E57_NO_PROJECTION;
-      imageType = E57_NO_IMAGE;
-      imageMaskType = E57_NO_IMAGE;
-      imageVisualType = E57_NO_IMAGE;
+      imageProjection = ProjectionNone;
+      imageType = ImageNone;
+      imageMaskType = ImageNone;
+      imageVisualType = ImageNone;
 
       const StructureNode image( images2D_.get( imageIndex ) );
 
@@ -488,7 +488,7 @@ namespace e57
 
          bool ret = _getImage2DNodeSizes( visualReferenceRepresentation, imageType, imageWidth, imageHeight, imageSize,
                                           imageMaskType );
-         imageProjection = E57_VISUAL;
+         imageProjection = ProjectionVisual;
          imageVisualType = imageType;
 
          return ret;
@@ -498,7 +498,7 @@ namespace e57
       {
          const StructureNode pinholeRepresentation( image.get( "pinholeRepresentation" ) );
 
-         imageProjection = E57_PINHOLE;
+         imageProjection = ProjectionPinhole;
 
          return _getImage2DNodeSizes( pinholeRepresentation, imageType, imageWidth, imageHeight, imageSize,
                                       imageMaskType );
@@ -508,7 +508,7 @@ namespace e57
       {
          const StructureNode sphericalRepresentation( image.get( "sphericalRepresentation" ) );
 
-         imageProjection = E57_SPHERICAL;
+         imageProjection = ProjectionSpherical;
 
          return _getImage2DNodeSizes( sphericalRepresentation, imageType, imageWidth, imageHeight, imageSize,
                                       imageMaskType );
@@ -518,7 +518,7 @@ namespace e57
       {
          const StructureNode cylindricalRepresentation( image.get( "cylindricalRepresentation" ) );
 
-         imageProjection = E57_CYLINDRICAL;
+         imageProjection = ProjectionCylindrical;
 
          return _getImage2DNodeSizes( cylindricalRepresentation, imageType, imageWidth, imageHeight, imageSize,
                                       imageMaskType );
@@ -540,10 +540,10 @@ namespace e57
 
       switch ( imageProjection )
       {
-         case E57_NO_PROJECTION:
+         case ProjectionNone:
             return 0;
 
-         case E57_VISUAL:
+         case ProjectionVisual:
             if ( image.isDefined( "visualReferenceRepresentation" ) )
             {
                const StructureNode visualReferenceRepresentation( image.get( "visualReferenceRepresentation" ) );
@@ -552,7 +552,7 @@ namespace e57
             }
             break;
 
-         case E57_PINHOLE:
+         case ProjectionPinhole:
             if ( image.isDefined( "pinholeRepresentation" ) )
             {
                const StructureNode pinholeRepresentation( image.get( "pinholeRepresentation" ) );
@@ -561,7 +561,7 @@ namespace e57
             }
             break;
 
-         case E57_SPHERICAL:
+         case ProjectionSpherical:
             if ( image.isDefined( "sphericalRepresentation" ) )
             {
                const StructureNode sphericalRepresentation( image.get( "sphericalRepresentation" ) );
@@ -570,7 +570,7 @@ namespace e57
             }
             break;
 
-         case E57_CYLINDRICAL:
+         case ProjectionCylindrical:
             if ( image.isDefined( "cylindricalRepresentation" ) )
             {
                const StructureNode cylindricalRepresentation( image.get( "cylindricalRepresentation" ) );
@@ -716,7 +716,7 @@ namespace e57
       {
          const StructureNode bbox( scan.get( "cartesianBounds" ) );
 
-         if ( bbox.get( "xMinimum" ).type() == E57_SCALED_INTEGER )
+         if ( bbox.get( "xMinimum" ).type() == TypeScaledInteger )
          {
             data3DHeader.cartesianBounds.xMinimum = ScaledIntegerNode( bbox.get( "xMinimum" ) ).scaledValue();
             data3DHeader.cartesianBounds.xMaximum = ScaledIntegerNode( bbox.get( "xMaximum" ) ).scaledValue();
@@ -725,7 +725,7 @@ namespace e57
             data3DHeader.cartesianBounds.zMinimum = ScaledIntegerNode( bbox.get( "zMinimum" ) ).scaledValue();
             data3DHeader.cartesianBounds.zMaximum = ScaledIntegerNode( bbox.get( "zMaximum" ) ).scaledValue();
          }
-         else if ( bbox.get( "xMinimum" ).type() == E57_FLOAT )
+         else if ( bbox.get( "xMinimum" ).type() == TypeFloat )
          {
             data3DHeader.cartesianBounds.xMinimum = FloatNode( bbox.get( "xMinimum" ) ).value();
             data3DHeader.cartesianBounds.xMaximum = FloatNode( bbox.get( "xMaximum" ) ).value();
@@ -740,36 +740,36 @@ namespace e57
       {
          const StructureNode sbox( scan.get( "sphericalBounds" ) );
 
-         if ( sbox.get( "rangeMinimum" ).type() == E57_SCALED_INTEGER )
+         if ( sbox.get( "rangeMinimum" ).type() == TypeScaledInteger )
          {
             data3DHeader.sphericalBounds.rangeMinimum = ScaledIntegerNode( sbox.get( "rangeMinimum" ) ).scaledValue();
             data3DHeader.sphericalBounds.rangeMaximum = ScaledIntegerNode( sbox.get( "rangeMaximum" ) ).scaledValue();
          }
-         else if ( sbox.get( "rangeMinimum" ).type() == E57_FLOAT )
+         else if ( sbox.get( "rangeMinimum" ).type() == TypeFloat )
          {
             data3DHeader.sphericalBounds.rangeMinimum = FloatNode( sbox.get( "rangeMinimum" ) ).value();
             data3DHeader.sphericalBounds.rangeMaximum = FloatNode( sbox.get( "rangeMaximum" ) ).value();
          }
 
-         if ( sbox.get( "elevationMinimum" ).type() == E57_SCALED_INTEGER )
+         if ( sbox.get( "elevationMinimum" ).type() == TypeScaledInteger )
          {
             data3DHeader.sphericalBounds.elevationMinimum =
                ScaledIntegerNode( sbox.get( "elevationMinimum" ) ).scaledValue();
             data3DHeader.sphericalBounds.elevationMaximum =
                ScaledIntegerNode( sbox.get( "elevationMaximum" ) ).scaledValue();
          }
-         else if ( sbox.get( "elevationMinimum" ).type() == E57_FLOAT )
+         else if ( sbox.get( "elevationMinimum" ).type() == TypeFloat )
          {
             data3DHeader.sphericalBounds.elevationMinimum = FloatNode( sbox.get( "elevationMinimum" ) ).value();
             data3DHeader.sphericalBounds.elevationMaximum = FloatNode( sbox.get( "elevationMaximum" ) ).value();
          }
 
-         if ( sbox.get( "azimuthStart" ).type() == E57_SCALED_INTEGER )
+         if ( sbox.get( "azimuthStart" ).type() == TypeScaledInteger )
          {
             data3DHeader.sphericalBounds.azimuthStart = ScaledIntegerNode( sbox.get( "azimuthStart" ) ).scaledValue();
             data3DHeader.sphericalBounds.azimuthEnd = ScaledIntegerNode( sbox.get( "azimuthEnd" ) ).scaledValue();
          }
-         else if ( sbox.get( "azimuthStart" ).type() == E57_FLOAT )
+         else if ( sbox.get( "azimuthStart" ).type() == TypeFloat )
          {
             data3DHeader.sphericalBounds.azimuthStart = FloatNode( sbox.get( "azimuthStart" ) ).value();
             data3DHeader.sphericalBounds.azimuthEnd = FloatNode( sbox.get( "azimuthEnd" ) ).value();
@@ -841,7 +841,7 @@ namespace e57
       {
          const auto cartesianXProto = proto.get( "cartesianX" );
 
-         if ( cartesianXProto.type() == E57_SCALED_INTEGER )
+         if ( cartesianXProto.type() == TypeScaledInteger )
          {
             const ScaledIntegerNode scaledCartesianX( cartesianXProto );
             const double scale = scaledCartesianX.scale();
@@ -853,14 +853,14 @@ namespace e57
             data3DHeader.pointFields.pointRangeMaximum = static_cast<double>( maximum ) * scale + offset;
             data3DHeader.pointFields.pointRangeScaledInteger = scale;
          }
-         else if ( cartesianXProto.type() == E57_FLOAT )
+         else if ( cartesianXProto.type() == TypeFloat )
          {
             const FloatNode floatCartesianX( cartesianXProto );
 
             data3DHeader.pointFields.pointRangeMinimum = floatCartesianX.minimum();
             data3DHeader.pointFields.pointRangeMaximum = floatCartesianX.maximum();
 
-            if ( floatCartesianX.precision() == E57_DOUBLE )
+            if ( floatCartesianX.precision() == PrecisionDouble )
             {
                data3DHeader.pointFields.pointRangeScaledInteger = -1.0;
             }
@@ -870,7 +870,7 @@ namespace e57
       {
          const auto sphericalRangeProto = proto.get( "sphericalRange" );
 
-         if ( sphericalRangeProto.type() == E57_SCALED_INTEGER )
+         if ( sphericalRangeProto.type() == TypeScaledInteger )
          {
             const ScaledIntegerNode scaledSphericalRange( sphericalRangeProto );
             const double scale = scaledSphericalRange.scale();
@@ -882,14 +882,14 @@ namespace e57
             data3DHeader.pointFields.pointRangeMaximum = static_cast<double>( maximum ) * scale + offset;
             data3DHeader.pointFields.pointRangeScaledInteger = scale;
          }
-         else if ( sphericalRangeProto.type() == E57_FLOAT )
+         else if ( sphericalRangeProto.type() == TypeFloat )
          {
             const FloatNode floatSphericalRange( sphericalRangeProto );
 
             data3DHeader.pointFields.pointRangeMinimum = floatSphericalRange.minimum();
             data3DHeader.pointFields.pointRangeMaximum = floatSphericalRange.maximum();
 
-            if ( floatSphericalRange.precision() == E57_DOUBLE )
+            if ( floatSphericalRange.precision() == PrecisionDouble )
             {
                data3DHeader.pointFields.pointRangeScaledInteger = -1.0;
             }
@@ -908,7 +908,7 @@ namespace e57
       {
          const auto sphericalAzimuthProto = proto.get( "sphericalAzimuth" );
 
-         if ( sphericalAzimuthProto.type() == E57_SCALED_INTEGER )
+         if ( sphericalAzimuthProto.type() == TypeScaledInteger )
          {
             const ScaledIntegerNode scaledSphericalAzimuth( sphericalAzimuthProto );
             const double scale = scaledSphericalAzimuth.scale();
@@ -920,14 +920,14 @@ namespace e57
             data3DHeader.pointFields.angleMaximum = static_cast<double>( maximum ) * scale + offset;
             data3DHeader.pointFields.angleScaledInteger = scale;
          }
-         else if ( sphericalAzimuthProto.type() == E57_FLOAT )
+         else if ( sphericalAzimuthProto.type() == TypeFloat )
          {
             const FloatNode floatSphericalAzimuth( sphericalAzimuthProto );
 
             data3DHeader.pointFields.angleMinimum = floatSphericalAzimuth.minimum();
             data3DHeader.pointFields.angleMaximum = floatSphericalAzimuth.maximum();
 
-            if ( floatSphericalAzimuth.precision() == E57_DOUBLE )
+            if ( floatSphericalAzimuth.precision() == PrecisionDouble )
             {
                data3DHeader.pointFields.angleScaledInteger = -1.0;
             }
@@ -970,7 +970,7 @@ namespace e57
       {
          const auto timeStampProto = proto.get( "timeStamp" );
 
-         if ( timeStampProto.type() == E57_INTEGER )
+         if ( timeStampProto.type() == TypeInteger )
          {
             const IntegerNode integerTimeStamp( timeStampProto );
 
@@ -978,7 +978,7 @@ namespace e57
             data3DHeader.pointFields.timeMinimum = static_cast<double>( integerTimeStamp.minimum() );
             data3DHeader.pointFields.timeScaledInteger = -1.0;
          }
-         else if ( timeStampProto.type() == E57_SCALED_INTEGER )
+         else if ( timeStampProto.type() == TypeScaledInteger )
          {
             const ScaledIntegerNode scaledTimeStamp( timeStampProto );
 
@@ -991,7 +991,7 @@ namespace e57
             data3DHeader.pointFields.timeMaximum = static_cast<double>( maximum ) * scale + offset;
             data3DHeader.pointFields.timeScaledInteger = scale;
          }
-         else if ( timeStampProto.type() == E57_FLOAT )
+         else if ( timeStampProto.type() == TypeFloat )
          {
             const FloatNode floatTimeStamp( timeStampProto );
 
@@ -1011,17 +1011,17 @@ namespace e57
          const auto intensityMaximumProto = intbox.get( "intensityMaximum" );
          const auto intensityMinimumProto = intbox.get( "intensityMinimum" );
 
-         if ( intensityMaximumProto.type() == E57_SCALED_INTEGER )
+         if ( intensityMaximumProto.type() == TypeScaledInteger )
          {
             data3DHeader.intensityLimits.intensityMaximum = ScaledIntegerNode( intensityMaximumProto ).scaledValue();
             data3DHeader.intensityLimits.intensityMinimum = ScaledIntegerNode( intensityMinimumProto ).scaledValue();
          }
-         else if ( intensityMaximumProto.type() == E57_FLOAT )
+         else if ( intensityMaximumProto.type() == TypeFloat )
          {
             data3DHeader.intensityLimits.intensityMaximum = FloatNode( intensityMaximumProto ).value();
             data3DHeader.intensityLimits.intensityMinimum = FloatNode( intensityMinimumProto ).value();
          }
-         else if ( intensityMaximumProto.type() == E57_INTEGER )
+         else if ( intensityMaximumProto.type() == TypeInteger )
          {
             data3DHeader.intensityLimits.intensityMaximum =
                static_cast<double>( IntegerNode( intensityMaximumProto ).value() );
@@ -1034,7 +1034,7 @@ namespace e57
       {
          const auto intensityProto = proto.get( "intensity" );
 
-         if ( intensityProto.type() == E57_INTEGER )
+         if ( intensityProto.type() == TypeInteger )
          {
             const IntegerNode integerIntensity( intensityProto );
 
@@ -1046,7 +1046,7 @@ namespace e57
 
             data3DHeader.pointFields.intensityScaledInteger = E57_NOT_SCALED_USE_INTEGER;
          }
-         else if ( intensityProto.type() == E57_SCALED_INTEGER )
+         else if ( intensityProto.type() == TypeScaledInteger )
          {
             const ScaledIntegerNode scaledIntensity( intensityProto );
             double scale = scaledIntensity.scale();
@@ -1063,7 +1063,7 @@ namespace e57
 
             data3DHeader.pointFields.intensityScaledInteger = scale;
          }
-         else if ( proto.get( "intensity" ).type() == E57_FLOAT )
+         else if ( proto.get( "intensity" ).type() == TypeFloat )
          {
             if ( data3DHeader.intensityLimits.intensityMaximum == 0.0 )
             {
@@ -1093,7 +1093,7 @@ namespace e57
       {
          const StructureNode colorbox( scan.get( "colorLimits" ) );
 
-         if ( colorbox.get( "colorRedMaximum" ).type() == E57_SCALED_INTEGER )
+         if ( colorbox.get( "colorRedMaximum" ).type() == TypeScaledInteger )
          {
             data3DHeader.colorLimits.colorRedMaximum =
                ScaledIntegerNode( colorbox.get( "colorRedMaximum" ) ).scaledValue();
@@ -1108,7 +1108,7 @@ namespace e57
             data3DHeader.colorLimits.colorBlueMinimum =
                ScaledIntegerNode( colorbox.get( "colorBlueMinimum" ) ).scaledValue();
          }
-         else if ( colorbox.get( "colorRedMaximum" ).type() == E57_FLOAT )
+         else if ( colorbox.get( "colorRedMaximum" ).type() == TypeFloat )
          {
             data3DHeader.colorLimits.colorRedMaximum = FloatNode( colorbox.get( "colorRedMaximum" ) ).value();
             data3DHeader.colorLimits.colorRedMinimum = FloatNode( colorbox.get( "colorRedMinimum" ) ).value();
@@ -1117,7 +1117,7 @@ namespace e57
             data3DHeader.colorLimits.colorBlueMaximum = FloatNode( colorbox.get( "colorBlueMaximum" ) ).value();
             data3DHeader.colorLimits.colorBlueMinimum = FloatNode( colorbox.get( "colorBlueMinimum" ) ).value();
          }
-         else if ( colorbox.get( "colorRedMaximum" ).type() == E57_INTEGER )
+         else if ( colorbox.get( "colorRedMaximum" ).type() == TypeInteger )
          {
             data3DHeader.colorLimits.colorRedMaximum =
                static_cast<double>( IntegerNode( colorbox.get( "colorRedMaximum" ) ).value() );
@@ -1345,7 +1345,7 @@ namespace e57
       {
          const ustring name = proto.get( protoIndex ).elementName();
          const NodeType type = proto.get( protoIndex ).type();
-         const bool scaled = ( type == E57_SCALED_INTEGER );
+         const bool scaled = ( type == TypeScaledInteger );
 
          // E57_EXT_surface_normals
          ustring norExtUri;

--- a/src/ScaledIntegerNode.cpp
+++ b/src/ScaledIntegerNode.cpp
@@ -103,11 +103,11 @@ true).
 destImageFile.isWritable() must be true).
 @pre     minimum <= rawValue <= maximum
 @pre     scale != 0
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_FILE_IS_READ_ONLY
-@throw   ::E57_ERROR_VALUE_OUT_OF_BOUNDS
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorFileReadOnly
+@throw   ::ErrorValueOutOfBounds
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ScaledIntegerNode::rawValue, Node, CompressedVectorNode, CompressedVectorNode::prototype
 */
 ScaledIntegerNode::ScaledIntegerNode( ImageFile destImageFile, int64_t rawValue, int64_t minimum, int64_t maximum,
@@ -160,11 +160,11 @@ true).
 destImageFile.isWritable() must be true).
 @pre     scaledMinimum <= scaledValue <= scaledMaximum
 @pre     scale != 0
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_FILE_IS_READ_ONLY
-@throw   ::E57_ERROR_VALUE_OUT_OF_BOUNDS
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorFileReadOnly
+@throw   ::ErrorValueOutOfBounds
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ScaledIntegerNode::scaledValue, Node, CompressedVectorNode, CompressedVectorNode::prototype
 */
 ScaledIntegerNode::ScaledIntegerNode( ImageFile destImageFile, double scaledValue, double scaledMinimum,
@@ -221,8 +221,8 @@ bool ScaledIntegerNode::isAttached() const
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  The raw unscaled integer value stored.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ScaledIntegerNode::scaledValue, ScaledIntegerNode::minimum, ScaledIntegerNode::maximum
 */
 int64_t ScaledIntegerNode::rawValue() const
@@ -236,8 +236,8 @@ int64_t ScaledIntegerNode::rawValue() const
 @post    No visible state is modified.
 @return  The scaled value (rawValue*scale + offset) calculated from the rawValue
 stored.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ScaledIntegerNode::rawValue
 */
 double ScaledIntegerNode::scaledValue() const
@@ -250,8 +250,8 @@ double ScaledIntegerNode::scaledValue() const
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  The declared minimum that the rawValue may take.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ScaledIntegerNode::maximum, ScaledIntegerNode::rawValue
 */
 int64_t ScaledIntegerNode::minimum() const
@@ -264,8 +264,8 @@ int64_t ScaledIntegerNode::minimum() const
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  The declared minimum that the rawValue may take.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ScaledIntegerNode::scaledMaximum, ScaledIntegerNode::scaledValue
 */
 double ScaledIntegerNode::scaledMinimum() const
@@ -278,8 +278,8 @@ double ScaledIntegerNode::scaledMinimum() const
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  The declared maximum that the rawValue may take.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ScaledIntegerNode::minimum, ScaledIntegerNode::rawValue
 */
 int64_t ScaledIntegerNode::maximum() const
@@ -292,8 +292,8 @@ int64_t ScaledIntegerNode::maximum() const
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  The declared maximum that the rawValue may take.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ScaledIntegerNode::scaledMinimum, ScaledIntegerNode::scaledValue
 */
 double ScaledIntegerNode::scaledMaximum() const // Added by SC
@@ -306,8 +306,8 @@ double ScaledIntegerNode::scaledMaximum() const // Added by SC
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  The scaling factor used to compute scaledValue from rawValue.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ScaledIntegerNode::scaledValue
 */
 double ScaledIntegerNode::scale() const
@@ -320,8 +320,8 @@ double ScaledIntegerNode::scale() const
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  The offset used to compute scaledValue from rawValue.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ScaledIntegerNode::scaledValue
 */
 double ScaledIntegerNode::offset() const
@@ -364,19 +364,19 @@ void ScaledIntegerNode::checkInvariant( bool /*doRecurse*/, bool doUpcast )
    // If value is out of bounds
    if ( rawValue() < minimum() || rawValue() > maximum() )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // If scale is zero
    if ( scale() == 0 )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 
    // If scaled value is not calculated correctly
    if ( scaledValue() != rawValue() * scale() + offset() )
    {
-      throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 }
 // endExample ScaledIntegerNode::checkInvariant
@@ -404,14 +404,14 @@ an exception is thrown. In designs that need to avoid the exception, use
 Node::type() to determine the actual type of the @a n before downcasting. This
 function must be explicitly called (c++ compiler cannot insert it
 automatically).
-@throw   ::E57_ERROR_BAD_NODE_DOWNCAST
+@throw   ::ErrorBadNodeDowncast
 @see     Node::type(), ScaledIntegerNode::operator, Node()
 */
 ScaledIntegerNode::ScaledIntegerNode( const Node &n )
 {
-   if ( n.type() != E57_SCALED_INTEGER )
+   if ( n.type() != TypeScaledInteger )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_NODE_DOWNCAST, "nodeType=" + toString( n.type() ) );
+      throw E57_EXCEPTION2( ErrorBadNodeDowncast, "nodeType=" + toString( n.type() ) );
    }
 
    /// Set our shared_ptr to the downcast shared_ptr

--- a/src/ScaledIntegerNodeImpl.cpp
+++ b/src/ScaledIntegerNodeImpl.cpp
@@ -43,7 +43,7 @@ namespace e57
       /// Enforce the given bounds on raw value
       if ( rawValue < minimum || maximum < rawValue )
       {
-         throw E57_EXCEPTION2( E57_ERROR_VALUE_OUT_OF_BOUNDS,
+         throw E57_EXCEPTION2( ErrorValueOutOfBounds,
                                "this->pathName=" + this->pathName() + " rawValue=" + toString( rawValue ) +
                                   " minimum=" + toString( minimum ) + " maximum=" + toString( maximum ) );
       }
@@ -63,10 +63,10 @@ namespace e57
       /// Enforce the given bounds on raw value
       if ( scaledValue < scaledMinimum || scaledMaximum < scaledValue )
       {
-         throw E57_EXCEPTION2( E57_ERROR_VALUE_OUT_OF_BOUNDS, "this->pathName=" + this->pathName() +
-                                                                 " scaledValue=" + toString( scaledValue ) +
-                                                                 " scaledMinimum=" + toString( scaledMinimum ) +
-                                                                 " scaledMaximum=" + toString( scaledMaximum ) );
+         throw E57_EXCEPTION2( ErrorValueOutOfBounds, "this->pathName=" + this->pathName() +
+                                                         " scaledValue=" + toString( scaledValue ) +
+                                                         " scaledMinimum=" + toString( scaledMinimum ) +
+                                                         " scaledMaximum=" + toString( scaledMaximum ) );
       }
    }
 
@@ -75,7 +75,7 @@ namespace e57
       // don't checkImageFileOpen
 
       /// Same node type?
-      if ( ni->type() != E57_SCALED_INTEGER )
+      if ( ni->type() != TypeScaledInteger )
       {
          return ( false );
       }
@@ -176,7 +176,7 @@ namespace e57
       /// We are a leaf node, so verify that we are listed in set.
       if ( pathNames.find( relativePathName( origin ) ) == pathNames.end() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_NO_BUFFER_FOR_ELEMENT, "this->pathName=" + this->pathName() );
+         throw E57_EXCEPTION2( ErrorNoBufferForElement, "this->pathName=" + this->pathName() );
       }
    }
 
@@ -198,11 +198,11 @@ namespace e57
       cf << space( indent ) << "<" << fieldName << " type=\"ScaledInteger\"";
 
       /// Don't need to write if are default values
-      if ( minimum_ != E57_INT64_MIN )
+      if ( minimum_ != INT64_MIN )
       {
          cf << " minimum=\"" << minimum_ << "\"";
       }
-      if ( maximum_ != E57_INT64_MAX )
+      if ( maximum_ != INT64_MAX )
       {
          cf << " maximum=\"" << maximum_ << "\"";
       }

--- a/src/ScaledIntegerNodeImpl.h
+++ b/src/ScaledIntegerNodeImpl.h
@@ -44,7 +44,7 @@ namespace e57
 
       NodeType type() const override
       {
-         return E57_SCALED_INTEGER;
+         return TypeScaledInteger;
       }
 
       bool isTypeEquivalent( NodeImplSharedPtr ni ) override;

--- a/src/SectionHeaders.cpp
+++ b/src/SectionHeaders.cpp
@@ -53,36 +53,35 @@ namespace e57
       {
          if ( reserved1[i] != 0 )
          {
-            throw E57_EXCEPTION2( E57_ERROR_BAD_CV_HEADER,
-                                  "i=" + toString( i ) + " reserved=" + toString( reserved1[i] ) );
+            throw E57_EXCEPTION2( ErrorBadCVHeader, "i=" + toString( i ) + " reserved=" + toString( reserved1[i] ) );
          }
       }
 
       /// Check section length is multiple of 4
       if ( sectionLogicalLength % 4 )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_CV_HEADER, "sectionLogicalLength=" + toString( sectionLogicalLength ) );
+         throw E57_EXCEPTION2( ErrorBadCVHeader, "sectionLogicalLength=" + toString( sectionLogicalLength ) );
       }
 
       /// Check sectionLogicalLength is in bounds
       if ( filePhysicalSize > 0 && sectionLogicalLength >= filePhysicalSize )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_CV_HEADER, "sectionLogicalLength=" + toString( sectionLogicalLength ) +
-                                                           " filePhysicalSize=" + toString( filePhysicalSize ) );
+         throw E57_EXCEPTION2( ErrorBadCVHeader, "sectionLogicalLength=" + toString( sectionLogicalLength ) +
+                                                    " filePhysicalSize=" + toString( filePhysicalSize ) );
       }
 
       /// Check dataPhysicalOffset is in bounds
       if ( filePhysicalSize > 0 && dataPhysicalOffset >= filePhysicalSize )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_CV_HEADER, "dataPhysicalOffset=" + toString( dataPhysicalOffset ) +
-                                                           " filePhysicalSize=" + toString( filePhysicalSize ) );
+         throw E57_EXCEPTION2( ErrorBadCVHeader, "dataPhysicalOffset=" + toString( dataPhysicalOffset ) +
+                                                    " filePhysicalSize=" + toString( filePhysicalSize ) );
       }
 
       /// Check indexPhysicalOffset is in bounds
       if ( filePhysicalSize > 0 && indexPhysicalOffset >= filePhysicalSize )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_CV_HEADER, "indexPhysicalOffset=" + toString( indexPhysicalOffset ) +
-                                                           " filePhysicalSize=" + toString( filePhysicalSize ) );
+         throw E57_EXCEPTION2( ErrorBadCVHeader, "indexPhysicalOffset=" + toString( indexPhysicalOffset ) +
+                                                    " filePhysicalSize=" + toString( filePhysicalSize ) );
       }
    }
 

--- a/src/SourceDestBuffer.cpp
+++ b/src/SourceDestBuffer.cpp
@@ -116,11 +116,11 @@ participate in a transfer with a CompressedVectorNode.
 @pre     The @a destImageFile must be open (i.e. destImageFile.isOpen() must be
 true).
 @pre     The stride must be >= sizeof(*b)
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_BAD_PATH_NAME
-@throw   ::E57_ERROR_BAD_BUFFER
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorBadPathName
+@throw   ::ErrorBadBuffer
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ImageFile::reader, ImageFile::writer,
 CompressedVectorReader::read(std::vector<SourceDestBuffer>&),
 CompressedVectorWriter::write(std::vector<SourceDestBuffer>&)
@@ -214,14 +214,10 @@ SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &path
 }
 
 /*!
-@brief   Designate vector of strings to transfer data to/from a CompressedVector
-as a block.
-@param   [in] destImageFile The ImageFile where the new node will eventually be
-stored.
-@param   [in] pathName      The pathname of the field in CompressedVectorNode
-that will transfer data to/from.
-@param   [in] b             The caller created vector of ustrings to transfer
-from/to.
+@brief   Designate vector of strings to transfer data to/from a CompressedVector as a block.
+@param   [in] destImageFile The ImageFile where the new node will eventually be stored.
+@param   [in] pathName      The pathname of the field in CompressedVectorNode that will transfer data to/from.
+@param   [in] b             The caller created vector of ustrings to transfer from/to.
 @details
 This overloaded form of the SourceDestBuffer constructor declares a
 vector<ustring> to be the source/destination of a transfer of StringNode values
@@ -245,11 +241,11 @@ Foundation Implementation cannot detect that the buffer been destroyed).
 @pre     b.size() must be > 0.
 @pre     The @a destImageFile must be open (i.e. destImageFile.isOpen() must be
 true).
-@throw   ::E57_ERROR_BAD_API_ARGUMENT
-@throw   ::E57_ERROR_BAD_PATH_NAME
-@throw   ::E57_ERROR_BAD_BUFFER
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadAPIArgument
+@throw   ::ErrorBadPathName
+@throw   ::ErrorBadBuffer
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     SourceDestBuffer::doConversion for discussion on representations compatible with string SourceDestBuffers.
 */
 SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, std::vector<ustring> *b ) :
@@ -273,7 +269,7 @@ CompressedVectorReader::read(std::vector<SourceDestBuffer>&)).
 @post    No visible state is modified.
 @return  Path name in prototype that this SourceDestBuffer will transfer data
 to/from.
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     CompressedVector, CompressedVectorNode::prototype
 */
 ustring SourceDestBuffer::pathName() const
@@ -288,17 +284,17 @@ The memory representation is deduced from which overloaded SourceDestBuffer
 constructor was used. The memory representation is independent of the type and
 minimum/maximum bounds of the node in the prototype that the SourceDestBuffer
 will transfer to/from. However, some combinations will result in an error if
-doConversion is not requested (e.g. E57_INT16 and FloatNode).
+doConversion is not requested (e.g. ::Int16 and FloatNode).
 
 Some combinations risk an error occurring during a write, if a value is too
-large (e.g. writing a E57_INT16 memory representation to an IntegerNode with
+large (e.g. writing an ::Int16 memory representation to an IntegerNode with
 minimum=-1024 maximum=1023). Some combinations risk an error occurring during a
 read, if a value is too large (e.g. reading an IntegerNode with minimum=-1024
-maximum=1023 int an E57_INT8 memory representation). Some combinations are never
-possible (e.g. E57_INT16 and StringNode).
+maximum=1023 int an ::Int8 memory representation). Some combinations are never
+possible (e.g. ::Int16 and StringNode).
 @post    No visible state is modified.
 @return  Memory representation of the elements in buffer.
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     MemoryRepresentation, NodeType
 */
 MemoryRepresentation SourceDestBuffer::memoryRepresentation() const
@@ -314,7 +310,7 @@ buffer. This function returns that declared length. If the length is incorrect
 (in particular, too long) memory may be corrupted or erroneous values written.
 @post    No visible state is modified.
 @return  Total capacity of buffer.
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorInternal           All objects in undocumented state
 */
 size_t SourceDestBuffer::capacity() const
 {
@@ -347,8 +343,8 @@ CompressedVectorReader or CompressedVectorWriter is created).
 @post    No visible state is modified.
 @return  true if conversions will be performed to match the memory type of
 buffer.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 */
 bool SourceDestBuffer::doConversion() const
 {
@@ -384,7 +380,7 @@ will have a fractional part.
 
 @post    No visible state is modified.
 @return  true if scaling will be performed for ScaledInteger transfers.
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ScaledIntegerNode
 */
 bool SourceDestBuffer::doScaling() const

--- a/src/SourceDestBufferImpl.cpp
+++ b/src/SourceDestBufferImpl.cpp
@@ -36,7 +36,7 @@ using namespace e57;
 SourceDestBufferImpl::SourceDestBufferImpl( ImageFileImplWeakPtr destImageFile, const ustring &pathName,
                                             const size_t capacity, bool doConversion, bool doScaling ) :
    destImageFile_( destImageFile ),
-   pathName_( pathName ), memoryRepresentation_( E57_INT32 ), capacity_( capacity ), doConversion_( doConversion ),
+   pathName_( pathName ), memoryRepresentation_( Int32 ), capacity_( capacity ), doConversion_( doConversion ),
    doScaling_( doScaling )
 {
 }
@@ -53,43 +53,43 @@ template <typename T> void SourceDestBufferImpl::setTypeInfo( T *base, size_t st
    // representation
    if ( std::is_same<T, int8_t>::value )
    {
-      memoryRepresentation_ = E57_INT8;
+      memoryRepresentation_ = Int8;
    }
    else if ( std::is_same<T, uint8_t>::value )
    {
-      memoryRepresentation_ = E57_UINT8;
+      memoryRepresentation_ = UInt8;
    }
    else if ( std::is_same<T, int16_t>::value )
    {
-      memoryRepresentation_ = E57_INT16;
+      memoryRepresentation_ = Int16;
    }
    else if ( std::is_same<T, uint16_t>::value )
    {
-      memoryRepresentation_ = E57_UINT16;
+      memoryRepresentation_ = UInt16;
    }
    else if ( std::is_same<T, int32_t>::value )
    {
-      memoryRepresentation_ = E57_INT32;
+      memoryRepresentation_ = Int32;
    }
    else if ( std::is_same<T, uint32_t>::value )
    {
-      memoryRepresentation_ = E57_UINT32;
+      memoryRepresentation_ = UInt32;
    }
    else if ( std::is_same<T, int64_t>::value )
    {
-      memoryRepresentation_ = E57_INT64;
+      memoryRepresentation_ = Int64;
    }
    else if ( std::is_same<T, bool>::value )
    {
-      memoryRepresentation_ = E57_BOOL;
+      memoryRepresentation_ = Bool;
    }
    else if ( std::is_same<T, float>::value )
    {
-      memoryRepresentation_ = E57_REAL32;
+      memoryRepresentation_ = Real32;
    }
    else if ( std::is_same<T, double>::value )
    {
-      memoryRepresentation_ = E57_REAL64;
+      memoryRepresentation_ = Real64;
    }
 
    checkState_();
@@ -109,14 +109,14 @@ template void SourceDestBufferImpl::setTypeInfo<double>( double *base, size_t st
 SourceDestBufferImpl::SourceDestBufferImpl( ImageFileImplWeakPtr destImageFile, const ustring &pathName,
                                             std::vector<ustring> *b ) :
    destImageFile_( destImageFile ),
-   pathName_( pathName ), memoryRepresentation_( E57_USTRING ), ustrings_( b )
+   pathName_( pathName ), memoryRepresentation_( UString ), ustrings_( b )
 {
    /// don't checkImageFileOpen, checkState_ will do it
 
    /// Set capacity_ after testing that b is OK
    if ( b == nullptr )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_BUFFER, "sdbuf.pathName=" + pathName );
+      throw E57_EXCEPTION2( ErrorBadBuffer, "sdbuf.pathName=" + pathName );
    }
 
    capacity_ = b->size();
@@ -138,7 +138,7 @@ template <typename T> void SourceDestBufferImpl::_setNextReal( T inValue )
    /// Verify have room
    if ( nextIndex_ >= capacity_ )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "pathName=" + pathName_ );
+      throw E57_EXCEPTION2( ErrorInternal, "pathName=" + pathName_ );
    }
 
    /// Calc start of memory location, index into buffer using stride_ (the
@@ -147,108 +147,108 @@ template <typename T> void SourceDestBufferImpl::_setNextReal( T inValue )
 
    switch ( memoryRepresentation_ )
    {
-      case E57_INT8:
+      case Int8:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          //??? fault if get special value: NaN, NegInf...  (all other ints below
          // too)
-         if ( inValue < E57_INT8_MIN || E57_INT8_MAX < inValue )
+         if ( inValue < INT8_MIN || INT8_MAX < inValue )
          {
-            throw E57_EXCEPTION2( E57_ERROR_VALUE_NOT_REPRESENTABLE,
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable,
                                   "pathName=" + pathName_ + " value=" + toString( inValue ) );
          }
          *reinterpret_cast<int8_t *>( p ) = static_cast<int8_t>( inValue );
          break;
-      case E57_UINT8:
+      case UInt8:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
-         if ( inValue < E57_UINT8_MIN || E57_UINT8_MAX < inValue )
+         if ( inValue < UINT8_MIN || UINT8_MAX < inValue )
          {
-            throw E57_EXCEPTION2( E57_ERROR_VALUE_NOT_REPRESENTABLE,
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable,
                                   "pathName=" + pathName_ + " value=" + toString( inValue ) );
          }
          *reinterpret_cast<uint8_t *>( p ) = static_cast<uint8_t>( inValue );
          break;
-      case E57_INT16:
+      case Int16:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
-         if ( inValue < E57_INT16_MIN || E57_INT16_MAX < inValue )
+         if ( inValue < INT16_MIN || INT16_MAX < inValue )
          {
-            throw E57_EXCEPTION2( E57_ERROR_VALUE_NOT_REPRESENTABLE,
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable,
                                   "pathName=" + pathName_ + " value=" + toString( inValue ) );
          }
          *reinterpret_cast<int16_t *>( p ) = static_cast<int16_t>( inValue );
          break;
-      case E57_UINT16:
+      case UInt16:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
-         if ( inValue < E57_UINT16_MIN || E57_UINT16_MAX < inValue )
+         if ( inValue < UINT16_MIN || UINT16_MAX < inValue )
          {
-            throw E57_EXCEPTION2( E57_ERROR_VALUE_NOT_REPRESENTABLE,
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable,
                                   "pathName=" + pathName_ + " value=" + toString( inValue ) );
          }
          *reinterpret_cast<uint16_t *>( p ) = static_cast<uint16_t>( inValue );
          break;
-      case E57_INT32:
+      case Int32:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
-         if ( inValue < E57_INT32_MIN || E57_INT32_MAX < inValue )
+         if ( inValue < INT32_MIN || INT32_MAX < inValue )
          {
-            throw E57_EXCEPTION2( E57_ERROR_VALUE_NOT_REPRESENTABLE,
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable,
                                   "pathName=" + pathName_ + " value=" + toString( inValue ) );
          }
          *reinterpret_cast<int32_t *>( p ) = static_cast<int32_t>( inValue );
          break;
-      case E57_UINT32:
+      case UInt32:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
-         if ( inValue < E57_UINT32_MIN || E57_UINT32_MAX < inValue )
+         if ( inValue < UINT32_MIN || UINT32_MAX < inValue )
          {
-            throw E57_EXCEPTION2( E57_ERROR_VALUE_NOT_REPRESENTABLE,
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable,
                                   "pathName=" + pathName_ + " value=" + toString( inValue ) );
          }
          *reinterpret_cast<uint32_t *>( p ) = static_cast<uint32_t>( inValue );
          break;
-      case E57_INT64:
+      case Int64:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
-         if ( inValue < E57_INT64_MIN || E57_INT64_MAX < inValue )
+         if ( inValue < INT64_MIN || INT64_MAX < inValue )
          {
-            throw E57_EXCEPTION2( E57_ERROR_VALUE_NOT_REPRESENTABLE,
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable,
                                   "pathName=" + pathName_ + " value=" + toString( inValue ) );
          }
          *reinterpret_cast<int64_t *>( p ) = static_cast<int64_t>( inValue );
          break;
-      case E57_BOOL:
+      case Bool:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          *reinterpret_cast<bool *>( p ) = ( inValue ? false : true );
          break;
-      case E57_REAL32:
+      case Real32:
          if ( std::is_same<T, double>::value )
          {
             /// Does this count as conversion?  It loses information.
             /// Check for really large exponents that can't fit in a single
             /// precision
-            if ( inValue < E57_DOUBLE_MIN || E57_DOUBLE_MAX < inValue )
+            if ( inValue < DOUBLE_MIN || DOUBLE_MAX < inValue )
             {
-               throw E57_EXCEPTION2( E57_ERROR_VALUE_NOT_REPRESENTABLE,
+               throw E57_EXCEPTION2( ErrorValueNotRepresentable,
                                      "pathName=" + pathName_ + " value=" + toString( inValue ) );
             }
             *reinterpret_cast<float *>( p ) = static_cast<float>( inValue );
@@ -265,12 +265,12 @@ template <typename T> void SourceDestBufferImpl::_setNextReal( T inValue )
 #endif
          }
          break;
-      case E57_REAL64:
+      case Real64:
          //??? does this count as a conversion?
          *reinterpret_cast<double *>( p ) = static_cast<double>( inValue );
          break;
-      case E57_USTRING:
-         throw E57_EXCEPTION2( E57_ERROR_EXPECTING_NUMERIC, "pathName=" + pathName_ );
+      case UString:
+         throw E57_EXCEPTION2( ErrorExpectingNumeric, "pathName=" + pathName_ );
    }
 
    nextIndex_++;
@@ -283,7 +283,7 @@ void SourceDestBufferImpl::checkState_() const
    ImageFileImplSharedPtr destImageFile( destImageFile_ );
    if ( !destImageFile->isOpen() )
    {
-      throw E57_EXCEPTION2( E57_ERROR_IMAGEFILE_NOT_OPEN, "fileName=" + destImageFile->fileName() );
+      throw E57_EXCEPTION2( ErrorImageFileNotOpen, "fileName=" + destImageFile->fileName() );
    }
 
    /// Check pathName is well formed (can't verify path is defined until
@@ -291,15 +291,15 @@ void SourceDestBufferImpl::checkState_() const
    ImageFileImplSharedPtr imf( destImageFile_ );
    imf->pathNameCheckWellFormed( pathName_ );
 
-   if ( memoryRepresentation_ != E57_USTRING )
+   if ( memoryRepresentation_ != UString )
    {
       if ( base_ == nullptr )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_BUFFER, "pathName=" + pathName_ );
+         throw E57_EXCEPTION2( ErrorBadBuffer, "pathName=" + pathName_ );
       }
       if ( stride_ == 0 )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_BUFFER, "pathName=" + pathName_ );
+         throw E57_EXCEPTION2( ErrorBadBuffer, "pathName=" + pathName_ );
       }
       //??? check base alignment, depending on CPU type
       //??? check if stride too small, positive or negative
@@ -308,7 +308,7 @@ void SourceDestBufferImpl::checkState_() const
    {
       if ( ustrings_ == nullptr )
       {
-         throw E57_EXCEPTION2( E57_ERROR_BAD_BUFFER, "pathName=" + pathName_ );
+         throw E57_EXCEPTION2( ErrorBadBuffer, "pathName=" + pathName_ );
       }
    }
 }
@@ -320,7 +320,7 @@ int64_t SourceDestBufferImpl::getNextInt64()
    /// Verify index is within bounds
    if ( nextIndex_ >= capacity_ )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "pathName=" + pathName_ );
+      throw E57_EXCEPTION2( ErrorInternal, "pathName=" + pathName_ );
    }
 
    /// Fetch value from source buffer.
@@ -329,55 +329,55 @@ int64_t SourceDestBufferImpl::getNextInt64()
    int64_t value;
    switch ( memoryRepresentation_ )
    {
-      case E57_INT8:
+      case Int8:
          value = static_cast<int64_t>( *reinterpret_cast<int8_t *>( p ) );
          break;
-      case E57_UINT8:
+      case UInt8:
          value = static_cast<int64_t>( *reinterpret_cast<uint8_t *>( p ) );
          break;
-      case E57_INT16:
+      case Int16:
          value = static_cast<int64_t>( *reinterpret_cast<int16_t *>( p ) );
          break;
-      case E57_UINT16:
+      case UInt16:
          value = static_cast<int64_t>( *reinterpret_cast<uint16_t *>( p ) );
          break;
-      case E57_INT32:
+      case Int32:
          value = static_cast<int64_t>( *reinterpret_cast<int32_t *>( p ) );
          break;
-      case E57_UINT32:
+      case UInt32:
          value = static_cast<int64_t>( *reinterpret_cast<uint32_t *>( p ) );
          break;
-      case E57_INT64:
+      case Int64:
          value = *reinterpret_cast<int64_t *>( p );
          break;
-      case E57_BOOL:
+      case Bool:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          /// Convert bool to 0/1, all non-zero values map to 1.0
          value = ( *reinterpret_cast<bool *>( p ) ) ? 1 : 0;
          break;
-      case E57_REAL32:
+      case Real32:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          //??? fault if get special value: NaN, NegInf...
          value = static_cast<int64_t>( *reinterpret_cast<float *>( p ) );
          break;
-      case E57_REAL64:
+      case Real64:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          //??? fault if get special value: NaN, NegInf...
          value = static_cast<int64_t>( *reinterpret_cast<double *>( p ) );
          break;
-      case E57_USTRING:
-         throw E57_EXCEPTION2( E57_ERROR_EXPECTING_NUMERIC, "pathName=" + pathName_ );
+      case UString:
+         throw E57_EXCEPTION2( ErrorExpectingNumeric, "pathName=" + pathName_ );
       default:
-         throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "pathName=" + pathName_ );
+         throw E57_EXCEPTION2( ErrorInternal, "pathName=" + pathName_ );
    }
    nextIndex_++;
    return ( value );
@@ -402,13 +402,13 @@ int64_t SourceDestBufferImpl::getNextInt64( double scale, double offset )
    /// Double check non-zero scale.  Going to divide by it below.
    if ( scale == 0 )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "pathName=" + pathName_ );
+      throw E57_EXCEPTION2( ErrorInternal, "pathName=" + pathName_ );
    }
 
    /// Verify index is within bounds
    if ( nextIndex_ >= capacity_ )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "pathName=" + pathName_ );
+      throw E57_EXCEPTION2( ErrorInternal, "pathName=" + pathName_ );
    }
 
    /// Fetch value from source buffer.
@@ -417,42 +417,42 @@ int64_t SourceDestBufferImpl::getNextInt64( double scale, double offset )
    double doubleRawValue;
    switch ( memoryRepresentation_ )
    {
-      case E57_INT8:
+      case Int8:
          /// Calc (x-offset)/scale rounded to nearest integer, but keep in
          /// floating point until sure is in bounds
          doubleRawValue = floor( ( *reinterpret_cast<int8_t *>( p ) - offset ) / scale + 0.5 );
          break;
-      case E57_UINT8:
+      case UInt8:
          /// Calc (x-offset)/scale rounded to nearest integer, but keep in
          /// floating point until sure is in bounds
          doubleRawValue = floor( ( *reinterpret_cast<uint8_t *>( p ) - offset ) / scale + 0.5 );
          break;
-      case E57_INT16:
+      case Int16:
          /// Calc (x-offset)/scale rounded to nearest integer, but keep in
          /// floating point until sure is in bounds
          doubleRawValue = floor( ( *reinterpret_cast<int16_t *>( p ) - offset ) / scale + 0.5 );
          break;
-      case E57_UINT16:
+      case UInt16:
          /// Calc (x-offset)/scale rounded to nearest integer, but keep in
          /// floating point until sure is in bounds
          doubleRawValue = floor( ( *reinterpret_cast<uint16_t *>( p ) - offset ) / scale + 0.5 );
          break;
-      case E57_INT32:
+      case Int32:
          /// Calc (x-offset)/scale rounded to nearest integer, but keep in
          /// floating point until sure is in bounds
          doubleRawValue = floor( ( *reinterpret_cast<int32_t *>( p ) - offset ) / scale + 0.5 );
          break;
-      case E57_UINT32:
+      case UInt32:
          /// Calc (x-offset)/scale rounded to nearest integer, but keep in
          /// floating point until sure is in bounds
          doubleRawValue = floor( ( *reinterpret_cast<uint32_t *>( p ) - offset ) / scale + 0.5 );
          break;
-      case E57_INT64:
+      case Int64:
          /// Calc (x-offset)/scale rounded to nearest integer, but keep in
          /// floating point until sure is in bounds
          doubleRawValue = floor( ( *reinterpret_cast<int64_t *>( p ) - offset ) / scale + 0.5 );
          break;
-      case E57_BOOL:
+      case Bool:
          if ( *reinterpret_cast<bool *>( p ) )
          {
             doubleRawValue = floor( ( 1 - offset ) / scale + 0.5 );
@@ -462,10 +462,10 @@ int64_t SourceDestBufferImpl::getNextInt64( double scale, double offset )
             doubleRawValue = floor( ( 0 - offset ) / scale + 0.5 );
          }
          break;
-      case E57_REAL32:
+      case Real32:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          //??? fault if get special value: NaN, NegInf...
 
@@ -473,10 +473,10 @@ int64_t SourceDestBufferImpl::getNextInt64( double scale, double offset )
          /// floating point until sure is in bounds
          doubleRawValue = floor( ( *reinterpret_cast<float *>( p ) - offset ) / scale + 0.5 );
          break;
-      case E57_REAL64:
+      case Real64:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          //??? fault if get special value: NaN, NegInf...
 
@@ -484,15 +484,15 @@ int64_t SourceDestBufferImpl::getNextInt64( double scale, double offset )
          /// floating point until sure is in bounds
          doubleRawValue = floor( ( *reinterpret_cast<double *>( p ) - offset ) / scale + 0.5 );
          break;
-      case E57_USTRING:
-         throw E57_EXCEPTION2( E57_ERROR_EXPECTING_NUMERIC, "pathName=" + pathName_ );
+      case UString:
+         throw E57_EXCEPTION2( ErrorExpectingNumeric, "pathName=" + pathName_ );
       default:
-         throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "pathName=" + pathName_ );
+         throw E57_EXCEPTION2( ErrorInternal, "pathName=" + pathName_ );
    }
    /// Make sure that value is representable in an int64_t
-   if ( doubleRawValue < E57_INT64_MIN || E57_INT64_MAX < doubleRawValue )
+   if ( doubleRawValue < INT64_MIN || INT64_MAX < doubleRawValue )
    {
-      throw E57_EXCEPTION2( E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE,
+      throw E57_EXCEPTION2( ErrorScaledValueNotRepresentable,
                             "pathName=" + pathName_ + " value=" + toString( doubleRawValue ) );
    }
 
@@ -509,7 +509,7 @@ float SourceDestBufferImpl::getNextFloat()
    /// Verify index is within bounds
    if ( nextIndex_ >= capacity_ )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "pathName=" + pathName_ );
+      throw E57_EXCEPTION2( ErrorInternal, "pathName=" + pathName_ );
    }
 
    /// Fetch value from source buffer.
@@ -518,85 +518,85 @@ float SourceDestBufferImpl::getNextFloat()
    float value;
    switch ( memoryRepresentation_ )
    {
-      case E57_INT8:
+      case Int8:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          value = static_cast<float>( *reinterpret_cast<int8_t *>( p ) );
          break;
-      case E57_UINT8:
+      case UInt8:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          value = static_cast<float>( *reinterpret_cast<uint8_t *>( p ) );
          break;
-      case E57_INT16:
+      case Int16:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          value = static_cast<float>( *reinterpret_cast<int16_t *>( p ) );
          break;
-      case E57_UINT16:
+      case UInt16:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          value = static_cast<float>( *reinterpret_cast<uint16_t *>( p ) );
          break;
-      case E57_INT32:
+      case Int32:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          value = static_cast<float>( *reinterpret_cast<int32_t *>( p ) );
          break;
-      case E57_UINT32:
+      case UInt32:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          value = static_cast<float>( *reinterpret_cast<uint32_t *>( p ) );
          break;
-      case E57_INT64:
+      case Int64:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          value = static_cast<float>( *reinterpret_cast<int64_t *>( p ) );
          break;
-      case E57_BOOL:
+      case Bool:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
 
          /// Convert bool to 0/1, all non-zero values map to 1.0
          value = ( *reinterpret_cast<bool *>( p ) ) ? 1.0F : 0.0F;
          break;
-      case E57_REAL32:
+      case Real32:
          value = *reinterpret_cast<float *>( p );
          break;
-      case E57_REAL64:
+      case Real64:
       {
          /// Check that exponent of user's value is not too large for single
          /// precision number in file.
          double d = *reinterpret_cast<double *>( p );
 
          ///??? silently limit here?
-         if ( d < E57_DOUBLE_MIN || E57_DOUBLE_MAX < d )
+         if ( d < DOUBLE_MIN || DOUBLE_MAX < d )
          {
-            throw E57_EXCEPTION2( E57_ERROR_REAL64_TOO_LARGE, "pathName=" + pathName_ + " value=" + toString( d ) );
+            throw E57_EXCEPTION2( ErrorReal64TooLarge, "pathName=" + pathName_ + " value=" + toString( d ) );
          }
          value = static_cast<float>( d );
          break;
       }
-      case E57_USTRING:
-         throw E57_EXCEPTION2( E57_ERROR_EXPECTING_NUMERIC, "pathName=" + pathName_ );
+      case UString:
+         throw E57_EXCEPTION2( ErrorExpectingNumeric, "pathName=" + pathName_ );
       default:
-         throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "pathName=" + pathName_ );
+         throw E57_EXCEPTION2( ErrorInternal, "pathName=" + pathName_ );
    }
    nextIndex_++;
    return ( value );
@@ -609,7 +609,7 @@ double SourceDestBufferImpl::getNextDouble()
    /// Verify index is within bounds
    if ( nextIndex_ >= capacity_ )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "pathName=" + pathName_ );
+      throw E57_EXCEPTION2( ErrorInternal, "pathName=" + pathName_ );
    }
 
    /// Fetch value from source buffer.
@@ -618,73 +618,73 @@ double SourceDestBufferImpl::getNextDouble()
    double value;
    switch ( memoryRepresentation_ )
    {
-      case E57_INT8:
+      case Int8:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          value = static_cast<double>( *reinterpret_cast<int8_t *>( p ) );
          break;
-      case E57_UINT8:
+      case UInt8:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          value = static_cast<double>( *reinterpret_cast<uint8_t *>( p ) );
          break;
-      case E57_INT16:
+      case Int16:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          value = static_cast<double>( *reinterpret_cast<int16_t *>( p ) );
          break;
-      case E57_UINT16:
+      case UInt16:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          value = static_cast<double>( *reinterpret_cast<uint16_t *>( p ) );
          break;
-      case E57_INT32:
+      case Int32:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          value = static_cast<double>( *reinterpret_cast<int32_t *>( p ) );
          break;
-      case E57_UINT32:
+      case UInt32:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          value = static_cast<double>( *reinterpret_cast<uint32_t *>( p ) );
          break;
-      case E57_INT64:
+      case Int64:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          value = static_cast<double>( *reinterpret_cast<int64_t *>( p ) );
          break;
-      case E57_BOOL:
+      case Bool:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          /// Convert bool to 0/1, all non-zero values map to 1.0
          value = ( *reinterpret_cast<bool *>( p ) ) ? 1.0 : 0.0;
          break;
-      case E57_REAL32:
+      case Real32:
          value = static_cast<double>( *reinterpret_cast<float *>( p ) );
          break;
-      case E57_REAL64:
+      case Real64:
          value = *reinterpret_cast<double *>( p );
          break;
-      case E57_USTRING:
-         throw E57_EXCEPTION2( E57_ERROR_EXPECTING_NUMERIC, "pathName=" + pathName_ );
+      case UString:
+         throw E57_EXCEPTION2( ErrorExpectingNumeric, "pathName=" + pathName_ );
       default:
-         throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "pathName=" + pathName_ );
+         throw E57_EXCEPTION2( ErrorInternal, "pathName=" + pathName_ );
    }
    nextIndex_++;
    return ( value );
@@ -695,15 +695,15 @@ ustring SourceDestBufferImpl::getNextString()
    /// don't checkImageFileOpen
 
    /// Check have correct type buffer
-   if ( memoryRepresentation_ != E57_USTRING )
+   if ( memoryRepresentation_ != UString )
    {
-      throw E57_EXCEPTION2( E57_ERROR_EXPECTING_USTRING, "pathName=" + pathName_ );
+      throw E57_EXCEPTION2( ErrorExpectingUString, "pathName=" + pathName_ );
    }
 
    /// Verify index is within bounds
    if ( nextIndex_ >= capacity_ )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "pathName=" + pathName_ );
+      throw E57_EXCEPTION2( ErrorInternal, "pathName=" + pathName_ );
    }
 
    /// Get ustring from vector
@@ -717,7 +717,7 @@ void SourceDestBufferImpl::setNextInt64( int64_t value )
    /// Verify have room
    if ( nextIndex_ >= capacity_ )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "pathName=" + pathName_ );
+      throw E57_EXCEPTION2( ErrorInternal, "pathName=" + pathName_ );
    }
 
    /// Calc start of memory location, index into buffer using stride_ (the
@@ -726,77 +726,71 @@ void SourceDestBufferImpl::setNextInt64( int64_t value )
 
    switch ( memoryRepresentation_ )
    {
-      case E57_INT8:
-         if ( value < E57_INT8_MIN || E57_INT8_MAX < value )
+      case Int8:
+         if ( value < INT8_MIN || INT8_MAX < value )
          {
-            throw E57_EXCEPTION2( E57_ERROR_VALUE_NOT_REPRESENTABLE,
-                                  "pathName=" + pathName_ + " value=" + toString( value ) );
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable, "pathName=" + pathName_ + " value=" + toString( value ) );
          }
          *reinterpret_cast<int8_t *>( p ) = static_cast<int8_t>( value );
          break;
-      case E57_UINT8:
-         if ( value < E57_UINT8_MIN || E57_UINT8_MAX < value )
+      case UInt8:
+         if ( value < UINT8_MIN || UINT8_MAX < value )
          {
-            throw E57_EXCEPTION2( E57_ERROR_VALUE_NOT_REPRESENTABLE,
-                                  "pathName=" + pathName_ + " value=" + toString( value ) );
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable, "pathName=" + pathName_ + " value=" + toString( value ) );
          }
          *reinterpret_cast<uint8_t *>( p ) = static_cast<uint8_t>( value );
          break;
-      case E57_INT16:
-         if ( value < E57_INT16_MIN || E57_INT16_MAX < value )
+      case Int16:
+         if ( value < INT16_MIN || INT16_MAX < value )
          {
-            throw E57_EXCEPTION2( E57_ERROR_VALUE_NOT_REPRESENTABLE,
-                                  "pathName=" + pathName_ + " value=" + toString( value ) );
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable, "pathName=" + pathName_ + " value=" + toString( value ) );
          }
          *reinterpret_cast<int16_t *>( p ) = static_cast<int16_t>( value );
          break;
-      case E57_UINT16:
-         if ( value < E57_UINT16_MIN || E57_UINT16_MAX < value )
+      case UInt16:
+         if ( value < UINT16_MIN || UINT16_MAX < value )
          {
-            throw E57_EXCEPTION2( E57_ERROR_VALUE_NOT_REPRESENTABLE,
-                                  "pathName=" + pathName_ + " value=" + toString( value ) );
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable, "pathName=" + pathName_ + " value=" + toString( value ) );
          }
          *reinterpret_cast<uint16_t *>( p ) = static_cast<uint16_t>( value );
          break;
-      case E57_INT32:
-         if ( value < E57_INT32_MIN || E57_INT32_MAX < value )
+      case Int32:
+         if ( value < INT32_MIN || INT32_MAX < value )
          {
-            throw E57_EXCEPTION2( E57_ERROR_VALUE_NOT_REPRESENTABLE,
-                                  "pathName=" + pathName_ + " value=" + toString( value ) );
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable, "pathName=" + pathName_ + " value=" + toString( value ) );
          }
          *reinterpret_cast<int32_t *>( p ) = static_cast<int32_t>( value );
          break;
-      case E57_UINT32:
-         if ( value < E57_UINT32_MIN || E57_UINT32_MAX < value )
+      case UInt32:
+         if ( value < UINT32_MIN || UINT32_MAX < value )
          {
-            throw E57_EXCEPTION2( E57_ERROR_VALUE_NOT_REPRESENTABLE,
-                                  "pathName=" + pathName_ + " value=" + toString( value ) );
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable, "pathName=" + pathName_ + " value=" + toString( value ) );
          }
          *reinterpret_cast<uint32_t *>( p ) = static_cast<uint32_t>( value );
          break;
-      case E57_INT64:
+      case Int64:
          *reinterpret_cast<int64_t *>( p ) = static_cast<int64_t>( value );
          break;
-      case E57_BOOL:
+      case Bool:
          *reinterpret_cast<bool *>( p ) = ( value ? false : true );
          break;
-      case E57_REAL32:
+      case Real32:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          //??? very large integers may lose some lowest bits here. error?
          *reinterpret_cast<float *>( p ) = static_cast<float>( value );
          break;
-      case E57_REAL64:
+      case Real64:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          *reinterpret_cast<double *>( p ) = static_cast<double>( value );
          break;
-      case E57_USTRING:
-         throw E57_EXCEPTION2( E57_ERROR_EXPECTING_NUMERIC, "pathName=" + pathName_ );
+      case UString:
+         throw E57_EXCEPTION2( ErrorExpectingNumeric, "pathName=" + pathName_ );
    }
 
    nextIndex_++;
@@ -822,7 +816,7 @@ void SourceDestBufferImpl::setNextInt64( int64_t value, double scale, double off
    /// Verify have room
    if ( nextIndex_ >= capacity_ )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "pathName=" + pathName_ );
+      throw E57_EXCEPTION2( ErrorInternal, "pathName=" + pathName_ );
    }
 
    /// Calc start of memory location, index into buffer using stride_ (the
@@ -831,7 +825,7 @@ void SourceDestBufferImpl::setNextInt64( int64_t value, double scale, double off
 
    /// Calc x*scale+offset
    double scaledValue;
-   if ( memoryRepresentation_ == E57_REAL32 || memoryRepresentation_ == E57_REAL64 )
+   if ( memoryRepresentation_ == Real32 || memoryRepresentation_ == Real64 )
    {
       /// Value will be stored in some floating point rep in user's buffer, so
       /// keep full resolution here.
@@ -847,83 +841,83 @@ void SourceDestBufferImpl::setNextInt64( int64_t value, double scale, double off
 
    switch ( memoryRepresentation_ )
    {
-      case E57_INT8:
-         if ( scaledValue < E57_INT8_MIN || E57_INT8_MAX < scaledValue )
+      case Int8:
+         if ( scaledValue < INT8_MIN || INT8_MAX < scaledValue )
          {
-            throw E57_EXCEPTION2( E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE,
+            throw E57_EXCEPTION2( ErrorScaledValueNotRepresentable,
                                   "pathName=" + pathName_ + " scaledValue=" + toString( scaledValue ) );
          }
          *reinterpret_cast<int8_t *>( p ) = static_cast<int8_t>( scaledValue );
          break;
-      case E57_UINT8:
-         if ( scaledValue < E57_UINT8_MIN || E57_UINT8_MAX < scaledValue )
+      case UInt8:
+         if ( scaledValue < UINT8_MIN || UINT8_MAX < scaledValue )
          {
-            throw E57_EXCEPTION2( E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE,
+            throw E57_EXCEPTION2( ErrorScaledValueNotRepresentable,
                                   "pathName=" + pathName_ + " scaledValue=" + toString( scaledValue ) );
          }
          *reinterpret_cast<uint8_t *>( p ) = static_cast<uint8_t>( scaledValue );
          break;
-      case E57_INT16:
-         if ( scaledValue < E57_INT16_MIN || E57_INT16_MAX < scaledValue )
+      case Int16:
+         if ( scaledValue < INT16_MIN || INT16_MAX < scaledValue )
          {
-            throw E57_EXCEPTION2( E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE,
+            throw E57_EXCEPTION2( ErrorScaledValueNotRepresentable,
                                   "pathName=" + pathName_ + " scaledValue=" + toString( scaledValue ) );
          }
          *reinterpret_cast<int16_t *>( p ) = static_cast<int16_t>( scaledValue );
          break;
-      case E57_UINT16:
-         if ( scaledValue < E57_UINT16_MIN || E57_UINT16_MAX < scaledValue )
+      case UInt16:
+         if ( scaledValue < UINT16_MIN || UINT16_MAX < scaledValue )
          {
-            throw E57_EXCEPTION2( E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE,
+            throw E57_EXCEPTION2( ErrorScaledValueNotRepresentable,
                                   "pathName=" + pathName_ + " scaledValue=" + toString( scaledValue ) );
          }
          *reinterpret_cast<uint16_t *>( p ) = static_cast<uint16_t>( scaledValue );
          break;
-      case E57_INT32:
-         if ( scaledValue < E57_INT32_MIN || E57_INT32_MAX < scaledValue )
+      case Int32:
+         if ( scaledValue < INT32_MIN || INT32_MAX < scaledValue )
          {
-            throw E57_EXCEPTION2( E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE,
+            throw E57_EXCEPTION2( ErrorScaledValueNotRepresentable,
                                   "pathName=" + pathName_ + " scaledValue=" + toString( scaledValue ) );
          }
          *reinterpret_cast<int32_t *>( p ) = static_cast<int32_t>( scaledValue );
          break;
-      case E57_UINT32:
-         if ( scaledValue < E57_UINT32_MIN || E57_UINT32_MAX < scaledValue )
+      case UInt32:
+         if ( scaledValue < UINT32_MIN || UINT32_MAX < scaledValue )
          {
-            throw E57_EXCEPTION2( E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE,
+            throw E57_EXCEPTION2( ErrorScaledValueNotRepresentable,
                                   "pathName=" + pathName_ + " scaledValue=" + toString( scaledValue ) );
          }
          *reinterpret_cast<uint32_t *>( p ) = static_cast<uint32_t>( scaledValue );
          break;
-      case E57_INT64:
+      case Int64:
          *reinterpret_cast<int64_t *>( p ) = static_cast<int64_t>( scaledValue );
          break;
-      case E57_BOOL:
+      case Bool:
          *reinterpret_cast<bool *>( p ) = ( scaledValue ? false : true );
          break;
-      case E57_REAL32:
+      case Real32:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          /// Check that exponent of result is not too big for single precision
          /// float
-         if ( scaledValue < E57_DOUBLE_MIN || E57_DOUBLE_MAX < scaledValue )
+         if ( scaledValue < DOUBLE_MIN || DOUBLE_MAX < scaledValue )
          {
-            throw E57_EXCEPTION2( E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE,
+            throw E57_EXCEPTION2( ErrorScaledValueNotRepresentable,
                                   "pathName=" + pathName_ + " scaledValue=" + toString( scaledValue ) );
          }
          *reinterpret_cast<float *>( p ) = static_cast<float>( scaledValue );
          break;
-      case E57_REAL64:
+      case Real64:
          if ( !doConversion_ )
          {
-            throw E57_EXCEPTION2( E57_ERROR_CONVERSION_REQUIRED, "pathName=" + pathName_ );
+            throw E57_EXCEPTION2( ErrorConversionRequired, "pathName=" + pathName_ );
          }
          *reinterpret_cast<double *>( p ) = scaledValue;
          break;
-      case E57_USTRING:
-         throw E57_EXCEPTION2( E57_ERROR_EXPECTING_NUMERIC, "pathName=" + pathName_ );
+      case UString:
+         throw E57_EXCEPTION2( ErrorExpectingNumeric, "pathName=" + pathName_ );
    }
 
    nextIndex_++;
@@ -943,15 +937,15 @@ void SourceDestBufferImpl::setNextString( const ustring &value )
 {
    /// don't checkImageFileOpen
 
-   if ( memoryRepresentation_ != E57_USTRING )
+   if ( memoryRepresentation_ != UString )
    {
-      throw E57_EXCEPTION2( E57_ERROR_EXPECTING_USTRING, "pathName=" + pathName_ );
+      throw E57_EXCEPTION2( ErrorExpectingUString, "pathName=" + pathName_ );
    }
 
    /// Verify have room.
    if ( nextIndex_ >= capacity_ )
    {
-      throw E57_EXCEPTION2( E57_ERROR_INTERNAL, "pathName=" + pathName_ );
+      throw E57_EXCEPTION2( ErrorInternal, "pathName=" + pathName_ );
    }
 
    /// Assign to already initialized element in vector
@@ -963,29 +957,27 @@ void SourceDestBufferImpl::checkCompatible( const std::shared_ptr<SourceDestBuff
 {
    if ( pathName_ != newBuf->pathName() )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BUFFERS_NOT_COMPATIBLE,
-                            "pathName=" + pathName_ + " newPathName=" + newBuf->pathName() );
+      throw E57_EXCEPTION2( ErrorBuffersNotCompatible, "pathName=" + pathName_ + " newPathName=" + newBuf->pathName() );
    }
    if ( memoryRepresentation_ != newBuf->memoryRepresentation() )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BUFFERS_NOT_COMPATIBLE,
+      throw E57_EXCEPTION2( ErrorBuffersNotCompatible,
                             "memoryRepresentation=" + toString( memoryRepresentation_ ) +
                                " newMemoryType=" + toString( newBuf->memoryRepresentation() ) );
    }
    if ( capacity_ != newBuf->capacity() )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BUFFERS_NOT_COMPATIBLE,
+      throw E57_EXCEPTION2( ErrorBuffersNotCompatible,
                             "capacity=" + toString( capacity_ ) + " newCapacity=" + toString( newBuf->capacity() ) );
    }
    if ( doConversion_ != newBuf->doConversion() )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BUFFERS_NOT_COMPATIBLE,
-                            "doConversion=" + toString( doConversion_ ) +
-                               "newDoConversion=" + toString( newBuf->doConversion() ) );
+      throw E57_EXCEPTION2( ErrorBuffersNotCompatible, "doConversion=" + toString( doConversion_ ) +
+                                                          "newDoConversion=" + toString( newBuf->doConversion() ) );
    }
    if ( stride_ != newBuf->stride() )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BUFFERS_NOT_COMPATIBLE,
+      throw E57_EXCEPTION2( ErrorBuffersNotCompatible,
                             "stride=" + toString( stride_ ) + " newStride=" + toString( newBuf->stride() ) );
    }
 }
@@ -999,37 +991,37 @@ void SourceDestBufferImpl::dump( int indent, std::ostream &os )
    os << space( indent ) << "memoryRepresentation: ";
    switch ( memoryRepresentation_ )
    {
-      case E57_INT8:
+      case Int8:
          os << "int8_t" << std::endl;
          break;
-      case E57_UINT8:
+      case UInt8:
          os << "uint8_t" << std::endl;
          break;
-      case E57_INT16:
+      case Int16:
          os << "int16_t" << std::endl;
          break;
-      case E57_UINT16:
+      case UInt16:
          os << "uint16_t" << std::endl;
          break;
-      case E57_INT32:
+      case Int32:
          os << "int32_t" << std::endl;
          break;
-      case E57_UINT32:
+      case UInt32:
          os << "uint32_t" << std::endl;
          break;
-      case E57_INT64:
+      case Int64:
          os << "int64_t" << std::endl;
          break;
-      case E57_BOOL:
+      case Bool:
          os << "bool" << std::endl;
          break;
-      case E57_REAL32:
+      case Real32:
          os << "float" << std::endl;
          break;
-      case E57_REAL64:
+      case Real64:
          os << "double" << std::endl;
          break;
-      case E57_USTRING:
+      case UString:
          os << "ustring" << std::endl;
          break;
       default:

--- a/src/SourceDestBufferImpl.h
+++ b/src/SourceDestBufferImpl.h
@@ -125,17 +125,16 @@ namespace e57
       ImageFileImplWeakPtr destImageFile_;
       ustring pathName_;                          /// Pathname from CompressedVectorNode to source/dest
                                                   /// object, e.g. "Indices/0"
-      MemoryRepresentation memoryRepresentation_; /// Type of element (e.g. E57_INT8, E57_UINT64,
-                                                  /// DOUBLE...)
+      MemoryRepresentation memoryRepresentation_; /// Type of element (e.g. ::Int8, ::UIin64, ::Real64...)
       char *base_ = nullptr;                      /// Address of first element, for non-ustring buffers
       size_t capacity_ = 0;                       /// Total number of elements in array
       bool doConversion_ = false;                 /// Convert memory representation to/from disk representation
       bool doScaling_ = false;                    /// Apply scale factor for integer type
-      size_t stride_ = 0;                         /// Distance between each element (different than size_
+      size_t stride_ = 0;                         /// Distance between each element (different from size_
                                                   /// if elements not contiguous)
       unsigned nextIndex_ = 0;                    /// Number of elements that have been set (dest
                                                   /// buffer) or read (source buffer) since rewind().
       StringList *ustrings_ = nullptr;            /// Optional array of ustrings (used if
-                                                  /// memoryRepresentation_==E57_USTRING) ???ownership
+                                                  /// memoryRepresentation_ == ::UString)
    };
 }

--- a/src/StringNode.cpp
+++ b/src/StringNode.cpp
@@ -83,9 +83,9 @@ recommended to specify a
 true).
 @pre     The @a destImageFile must have been opened in write mode (i.e.
 destImageFile.isWritable() must be true).
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_FILE_IS_READ_ONLY
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorFileReadOnly
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     StringNode::value, Node, CompressedVectorNode, CompressedVectorNode::prototype
 */
 StringNode::StringNode( ImageFile destImageFile, const ustring &value ) :
@@ -141,8 +141,8 @@ bool StringNode::isAttached() const
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  The Unicode character string value stored.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 */
 ustring StringNode::value() const
 {
@@ -207,14 +207,14 @@ exception is thrown. In designs that need to avoid the exception, use
 Node::type() to determine the actual type of the @a n before downcasting. This
 function must be explicitly called (c++ compiler cannot insert it
 automatically).
-@throw   ::E57_ERROR_BAD_NODE_DOWNCAST
+@throw   ::ErrorBadNodeDowncast
 @see     Node::type(), StringNode::operator Node()
 */
 StringNode::StringNode( const Node &n )
 {
-   if ( n.type() != E57_STRING )
+   if ( n.type() != TypeString )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_NODE_DOWNCAST, "nodeType=" + toString( n.type() ) );
+      throw E57_EXCEPTION2( ErrorBadNodeDowncast, "nodeType=" + toString( n.type() ) );
    }
 
    /// Set our shared_ptr to the downcast shared_ptr

--- a/src/StringNodeImpl.cpp
+++ b/src/StringNodeImpl.cpp
@@ -42,7 +42,7 @@ namespace e57
       // don't checkImageFileOpen
 
       /// Same node type?
-      if ( ni->type() != E57_STRING )
+      if ( ni->type() != TypeString )
       {
          return ( false );
       }
@@ -74,7 +74,7 @@ namespace e57
       /// We are a leaf node, so verify that we are listed in set.
       if ( pathNames.find( relativePathName( origin ) ) == pathNames.end() )
       {
-         throw E57_EXCEPTION2( E57_ERROR_NO_BUFFER_FOR_ELEMENT, "this->pathName=" + this->pathName() );
+         throw E57_EXCEPTION2( ErrorNoBufferForElement, "this->pathName=" + this->pathName() );
       }
    }
 

--- a/src/StringNodeImpl.h
+++ b/src/StringNodeImpl.h
@@ -38,7 +38,7 @@ namespace e57
 
       NodeType type() const override
       {
-         return E57_STRING;
+         return TypeString;
       }
 
       bool isTypeEquivalent( NodeImplSharedPtr ni ) override;

--- a/src/StructureNode.cpp
+++ b/src/StructureNode.cpp
@@ -75,8 +75,8 @@ error to attempt to attach the StructureNode to a different ImageFile.
 true).
 @pre     The @a destImageFile must have been opened in write mode (i.e.
 destImageFile.isWritable() must be true).
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     Node
 */
 StructureNode::StructureNode( ImageFile destImageFile ) : impl_( new StructureNodeImpl( destImageFile.impl() ) )
@@ -131,8 +131,8 @@ bool StructureNode::isAttached() const
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  Number of child nodes contained by this StructureNode.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     StructureNode::get(int64_t) const,
 StructureNode::set, VectorNode::childCount
 */
@@ -153,9 +153,9 @@ pathName origin root will not the root node of an ImageFile.
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  true if pathName is currently defined.
-@throw   ::E57_ERROR_BAD_PATH_NAME
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadPathName
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     ImageFile::root, VectorNode::isDefined
 */
 bool StructureNode::isDefined( const ustring &pathName ) const
@@ -174,9 +174,9 @@ more children are added to the StructureNode.
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  A smart Node handle referencing the child node.
-@throw   ::E57_ERROR_CHILD_INDEX_OUT_OF_BOUNDS
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorChildIndexOutOfBounds
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     StructureNode::childCount,
 StructureNode::get(const ustring&) const, VectorNode::get
 */
@@ -197,10 +197,10 @@ an ImageFile.
 @pre     The @a pathName must be defined (i.e. isDefined(pathName)).
 @post    No visible state is modified.
 @return  A smart Node handle referencing the child node.
-@throw   ::E57_ERROR_BAD_PATH_NAME
-@throw   ::E57_ERROR_PATH_UNDEFINED
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadPathName
+@throw   ::ErrorPathUndefined
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     StructureNode::get(int64_t) const
 */
 Node StructureNode::get( const ustring &pathName ) const
@@ -238,15 +238,15 @@ destImageFile().isWritable()).
 @pre     The associated destImageFile of this StructureNode and of @a n must be
 same (i.e. destImageFile() == n.destImageFile()).
 @post    The @a pathName will be defined (i.e. isDefined(pathName)).
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_BAD_PATH_NAME
-@throw   ::E57_ERROR_PATH_UNDEFINED
-@throw   ::E57_ERROR_SET_TWICE
-@throw   ::E57_ERROR_ALREADY_HAS_PARENT
-@throw   ::E57_ERROR_DIFFERENT_DEST_IMAGEFILE
-@throw   ::E57_ERROR_HOMOGENEOUS_VIOLATION
-@throw   ::E57_ERROR_FILE_IS_READ_ONLY
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorBadPathName
+@throw   ::ErrorPathUndefined
+@throw   ::ErrorSetTwice
+@throw   ::ErrorAlreadyHasParent
+@throw   ::ErrorDifferentDestImageFile
+@throw   ::ErrorHomogeneousViolation
+@throw   ::ErrorFileReadOnly
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     VectorNode::append
 */
 void StructureNode::set( const ustring &pathName, const Node &n )
@@ -300,20 +300,20 @@ void StructureNode::checkInvariant( bool doRecurse, bool doUpcast )
       // Child's parent must be this
       if ( static_cast<Node>( *this ) != child.parent() )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
 
       // Child's elementName must be defined
       if ( !isDefined( child.elementName() ) )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
 
       // Getting child by element name must yield same child
       Node n = get( child.elementName() );
       if ( n != child )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
    }
 }
@@ -342,14 +342,14 @@ exception is thrown. In designs that need to avoid the exception, use
 Node::type() to determine the actual type of the @a n before downcasting. This
 function must be explicitly called (c++ compiler cannot insert it
 automatically).
-@throw   ::E57_ERROR_BAD_NODE_DOWNCAST
+@throw   ::ErrorBadNodeDowncast
 @see     Node::type(), StructureNode::operator Node()
 */
 StructureNode::StructureNode( const Node &n )
 {
-   if ( n.type() != E57_STRUCTURE )
+   if ( n.type() != TypeStructure )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_NODE_DOWNCAST, "nodeType=" + toString( n.type() ) );
+      throw E57_EXCEPTION2( ErrorBadNodeDowncast, "nodeType=" + toString( n.type() ) );
    }
 
    /// Set our shared_ptr to the downcast shared_ptr

--- a/src/VectorNode.cpp
+++ b/src/VectorNode.cpp
@@ -95,9 +95,9 @@ VectorNode are completely unconstrained.
 true).
 @pre     The @a destImageFile must have been opened in write mode (i.e.
 destImageFile.isWritable() must be true).
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
-@see     Node, VectorNode::allowHeteroChildren, ::E57_ERROR_HOMOGENEOUS_VIOLATION
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
+@see     Node, VectorNode::allowHeteroChildren, ::ErrorHomogeneousViolation
 */
 VectorNode::VectorNode( ImageFile destImageFile, bool allowHeteroChildren ) :
    impl_( new VectorNodeImpl( destImageFile.impl(), allowHeteroChildren ) )
@@ -156,9 +156,9 @@ the VectorNode is created, and cannot be changed.
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  True if child elements can be different types.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
-@see     ::E57_ERROR_HOMOGENEOUS_VIOLATION
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
+@see     ::ErrorHomogeneousViolation
 */
 bool VectorNode::allowHeteroChildren() const
 {
@@ -170,8 +170,8 @@ bool VectorNode::allowHeteroChildren() const
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  Number of child elements in this VectorNode.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     VectorNode::get(int64_t), VectorNode::append, StructureNode::childCount
 */
 int64_t VectorNode::childCount() const
@@ -194,9 +194,9 @@ strings, starting at "0".
 @pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
 @post    No visible state is modified.
 @return  true if pathName is currently defined.
-@throw   ::E57_ERROR_BAD_PATH_NAME
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadPathName
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     StructureNode::isDefined
 */
 bool VectorNode::isDefined( const ustring &pathName ) const
@@ -211,9 +211,9 @@ bool VectorNode::isDefined( const ustring &pathName ) const
 @pre     0 <= @a index < childCount()
 @post    No visible state is modified.
 @return  A smart Node handle referencing the child node.
-@throw   ::E57_ERROR_CHILD_INDEX_OUT_OF_BOUNDS
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorChildIndexOutOfBounds
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     VectorNode::childCount, VectorNode::append, StructureNode::get(int64_t) const
 */
 Node VectorNode::get( int64_t index ) const
@@ -237,10 +237,10 @@ strings, starting at "0".
 @pre     The @a pathName must be defined (i.e. isDefined(pathName)).
 @post    No visible state is modified.
 @return  A smart Node handle referencing the child node.
-@throw   ::E57_ERROR_BAD_PATH_NAME
-@throw   ::E57_ERROR_PATH_UNDEFINED
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorBadPathName
+@throw   ::ErrorPathUndefined
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     VectorNode::childCount, VectorNode::append, StructureNode::get(int64_t) const
 */
 Node VectorNode::get( const ustring &pathName ) const
@@ -268,12 +268,12 @@ parent).
 @pre     The associated destImageFile must have been opened in write mode (i.e.
 destImageFile().isWritable()).
 @post    the childCount is incremented.
-@throw   ::E57_ERROR_IMAGEFILE_NOT_OPEN
-@throw   ::E57_ERROR_HOMOGENEOUS_VIOLATION
-@throw   ::E57_ERROR_FILE_IS_READ_ONLY
-@throw   ::E57_ERROR_ALREADY_HAS_PARENT
-@throw   ::E57_ERROR_DIFFERENT_DEST_IMAGEFILE
-@throw   ::E57_ERROR_INTERNAL           All objects in undocumented state
+@throw   ::ErrorImageFileNotOpen
+@throw   ::ErrorHomogeneousViolation
+@throw   ::ErrorFileReadOnly
+@throw   ::ErrorAlreadyHasParent
+@throw   ::ErrorDifferentDestImageFile
+@throw   ::ErrorInternal           All objects in undocumented state
 @see     VectorNode::childCount, VectorNode::get(int64_t), StructureNode::set
 */
 void VectorNode::append( const Node &n )
@@ -327,20 +327,20 @@ void VectorNode::checkInvariant( bool doRecurse, bool doUpcast )
       // Child's parent must be this
       if ( static_cast<Node>( *this ) != child.parent() )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
 
       // Child's elementName must be defined
       if ( !isDefined( child.elementName() ) )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
 
       // Getting child by element name must yield same child
       Node n = get( child.elementName() );
       if ( n != child )
       {
-         throw E57_EXCEPTION1( E57_ERROR_INVARIANCE_VIOLATION );
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
    }
 }
@@ -369,14 +369,14 @@ exception is thrown. In designs that need to avoid the exception, use
 Node::type() to determine the actual type of the @a n before downcasting. This
 function must be explicitly called (c++ compiler cannot insert it
 automatically).
-@throw   ::E57_ERROR_BAD_NODE_DOWNCAST
+@throw   ::ErrorBadNodeDowncast
 @see     Node::type(), VectorNode::operator Node()
 */
 VectorNode::VectorNode( const Node &n )
 {
-   if ( n.type() != E57_VECTOR )
+   if ( n.type() != TypeVector )
    {
-      throw E57_EXCEPTION2( E57_ERROR_BAD_NODE_DOWNCAST, "nodeType=" + toString( n.type() ) );
+      throw E57_EXCEPTION2( ErrorBadNodeDowncast, "nodeType=" + toString( n.type() ) );
    }
 
    /// Set our shared_ptr to the downcast shared_ptr

--- a/src/VectorNodeImpl.cpp
+++ b/src/VectorNodeImpl.cpp
@@ -42,7 +42,7 @@ namespace e57
       /// don't checkImageFileOpen
 
       /// Same node type?
-      if ( ni->type() != E57_VECTOR )
+      if ( ni->type() != TypeVector )
       {
          return ( false );
       }
@@ -90,7 +90,7 @@ namespace e57
          {
             if ( !child->isTypeEquivalent( ni ) )
             {
-               throw E57_EXCEPTION2( E57_ERROR_HOMOGENEOUS_VIOLATION, "this->pathName=" + this->pathName() );
+               throw E57_EXCEPTION2( ErrorHomogeneousViolation, "this->pathName=" + this->pathName() );
             }
          }
       }

--- a/src/VectorNodeImpl.h
+++ b/src/VectorNodeImpl.h
@@ -38,7 +38,7 @@ namespace e57
 
       NodeType type() const override
       {
-         return E57_VECTOR;
+         return TypeVector;
       }
 
       bool isTypeEquivalent( NodeImplSharedPtr ni ) override;

--- a/src/WriterImpl.cpp
+++ b/src/WriterImpl.cpp
@@ -46,10 +46,10 @@ namespace e57
 
       switch ( imageType )
       {
-         case E57_NO_IMAGE:
+         case ImageNone:
             return 0;
 
-         case E57_JPEG_IMAGE:
+         case ImageJPEG:
             if ( image.isDefined( "jpegImage" ) )
             {
                BlobNode jpegImage( image.get( "jpegImage" ) );
@@ -58,7 +58,7 @@ namespace e57
             }
             break;
 
-         case E57_PNG_IMAGE:
+         case ImagePNG:
             if ( image.isDefined( "pngImage" ) )
             {
                BlobNode pngImage( image.get( "pngImage" ) );
@@ -67,7 +67,7 @@ namespace e57
             }
             break;
 
-         case E57_PNG_IMAGE_MASK:
+         case ImageMaskPNG:
             if ( image.isDefined( "imageMask" ) )
             {
                BlobNode imageMask( image.get( "imageMask" ) );
@@ -86,7 +86,7 @@ namespace e57
       // We are using the E57 v1.0 data format standard fieldnames.
       // The standard fieldnames are used without an extension prefix (in the default namespace).
       // We explicitly register it for completeness (the reference implementation would do it for us, if we didn't).
-      imf_.extensionsAdd( "", E57_V1_0_URI );
+      imf_.extensionsAdd( "", e57::VERSION_1_0_URI );
 
       // Set per-file properties.
       // Path names: "/formatName", "/majorVersion", "/minorVersion", "/coordinateMetadata"
@@ -369,10 +369,10 @@ namespace e57
 
       switch ( imageProjection )
       {
-         case E57_NO_PROJECTION:
+         case ProjectionNone:
             return 0;
 
-         case E57_VISUAL:
+         case ProjectionVisual:
             if ( image.isDefined( "visualReferenceRepresentation" ) )
             {
                StructureNode visualReferenceRepresentation( image.get( "visualReferenceRepresentation" ) );
@@ -380,7 +380,7 @@ namespace e57
             }
             break;
 
-         case E57_PINHOLE:
+         case ProjectionPinhole:
             if ( image.isDefined( "pinholeRepresentation" ) )
             {
                StructureNode pinholeRepresentation( image.get( "pinholeRepresentation" ) );
@@ -388,7 +388,7 @@ namespace e57
             }
             break;
 
-         case E57_SPHERICAL:
+         case ProjectionSpherical:
             if ( image.isDefined( "sphericalRepresentation" ) )
             {
                StructureNode sphericalRepresentation( image.get( "sphericalRepresentation" ) );
@@ -396,7 +396,7 @@ namespace e57
             }
             break;
 
-         case E57_CYLINDRICAL:
+         case ProjectionCylindrical:
             if ( image.isDefined( "cylindricalRepresentation" ) )
             {
                StructureNode cylindricalRepresentation( image.get( "cylindricalRepresentation" ) );
@@ -478,17 +478,17 @@ namespace e57
 
       // Add temp/humidity to scan.
       // Path names: "/data3D/0/temperature", etc...
-      if ( data3DHeader.temperature != E57_FLOAT_MAX )
+      if ( data3DHeader.temperature != FLOAT_MAX )
       {
          scan.set( "temperature", FloatNode( imf_, data3DHeader.temperature ) );
       }
 
-      if ( data3DHeader.relativeHumidity != E57_FLOAT_MAX )
+      if ( data3DHeader.relativeHumidity != FLOAT_MAX )
       {
          scan.set( "relativeHumidity", FloatNode( imf_, data3DHeader.relativeHumidity ) );
       }
 
-      if ( data3DHeader.atmosphericPressure != E57_FLOAT_MAX )
+      if ( data3DHeader.atmosphericPressure != FLOAT_MAX )
       {
          scan.set( "atmosphericPressure", FloatNode( imf_, data3DHeader.atmosphericPressure ) );
       }
@@ -575,8 +575,8 @@ namespace e57
 
       // Add Cartesian bounding box to scan.
       // Path names: "/data3D/0/cartesianBounds/xMinimum", etc...
-      if ( ( data3DHeader.cartesianBounds.xMinimum != -E57_DOUBLE_MAX ) ||
-           ( data3DHeader.cartesianBounds.xMaximum != E57_DOUBLE_MAX ) )
+      if ( ( data3DHeader.cartesianBounds.xMinimum != -DOUBLE_MAX ) ||
+           ( data3DHeader.cartesianBounds.xMaximum != DOUBLE_MAX ) )
       {
          StructureNode bbox( imf_ );
 
@@ -591,7 +591,7 @@ namespace e57
       }
 
       if ( ( data3DHeader.sphericalBounds.rangeMinimum != 0.0 ) ||
-           ( data3DHeader.sphericalBounds.rangeMaximum != E57_DOUBLE_MAX ) )
+           ( data3DHeader.sphericalBounds.rangeMaximum != DOUBLE_MAX ) )
       {
          StructureNode sbox( imf_ );
 
@@ -734,7 +734,8 @@ namespace e57
                                       pointRangeOffset );
          }
 
-         return FloatNode( imf_, 0.0, ( pointRangeScale < E57_NOT_SCALED_USE_FLOAT ) ? E57_DOUBLE : E57_SINGLE,
+         return FloatNode( imf_, 0.0,
+                           ( pointRangeScale < E57_NOT_SCALED_USE_FLOAT ) ? PrecisionDouble : PrecisionSingle,
                            pointRangeMin, pointRangeMax );
       };
 
@@ -772,8 +773,8 @@ namespace e57
             return ScaledIntegerNode( imf_, 0, angleMinimum, angleMaximum, angleScale, angleOffset );
          }
 
-         return FloatNode( imf_, 0.0, ( angleScale < E57_NOT_SCALED_USE_FLOAT ) ? E57_DOUBLE : E57_SINGLE, angleMin,
-                           angleMax );
+         return FloatNode( imf_, 0.0, ( angleScale < E57_NOT_SCALED_USE_FLOAT ) ? PrecisionDouble : PrecisionSingle,
+                           angleMin, angleMax );
       };
 
       if ( data3DHeader.pointFields.sphericalAzimuthField )
@@ -803,8 +804,9 @@ namespace e57
          }
          else if ( data3DHeader.pointFields.intensityScaledInteger == E57_NOT_SCALED_USE_FLOAT )
          {
-            proto.set( "intensity", FloatNode( imf_, 0.0, E57_SINGLE, data3DHeader.intensityLimits.intensityMinimum,
-                                               data3DHeader.intensityLimits.intensityMaximum ) );
+            proto.set( "intensity",
+                       FloatNode( imf_, 0.0, PrecisionSingle, data3DHeader.intensityLimits.intensityMinimum,
+                                  data3DHeader.intensityLimits.intensityMaximum ) );
          }
          else
          {
@@ -833,21 +835,20 @@ namespace e57
 
       if ( data3DHeader.pointFields.returnIndexField )
       {
-         proto.set( "returnIndex", IntegerNode( imf_, 0, E57_UINT8_MIN, data3DHeader.pointFields.returnMaximum ) );
+         proto.set( "returnIndex", IntegerNode( imf_, 0, UINT8_MIN, data3DHeader.pointFields.returnMaximum ) );
       }
       if ( data3DHeader.pointFields.returnCountField )
       {
-         proto.set( "returnCount", IntegerNode( imf_, 0, E57_UINT8_MIN, data3DHeader.pointFields.returnMaximum ) );
+         proto.set( "returnCount", IntegerNode( imf_, 0, UINT8_MIN, data3DHeader.pointFields.returnMaximum ) );
       }
 
       if ( data3DHeader.pointFields.rowIndexField )
       {
-         proto.set( "rowIndex", IntegerNode( imf_, 0, E57_UINT32_MIN, data3DHeader.pointFields.rowIndexMaximum ) );
+         proto.set( "rowIndex", IntegerNode( imf_, 0, UINT32_MIN, data3DHeader.pointFields.rowIndexMaximum ) );
       }
       if ( data3DHeader.pointFields.columnIndexField )
       {
-         proto.set( "columnIndex",
-                    IntegerNode( imf_, 0, E57_UINT32_MIN, data3DHeader.pointFields.columnIndexMaximum ) );
+         proto.set( "columnIndex", IntegerNode( imf_, 0, UINT32_MIN, data3DHeader.pointFields.columnIndexMaximum ) );
       }
 
       if ( data3DHeader.pointFields.timeStampField )
@@ -867,13 +868,13 @@ namespace e57
          }
          else if ( data3DHeader.pointFields.timeScaledInteger == E57_NOT_SCALED_USE_FLOAT )
          {
-            if ( data3DHeader.pointFields.timeMaximum == E57_FLOAT_MAX )
+            if ( data3DHeader.pointFields.timeMaximum == FLOAT_MAX )
             {
-               proto.set( "timeStamp", FloatNode( imf_, 0.0, E57_SINGLE, E57_FLOAT_MIN, E57_FLOAT_MAX ) );
+               proto.set( "timeStamp", FloatNode( imf_, 0.0, PrecisionSingle, FLOAT_MIN, FLOAT_MAX ) );
             }
-            else if ( data3DHeader.pointFields.timeMaximum == E57_DOUBLE_MAX )
+            else if ( data3DHeader.pointFields.timeMaximum == DOUBLE_MAX )
             {
-               proto.set( "timeStamp", FloatNode( imf_, 0.0, E57_DOUBLE, E57_DOUBLE_MIN, E57_DOUBLE_MAX ) );
+               proto.set( "timeStamp", FloatNode( imf_, 0.0, PrecisionDouble, DOUBLE_MIN, DOUBLE_MAX ) );
             }
          }
          else
@@ -919,15 +920,15 @@ namespace e57
       // currently we support writing normals only as float32
       if ( data3DHeader.pointFields.normalXField )
       {
-         proto.set( "nor:normalX", FloatNode( imf_, 0.0, E57_SINGLE, -1., 1. ) );
+         proto.set( "nor:normalX", FloatNode( imf_, 0.0, PrecisionSingle, -1.0, 1.0 ) );
       }
       if ( data3DHeader.pointFields.normalYField )
       {
-         proto.set( "nor:normalY", FloatNode( imf_, 0.0, E57_SINGLE, -1., 1. ) );
+         proto.set( "nor:normalY", FloatNode( imf_, 0.0, PrecisionSingle, -1.0, 1.0 ) );
       }
       if ( data3DHeader.pointFields.normalZField )
       {
-         proto.set( "nor:normalZ", FloatNode( imf_, 0.0, E57_SINGLE, -1., 1. ) );
+         proto.set( "nor:normalZ", FloatNode( imf_, 0.0, PrecisionSingle, -1.0, 1.0 ) );
       }
 
       // Make empty codecs vector for use in creating points CompressedVector.

--- a/test/src/test_SimpleData.cpp
+++ b/test/src/test_SimpleData.cpp
@@ -23,22 +23,22 @@ TEST( SimpleDataHeader, HeaderMinMaxFloat )
 
    dataHeader.pointCount = 1;
 
-   EXPECT_EQ( dataHeader.pointFields.pointRangeMinimum, e57::E57_DOUBLE_MIN );
-   EXPECT_EQ( dataHeader.pointFields.pointRangeMaximum, e57::E57_DOUBLE_MAX );
-   EXPECT_EQ( dataHeader.pointFields.angleMinimum, e57::E57_DOUBLE_MIN );
-   EXPECT_EQ( dataHeader.pointFields.angleMaximum, e57::E57_DOUBLE_MAX );
-   EXPECT_EQ( dataHeader.pointFields.timeMinimum, e57::E57_DOUBLE_MIN );
-   EXPECT_EQ( dataHeader.pointFields.timeMaximum, e57::E57_DOUBLE_MAX );
+   EXPECT_EQ( dataHeader.pointFields.pointRangeMinimum, e57::DOUBLE_MIN );
+   EXPECT_EQ( dataHeader.pointFields.pointRangeMaximum, e57::DOUBLE_MAX );
+   EXPECT_EQ( dataHeader.pointFields.angleMinimum, e57::DOUBLE_MIN );
+   EXPECT_EQ( dataHeader.pointFields.angleMaximum, e57::DOUBLE_MAX );
+   EXPECT_EQ( dataHeader.pointFields.timeMinimum, e57::DOUBLE_MIN );
+   EXPECT_EQ( dataHeader.pointFields.timeMaximum, e57::DOUBLE_MAX );
 
    // This call should adjust our min/max for a variety of fields since we are using floats.
    e57::Data3DPointsData pointsData( dataHeader );
 
-   EXPECT_EQ( dataHeader.pointFields.pointRangeMinimum, e57::E57_FLOAT_MIN );
-   EXPECT_EQ( dataHeader.pointFields.pointRangeMaximum, e57::E57_FLOAT_MAX );
-   EXPECT_EQ( dataHeader.pointFields.angleMinimum, e57::E57_FLOAT_MIN );
-   EXPECT_EQ( dataHeader.pointFields.angleMaximum, e57::E57_FLOAT_MAX );
-   EXPECT_EQ( dataHeader.pointFields.timeMinimum, e57::E57_FLOAT_MIN );
-   EXPECT_EQ( dataHeader.pointFields.timeMaximum, e57::E57_FLOAT_MAX );
+   EXPECT_EQ( dataHeader.pointFields.pointRangeMinimum, e57::FLOAT_MIN );
+   EXPECT_EQ( dataHeader.pointFields.pointRangeMaximum, e57::FLOAT_MAX );
+   EXPECT_EQ( dataHeader.pointFields.angleMinimum, e57::FLOAT_MIN );
+   EXPECT_EQ( dataHeader.pointFields.angleMaximum, e57::FLOAT_MAX );
+   EXPECT_EQ( dataHeader.pointFields.timeMinimum, e57::FLOAT_MIN );
+   EXPECT_EQ( dataHeader.pointFields.timeMaximum, e57::FLOAT_MAX );
 }
 
 TEST( SimpleDataHeader, HeaderMinMaxDouble )
@@ -47,22 +47,22 @@ TEST( SimpleDataHeader, HeaderMinMaxDouble )
 
    dataHeader.pointCount = 1;
 
-   EXPECT_EQ( dataHeader.pointFields.pointRangeMinimum, e57::E57_DOUBLE_MIN );
-   EXPECT_EQ( dataHeader.pointFields.pointRangeMaximum, e57::E57_DOUBLE_MAX );
-   EXPECT_EQ( dataHeader.pointFields.angleMinimum, e57::E57_DOUBLE_MIN );
-   EXPECT_EQ( dataHeader.pointFields.angleMaximum, e57::E57_DOUBLE_MAX );
-   EXPECT_EQ( dataHeader.pointFields.timeMinimum, e57::E57_DOUBLE_MIN );
-   EXPECT_EQ( dataHeader.pointFields.timeMaximum, e57::E57_DOUBLE_MAX );
+   EXPECT_EQ( dataHeader.pointFields.pointRangeMinimum, e57::DOUBLE_MIN );
+   EXPECT_EQ( dataHeader.pointFields.pointRangeMaximum, e57::DOUBLE_MAX );
+   EXPECT_EQ( dataHeader.pointFields.angleMinimum, e57::DOUBLE_MIN );
+   EXPECT_EQ( dataHeader.pointFields.angleMaximum, e57::DOUBLE_MAX );
+   EXPECT_EQ( dataHeader.pointFields.timeMinimum, e57::DOUBLE_MIN );
+   EXPECT_EQ( dataHeader.pointFields.timeMaximum, e57::DOUBLE_MAX );
 
    // This call should NOT adjust our min/max for a variety of fields since we are using doubles.
    e57::Data3DPointsData_d pointsData( dataHeader );
 
-   EXPECT_EQ( dataHeader.pointFields.pointRangeMinimum, e57::E57_DOUBLE_MIN );
-   EXPECT_EQ( dataHeader.pointFields.pointRangeMaximum, e57::E57_DOUBLE_MAX );
-   EXPECT_EQ( dataHeader.pointFields.angleMinimum, e57::E57_DOUBLE_MIN );
-   EXPECT_EQ( dataHeader.pointFields.angleMaximum, e57::E57_DOUBLE_MAX );
-   EXPECT_EQ( dataHeader.pointFields.timeMinimum, e57::E57_DOUBLE_MIN );
-   EXPECT_EQ( dataHeader.pointFields.timeMaximum, e57::E57_DOUBLE_MAX );
+   EXPECT_EQ( dataHeader.pointFields.pointRangeMinimum, e57::DOUBLE_MIN );
+   EXPECT_EQ( dataHeader.pointFields.pointRangeMaximum, e57::DOUBLE_MAX );
+   EXPECT_EQ( dataHeader.pointFields.angleMinimum, e57::DOUBLE_MIN );
+   EXPECT_EQ( dataHeader.pointFields.angleMaximum, e57::DOUBLE_MAX );
+   EXPECT_EQ( dataHeader.pointFields.timeMinimum, e57::DOUBLE_MIN );
+   EXPECT_EQ( dataHeader.pointFields.timeMaximum, e57::DOUBLE_MAX );
 }
 
 // Checks that the Data3D header and the the cartesianX FloatNode data are the same when read, written, and read again.

--- a/test/src/test_SimpleReader.cpp
+++ b/test/src/test_SimpleReader.cpp
@@ -52,7 +52,7 @@ TEST( SimpleReaderData, BadCRC )
 
 TEST( SimpleReaderData, DoNotCheckCRC )
 {
-   E57_ASSERT_NO_THROW( e57::Reader( TestData::Path() + "/self/bad-crc.e57", { e57::ChecksumPolicy::None } ) );
+   E57_ASSERT_NO_THROW( e57::Reader( TestData::Path() + "/self/bad-crc.e57", { e57::ChecksumNone } ) );
 }
 
 // https://github.com/asmaloney/libE57Format/issues/26

--- a/test/src/test_SimpleWriter.cpp
+++ b/test/src/test_SimpleWriter.cpp
@@ -170,8 +170,8 @@ TEST( SimpleWriter, ColouredCubeDouble )
    e57::Data3DPointsData_d pointsData( header );
 
    // reset these so we can calculate them using min/max
-   header.pointFields.pointRangeMinimum = e57::E57_DOUBLE_MAX;
-   header.pointFields.pointRangeMaximum = e57::E57_DOUBLE_MIN;
+   header.pointFields.pointRangeMinimum = e57::DOUBLE_MAX;
+   header.pointFields.pointRangeMaximum = e57::DOUBLE_MIN;
 
    int64_t i = 0;
    auto writePointLambda = [&]( uint8_t inFace, const Point &inPoint ) {
@@ -222,8 +222,8 @@ TEST( SimpleWriter, ColouredCubeFloat )
    e57::Data3DPointsData pointsData( header );
 
    // reset these so we can calculate them using min/max
-   header.pointFields.pointRangeMinimum = e57::E57_FLOAT_MAX;
-   header.pointFields.pointRangeMaximum = e57::E57_FLOAT_MIN;
+   header.pointFields.pointRangeMinimum = e57::FLOAT_MAX;
+   header.pointFields.pointRangeMaximum = e57::FLOAT_MIN;
 
    int64_t i = 0;
    auto writePointLambda = [&]( uint8_t inFace, const Point &inPoint ) {
@@ -283,8 +283,8 @@ TEST( SimpleWriter, ColouredCubeScaledInt )
    e57::Data3DPointsData_d pointsData( header );
 
    // reset these so we can calculate them using min/max
-   header.pointFields.pointRangeMinimum = e57::E57_DOUBLE_MAX;
-   header.pointFields.pointRangeMaximum = e57::E57_DOUBLE_MIN;
+   header.pointFields.pointRangeMinimum = e57::DOUBLE_MAX;
+   header.pointFields.pointRangeMaximum = e57::DOUBLE_MIN;
 
    int64_t i = 0;
    auto writePointLambda = [&]( uint8_t inFace, const Point &inPoint ) {
@@ -491,11 +491,11 @@ TEST( SimpleWriter, MinMaxIssuesCartesianFloat )
 
    delete writer;
 
-   EXPECT_NE( header.pointFields.pointRangeMinimum, e57::E57_FLOAT_MIN );
-   EXPECT_NE( header.pointFields.pointRangeMaximum, e57::E57_FLOAT_MAX );
+   EXPECT_NE( header.pointFields.pointRangeMinimum, e57::FLOAT_MIN );
+   EXPECT_NE( header.pointFields.pointRangeMaximum, e57::FLOAT_MAX );
 
-   EXPECT_NE( header.pointFields.timeMinimum, e57::E57_FLOAT_MIN );
-   EXPECT_NE( header.pointFields.timeMaximum, e57::E57_FLOAT_MAX );
+   EXPECT_NE( header.pointFields.timeMinimum, e57::FLOAT_MIN );
+   EXPECT_NE( header.pointFields.timeMaximum, e57::FLOAT_MAX );
 
    EXPECT_NE( header.intensityLimits.intensityMinimum, 0.0 );
    EXPECT_NE( header.intensityLimits.intensityMaximum, 0.0 );
@@ -550,11 +550,11 @@ TEST( SimpleWriter, MinMaxIssuesSpericalDouble )
 
    delete writer;
 
-   EXPECT_NE( header.pointFields.pointRangeMinimum, e57::E57_DOUBLE_MIN );
-   EXPECT_NE( header.pointFields.pointRangeMaximum, e57::E57_DOUBLE_MAX );
+   EXPECT_NE( header.pointFields.pointRangeMinimum, e57::DOUBLE_MIN );
+   EXPECT_NE( header.pointFields.pointRangeMaximum, e57::DOUBLE_MAX );
 
-   EXPECT_NE( header.pointFields.timeMinimum, e57::E57_DOUBLE_MIN );
-   EXPECT_NE( header.pointFields.timeMaximum, e57::E57_DOUBLE_MAX );
+   EXPECT_NE( header.pointFields.timeMinimum, e57::DOUBLE_MIN );
+   EXPECT_NE( header.pointFields.timeMaximum, e57::DOUBLE_MAX );
 
    EXPECT_NE( header.intensityLimits.intensityMinimum, 0.0 );
    EXPECT_NE( header.intensityLimits.intensityMaximum, 0.0 );
@@ -592,7 +592,7 @@ TEST( SimpleWriterData, VisualRefImage )
    image2DHeader.visualReferenceRepresentation.imageHeight = 300;
    image2DHeader.visualReferenceRepresentation.jpegImageSize = cImageSize;
 
-   writer->WriteImage2DData( image2DHeader, e57::E57_JPEG_IMAGE, e57::E57_VISUAL, 0, imageBuffer, cImageSize );
+   writer->WriteImage2DData( image2DHeader, e57::ImageJPEG, e57::ProjectionVisual, 0, imageBuffer, cImageSize );
 
    delete[] imageBuffer;
 


### PR DESCRIPTION
- use namespaces instead of adding “E57_” to variable name
  e.g. instead of `e57::E57_STRUCTURE`, use `e57::TypeStructure`

- deprecate the old versions for later removal

- uses standard names from `cstdint` for integer min/max values instead of defining them ourselves (internal change)

This results in a lot of changes, however all the enums are 1-to-1 replacements (just renamed).