### PR TITLE
E57Simple: Simplify & clarify node types when setting up Data3D

### DIFF
--- a/include/E57Exception.h
+++ b/include/E57Exception.h
@@ -95,6 +95,8 @@ namespace e57
       ErrorBadConfiguration = 49,           //!< bad configuration string
       ErrorInvarianceViolation = 50,        //!< class invariance constraint violation in debug mode
 
+      ErrorInvalidNodeType = 51, ///< an invalid note type was passed in Data3D pointFields
+
       /// @deprecated Will be removed in 4.0. Use e57::Success.
       E57_SUCCESS [[deprecated( "Will be removed in 4.0. Use Success." )]] = Success,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadCVHeader.

--- a/include/E57SimpleData.h
+++ b/include/E57SimpleData.h
@@ -37,12 +37,6 @@
 
 namespace e57
 {
-   //! Indicates to use FloatNode instead of ScaledIntegerNode in fields that can use both.
-   constexpr double E57_NOT_SCALED_USE_FLOAT = 0.0;
-
-   //! Indicates to use ScaledIntegerNode instead of FloatNode in fields that can use both.
-   constexpr double E57_NOT_SCALED_USE_INTEGER = -1.0;
-
    //! @cond documentNonPublic   The following isn't part of the API, and isn't documented.
    class ReaderImpl;
    class WriterImpl;
@@ -305,6 +299,15 @@ namespace e57
       GroupingByLine groupingByLine; //!< Grouping information by row or column index
    };
 
+   //! @brief Used to set the type of node in some PointStandardizedFieldsAvailable fields.
+   enum class NumericalNodeType
+   {
+      Integer = 0,   ///< Use IntegerNode
+      ScaledInteger, ///< Use ScaledIntegerNode
+      Float,         ///< Use FloatNode with floats
+      Double,        ///< Use FloatNode with doubles
+   };
+
    //! @brief Used to interrogate if standardized fields are available
    struct E57_DLL PointStandardizedFieldsAvailable
    {
@@ -326,14 +329,15 @@ namespace e57
       //! E57_FLOAT_MAX or E57_DOUBLE_MAX. If using a ScaledIntegerNode then this needs to be a maximum range value.
       double pointRangeMaximum = DOUBLE_MAX;
 
-      //! @brief Controls the type of Node used for the PointRecord cartesian and range fields
-      //! @details The value determines which type of Node to use and whether to use floats or doubles.
-      //! Value | Node Type
-      //! -- | --
-      //! &lt; 0.0 | FloatNode using doubles
-      //! == 0.0 (e57::E57_NOT_SCALED_USE_FLOAT) | FloatNode using floats (@em default)
-      //! &gt; 0.0 | ScaledIntegerNode with the value as the scale setting
-      double pointRangeScaledInteger = E57_NOT_SCALED_USE_FLOAT;
+      /// @brief Controls the type of Node used for the PointRecord cartesian and range fields
+      /// @details Accepts NumericalNodeType::ScaledInteger, NumericalNodeType::Float, and
+      /// NumericalNodeType::Double.
+      NumericalNodeType pointRangeNodeType = NumericalNodeType::Float;
+
+      /// @brief Sets the scale if using scaled integers for point fields
+      /// @details If pointRangeNodeType == NumericalNodeType::ScaledInteger, it will use this value
+      /// to scale the numbers and it must be > 0.0.
+      double pointRangeScale = 0.0;
 
       //! Indicates that the PointRecord angle fields should be configured with this minimum value E57_FLOAT_MIN or
       //! E57_DOUBLE_MIN. If using a ScaledIntegerNode then this needs to be a minimum angle value.
@@ -343,14 +347,15 @@ namespace e57
       //! E57_DOUBLE_MAX. If using a ScaledIntegerNode then this needs to be a maximum angle value.
       double angleMaximum = DOUBLE_MAX;
 
-      //! @brief Controls the type of Node used for the PointRecord angle fields
-      //! @details The value determines which type of Node to use and whether to use floats or doubles.
-      //! Value | Node Type
-      //! -- | --
-      //! &lt; 0.0 | FloatNode using doubles
-      //! == 0.0 (e57::E57_NOT_SCALED_USE_FLOAT) | FloatNode using floats (@em default)
-      //! &gt; 0.0 | ScaledIntegerNode with the value as the scale setting
-      double angleScaledInteger = E57_NOT_SCALED_USE_FLOAT;
+      /// @brief Controls the type of Node used for the PointRecord angle fields
+      /// @details Accepts NumericalNodeType::ScaledInteger, NumericalNodeType::Float, and
+      /// NumericalNodeType::Double.
+      NumericalNodeType angleNodeType = NumericalNodeType::Float;
+
+      /// @brief Sets the scale if using scaled integers for angle fields
+      /// @details If angleNodeType == NumericalNodeType::ScaledInteger, it will use this value
+      /// to scale the numbers and it must be > 0.0.
+      double angleScale = 0.0;
 
       bool rowIndexField = false; //!< Indicates that the PointRecord @a rowIndex field is active
 
@@ -381,36 +386,46 @@ namespace e57
       //! E57_UINT32_MAX, E57_DOUBLE_MAX or E57_DOUBLE_MAX.
       double timeMaximum = DOUBLE_MAX;
 
-      //! @brief Controls the type of Node used for the PointRecord @a timeStamp fields
-      //! @details The value determines which type of Node to use and whether to use floats or doubles.
-      //! Value  | Node Type
-      //! -- | --
-      //! &lt; 0.0 | IntegerNode
-      //! == 0.0 (e57::E57_NOT_SCALED_USE_FLOAT) | FloatNode using floats if (::timeMaximum == E57_FLOAT_MAX)
-      //! == 0.0 | FloatNode using doubles if (::timeMaximum == E57_DOUBLE_MAX) (@em default)
-      //! &gt; 0.0 | ScaledIntegerNode with the value as the scale setting
-      double timeScaledInteger = E57_NOT_SCALED_USE_FLOAT;
+      /// @brief Controls the type of Node used for the PointRecord time fields
+      /// @details Accepts NumericalNodeType::Integer, NumericalNodeType::ScaledInteger, NumericalNodeType::Float, and
+      /// NumericalNodeType::Double.
+      NumericalNodeType timeNodeType = NumericalNodeType::Float;
 
-      bool intensityField = false;          //!< Indicates that the PointRecord @a intensity field is active
-      bool isIntensityInvalidField = false; //!< Indicates that the PointRecord @a isIntensityInvalid field is active
+      /// @brief Sets the scale if using scaled integers for time fields
+      /// @details If timeNodeType == NumericalNodeType::ScaledInteger, it will use this value
+      /// to scale the numbers and it must be > 0.0.
+      double timeScale = 0.0;
 
-      //! @brief Controls the type of Node used for the PointRecord @a intensity fields
-      //! @details The value determines which type of Node to use.
-      //! Value | Node Type
-      //! -- | --
-      //! &lt; 0.0 | IntegerNode
-      //! == 0.0 (e57::E57_NOT_SCALED_USE_FLOAT) | FloatNode using floats (@em default)
-      //! &gt; 0.0 | ScaledIntegerNode with the value as the scale setting
-      double intensityScaledInteger = E57_NOT_SCALED_USE_INTEGER;
+      /// Indicates that the PointRecord @a intensity field is active
+      bool intensityField = false;
+      /// Indicates that the PointRecord @a isIntensityInvalid field is active
+      bool isIntensityInvalidField = false;
 
-      bool colorRedField = false;       //!< Indicates that the PointRecord @a colorRed field is active
-      bool colorGreenField = false;     //!< Indicates that the PointRecord @a colorGreen field is active
-      bool colorBlueField = false;      //!< Indicates that the PointRecord @a colorBlue field is active
-      bool isColorInvalidField = false; //!< Indicates that the PointRecord @a isColorInvalid field is active
+      /// @brief Controls the type of Node used for the PointRecord intensity fields
+      /// @details Accepts NumericalNodeType::Integer, NumericalNodeType::ScaledInteger, NumericalNodeType::Float, and
+      /// NumericalNodeType::Double.
+      NumericalNodeType intensityNodeType = NumericalNodeType::Float;
 
-      bool normalXField = false; //!< Indicates that the PointRecord @a nor:normalX field is active
-      bool normalYField = false; //!< Indicates that the PointRecord @a nor:normalY field is active
-      bool normalZField = false; //!< Indicates that the PointRecord @a nor:normalZ field is active
+      /// @brief Sets the scale if using scaled integers for intensity fields
+      /// @details If intensityNodeType == NumericalNodeType::ScaledInteger, it will use this value
+      /// to scale the numbers and it must be > 0.0.
+      double intensityScale = 0.0;
+
+      /// Indicates that the PointRecord @a colorRed field is active
+      bool colorRedField = false;
+      /// Indicates that the PointRecord @a colorGreen field is active
+      bool colorGreenField = false;
+      /// Indicates that the PointRecord @a colorBlue field is active
+      bool colorBlueField = false;
+      /// Indicates that the PointRecord @a isColorInvalid field is active
+      bool isColorInvalidField = false;
+
+      /// Indicates that the PointRecord @a nor:normalX field is active
+      bool normalXField = false;
+      /// Indicates that the PointRecord @a nor:normalY field is active
+      bool normalYField = false;
+      /// Indicates that the PointRecord @a nor:normalZ field is active
+      bool normalZField = false;
    };
 
    //! @brief Stores the top-level information for a single lidar scan
@@ -478,12 +493,15 @@ namespace e57
    {
       static_assert( std::is_floating_point<COORDTYPE>::value, "Floating point type required." );
 
-      //! @brief Default constructor does not manage any memory or adjust min/max for floats.
+      //! @brief Default constructor does not manage any memory, adjust min/max for floats, or validate data.
       Data3DPointsData_t() = default;
 
-      //! @brief Constructor which allocates buffers for all valid fields in the given Data3D header
-      //! This constructor will also adjust the min/max fields in the data3D pointFields if we are using floats.
-      //! @param [in] data3D Completed header which indicates the fields we are using
+      /// @brief Constructor which allocates buffers for all valid fields in the given Data3D header.
+      /// @details This constructor will also adjust the min/max fields in the data3D pointFields if we are using
+      /// floats, and run some validation on the Data3D.
+      /// @param [in] data3D Completed header which indicates the fields we are using
+      /// @throw ::ErrorValueOutOfBounds
+      /// @throw ::ErrorInvalidNodeType
       explicit Data3DPointsData_t( e57::Data3D &data3D );
 
       //! @brief Destructor will delete any memory allocated using the Data3DPointsData_t( const e57::Data3D & )
@@ -502,8 +520,8 @@ namespace e57
       //! Value = 0 if the point is considered valid, 1 otherwise
       int8_t *cartesianInvalidState = nullptr;
 
-      //! Pointer to a buffer with the Point response intensity. Unit is unspecified.
-      float *intensity = nullptr;
+      /// @brief Pointer to a buffer with the Point response intensity. Unit is unspecified.
+      double *intensity = nullptr;
 
       //! Value = 0 if the intensity is considered valid, 1 otherwise
       int8_t *isIntensityInvalid = nullptr;

--- a/src/E57Exception.cpp
+++ b/src/E57Exception.cpp
@@ -447,6 +447,9 @@ namespace e57
          case ErrorInvarianceViolation:
             return "class invariance constraint violation in debug mode "
                    "(ErrorInvarianceViolation)";
+         case ErrorInvalidNodeType:
+            return "an invalid node type was passed in Data3D pointFields";
+
          default:
             return "unknown error (" + std::to_string( ecode ) + ")";
       }

--- a/src/E57SimpleWriter.cpp
+++ b/src/E57SimpleWriter.cpp
@@ -54,7 +54,7 @@ namespace
       auto pointRangeMinimum = cMax;
       auto pointRangeMaximum = cMin;
 
-      const bool writePointRange = ( pointFields.pointRangeScaledInteger != 0.0 ) &&
+      const bool writePointRange = ( pointFields.pointRangeNodeType == e57::NumericalNodeType::ScaledInteger ) &&
                                    ( pointFields.pointRangeMinimum == cMin ) &&
                                    ( pointFields.pointRangeMaximum == cMax );
 
@@ -64,14 +64,14 @@ namespace
       auto angleMinimum = cMax;
       auto angleMaximum = cMin;
 
-      const bool writeAngle = ( pointFields.angleScaledInteger != 0.0 ) && ( pointFields.angleMinimum == cMin ) &&
-                              ( pointFields.angleMaximum == cMax );
+      const bool writeAngle = ( pointFields.angleNodeType == e57::NumericalNodeType::ScaledInteger ) &&
+                              ( pointFields.angleMinimum == cMin ) && ( pointFields.angleMaximum == cMax );
 
       // IF we are using intesity
       // AND we haven't set either min or max
       // THEN calculate them from the points
-      float intensityMinimum = std::numeric_limits<float>::max();
-      float intensityMaximum = std::numeric_limits<float>::lowest();
+      double intensityMinimum = std::numeric_limits<double>::max();
+      double intensityMaximum = std::numeric_limits<double>::lowest();
 
       const bool writeIntensity =
          pointFields.intensityField && ( ioData3DHeader.intensityLimits == e57::IntensityLimits{} );
@@ -82,7 +82,8 @@ namespace
       double timeMinimum = std::numeric_limits<double>::max();
       double timeMaximum = std::numeric_limits<double>::lowest();
 
-      const bool writeTimeStamp = pointFields.timeStampField && ( pointFields.timeScaledInteger != 0.0 ) &&
+      const bool writeTimeStamp = pointFields.timeStampField &&
+                                  ( pointFields.timeNodeType == e57::NumericalNodeType::ScaledInteger ) &&
                                   ( pointFields.timeMinimum == cMin ) && ( pointFields.timeMaximum == cMax );
 
       // Now run through the points and set the things we need to

--- a/src/ReaderImpl.cpp
+++ b/src/ReaderImpl.cpp
@@ -27,6 +27,8 @@
  */
 
 #include "ReaderImpl.h"
+#include "Common.h"
+#include "StringFunctions.h"
 
 namespace e57
 {
@@ -841,58 +843,108 @@ namespace e57
       {
          const auto cartesianXProto = proto.get( "cartesianX" );
 
-         if ( cartesianXProto.type() == TypeScaledInteger )
+         switch ( cartesianXProto.type() )
          {
-            const ScaledIntegerNode scaledCartesianX( cartesianXProto );
-            const double scale = scaledCartesianX.scale();
-            const double offset = scaledCartesianX.offset();
-            const int64_t minimum = scaledCartesianX.minimum();
-            const int64_t maximum = scaledCartesianX.maximum();
-
-            data3DHeader.pointFields.pointRangeMinimum = static_cast<double>( minimum ) * scale + offset;
-            data3DHeader.pointFields.pointRangeMaximum = static_cast<double>( maximum ) * scale + offset;
-            data3DHeader.pointFields.pointRangeScaledInteger = scale;
-         }
-         else if ( cartesianXProto.type() == TypeFloat )
-         {
-            const FloatNode floatCartesianX( cartesianXProto );
-
-            data3DHeader.pointFields.pointRangeMinimum = floatCartesianX.minimum();
-            data3DHeader.pointFields.pointRangeMaximum = floatCartesianX.maximum();
-
-            if ( floatCartesianX.precision() == PrecisionDouble )
+            case TypeInteger:
             {
-               data3DHeader.pointFields.pointRangeScaledInteger = -1.0;
+               // Should be a warning that we don't handle this type, but we don't have a mechanism for warnings.
+               break;
             }
+
+            case TypeScaledInteger:
+            {
+               const ScaledIntegerNode scaledCartesianX( cartesianXProto );
+               const double scale = scaledCartesianX.scale();
+               const double offset = scaledCartesianX.offset();
+               const int64_t minimum = scaledCartesianX.minimum();
+               const int64_t maximum = scaledCartesianX.maximum();
+
+               data3DHeader.pointFields.pointRangeMinimum = static_cast<double>( minimum ) * scale + offset;
+               data3DHeader.pointFields.pointRangeMaximum = static_cast<double>( maximum ) * scale + offset;
+
+               data3DHeader.pointFields.pointRangeNodeType = NumericalNodeType::ScaledInteger;
+               data3DHeader.pointFields.pointRangeScale = scale;
+
+               break;
+            }
+
+            case TypeFloat:
+            {
+               const FloatNode floatCartesianX( cartesianXProto );
+
+               data3DHeader.pointFields.pointRangeMinimum = floatCartesianX.minimum();
+               data3DHeader.pointFields.pointRangeMaximum = floatCartesianX.maximum();
+
+               if ( floatCartesianX.precision() == PrecisionSingle )
+               {
+                  data3DHeader.pointFields.pointRangeNodeType = NumericalNodeType::Float;
+               }
+               else
+               {
+                  data3DHeader.pointFields.pointRangeNodeType = NumericalNodeType::Double;
+               }
+
+               break;
+            }
+
+            default:
+               throw E57_EXCEPTION2( ErrorInvalidNodeType, "invalid node type reading cartesianX field: " +
+                                                              toString( cartesianXProto.type() ) );
+               break;
          }
       }
       else if ( proto.isDefined( "sphericalRange" ) )
       {
          const auto sphericalRangeProto = proto.get( "sphericalRange" );
 
-         if ( sphericalRangeProto.type() == TypeScaledInteger )
+         switch ( sphericalRangeProto.type() )
          {
-            const ScaledIntegerNode scaledSphericalRange( sphericalRangeProto );
-            const double scale = scaledSphericalRange.scale();
-            const double offset = scaledSphericalRange.offset();
-            const int64_t minimum = scaledSphericalRange.minimum();
-            const int64_t maximum = scaledSphericalRange.maximum();
-
-            data3DHeader.pointFields.pointRangeMinimum = static_cast<double>( minimum ) * scale + offset;
-            data3DHeader.pointFields.pointRangeMaximum = static_cast<double>( maximum ) * scale + offset;
-            data3DHeader.pointFields.pointRangeScaledInteger = scale;
-         }
-         else if ( sphericalRangeProto.type() == TypeFloat )
-         {
-            const FloatNode floatSphericalRange( sphericalRangeProto );
-
-            data3DHeader.pointFields.pointRangeMinimum = floatSphericalRange.minimum();
-            data3DHeader.pointFields.pointRangeMaximum = floatSphericalRange.maximum();
-
-            if ( floatSphericalRange.precision() == PrecisionDouble )
+            case TypeInteger:
             {
-               data3DHeader.pointFields.pointRangeScaledInteger = -1.0;
+               // Should be a warning that we don't handle this type, but we don't have a mechanism for warnings.
+               break;
             }
+
+            case TypeScaledInteger:
+            {
+               const ScaledIntegerNode scaledSphericalRange( sphericalRangeProto );
+               const double scale = scaledSphericalRange.scale();
+               const double offset = scaledSphericalRange.offset();
+               const int64_t minimum = scaledSphericalRange.minimum();
+               const int64_t maximum = scaledSphericalRange.maximum();
+
+               data3DHeader.pointFields.pointRangeMinimum = static_cast<double>( minimum ) * scale + offset;
+               data3DHeader.pointFields.pointRangeMaximum = static_cast<double>( maximum ) * scale + offset;
+
+               data3DHeader.pointFields.pointRangeNodeType = NumericalNodeType::ScaledInteger;
+               data3DHeader.pointFields.pointRangeScale = scale;
+
+               break;
+            }
+
+            case TypeFloat:
+            {
+               const FloatNode floatSphericalRange( sphericalRangeProto );
+
+               data3DHeader.pointFields.pointRangeMinimum = floatSphericalRange.minimum();
+               data3DHeader.pointFields.pointRangeMaximum = floatSphericalRange.maximum();
+
+               if ( floatSphericalRange.precision() == PrecisionSingle )
+               {
+                  data3DHeader.pointFields.pointRangeNodeType = NumericalNodeType::Float;
+               }
+               else
+               {
+                  data3DHeader.pointFields.pointRangeNodeType = NumericalNodeType::Double;
+               }
+
+               break;
+            }
+
+            default:
+               throw E57_EXCEPTION2( ErrorInvalidNodeType, "invalid node type reading sphericalRange field: " +
+                                                              toString( sphericalRangeProto.type() ) );
+               break;
          }
       }
 
@@ -908,29 +960,48 @@ namespace e57
       {
          const auto sphericalAzimuthProto = proto.get( "sphericalAzimuth" );
 
-         if ( sphericalAzimuthProto.type() == TypeScaledInteger )
+         switch ( sphericalAzimuthProto.type() )
          {
-            const ScaledIntegerNode scaledSphericalAzimuth( sphericalAzimuthProto );
-            const double scale = scaledSphericalAzimuth.scale();
-            const double offset = scaledSphericalAzimuth.offset();
-            const int64_t minimum = scaledSphericalAzimuth.minimum();
-            const int64_t maximum = scaledSphericalAzimuth.maximum();
-
-            data3DHeader.pointFields.angleMinimum = static_cast<double>( minimum ) * scale + offset;
-            data3DHeader.pointFields.angleMaximum = static_cast<double>( maximum ) * scale + offset;
-            data3DHeader.pointFields.angleScaledInteger = scale;
-         }
-         else if ( sphericalAzimuthProto.type() == TypeFloat )
-         {
-            const FloatNode floatSphericalAzimuth( sphericalAzimuthProto );
-
-            data3DHeader.pointFields.angleMinimum = floatSphericalAzimuth.minimum();
-            data3DHeader.pointFields.angleMaximum = floatSphericalAzimuth.maximum();
-
-            if ( floatSphericalAzimuth.precision() == PrecisionDouble )
+            case TypeScaledInteger:
             {
-               data3DHeader.pointFields.angleScaledInteger = -1.0;
+               const ScaledIntegerNode scaledSphericalAzimuth( sphericalAzimuthProto );
+               const double scale = scaledSphericalAzimuth.scale();
+               const double offset = scaledSphericalAzimuth.offset();
+               const int64_t minimum = scaledSphericalAzimuth.minimum();
+               const int64_t maximum = scaledSphericalAzimuth.maximum();
+
+               data3DHeader.pointFields.angleMinimum = static_cast<double>( minimum ) * scale + offset;
+               data3DHeader.pointFields.angleMaximum = static_cast<double>( maximum ) * scale + offset;
+
+               data3DHeader.pointFields.angleNodeType = NumericalNodeType::ScaledInteger;
+               data3DHeader.pointFields.angleScale = scale;
+
+               break;
             }
+
+            case TypeFloat:
+            {
+               const FloatNode floatSphericalAzimuth( sphericalAzimuthProto );
+
+               data3DHeader.pointFields.angleMinimum = floatSphericalAzimuth.minimum();
+               data3DHeader.pointFields.angleMaximum = floatSphericalAzimuth.maximum();
+
+               if ( floatSphericalAzimuth.precision() == PrecisionSingle )
+               {
+                  data3DHeader.pointFields.angleNodeType = NumericalNodeType::Float;
+               }
+               else
+               {
+                  data3DHeader.pointFields.angleNodeType = NumericalNodeType::Double;
+               }
+
+               break;
+            }
+
+            default:
+               throw E57_EXCEPTION2( ErrorInvalidNodeType, "invalid node type reading sphericalAzimuth field: " +
+                                                              toString( sphericalAzimuthProto.type() ) );
+               break;
          }
       }
 
@@ -970,33 +1041,61 @@ namespace e57
       {
          const auto timeStampProto = proto.get( "timeStamp" );
 
-         if ( timeStampProto.type() == TypeInteger )
+         switch ( timeStampProto.type() )
          {
-            const IntegerNode integerTimeStamp( timeStampProto );
+            case TypeInteger:
+            {
+               const IntegerNode integerTimeStamp( timeStampProto );
 
-            data3DHeader.pointFields.timeMaximum = static_cast<double>( integerTimeStamp.maximum() );
-            data3DHeader.pointFields.timeMinimum = static_cast<double>( integerTimeStamp.minimum() );
-            data3DHeader.pointFields.timeScaledInteger = -1.0;
-         }
-         else if ( timeStampProto.type() == TypeScaledInteger )
-         {
-            const ScaledIntegerNode scaledTimeStamp( timeStampProto );
+               data3DHeader.pointFields.timeMaximum = static_cast<double>( integerTimeStamp.maximum() );
+               data3DHeader.pointFields.timeMinimum = static_cast<double>( integerTimeStamp.minimum() );
 
-            const double scale = scaledTimeStamp.scale();
-            const double offset = scaledTimeStamp.offset();
-            const int64_t minimum = scaledTimeStamp.minimum();
-            const int64_t maximum = scaledTimeStamp.maximum();
+               data3DHeader.pointFields.timeNodeType = NumericalNodeType::Integer;
 
-            data3DHeader.pointFields.timeMinimum = static_cast<double>( minimum ) * scale + offset;
-            data3DHeader.pointFields.timeMaximum = static_cast<double>( maximum ) * scale + offset;
-            data3DHeader.pointFields.timeScaledInteger = scale;
-         }
-         else if ( timeStampProto.type() == TypeFloat )
-         {
-            const FloatNode floatTimeStamp( timeStampProto );
+               break;
+            }
 
-            data3DHeader.pointFields.timeMinimum = floatTimeStamp.minimum();
-            data3DHeader.pointFields.timeMaximum = floatTimeStamp.maximum();
+            case TypeScaledInteger:
+            {
+               const ScaledIntegerNode scaledTimeStamp( timeStampProto );
+
+               const double scale = scaledTimeStamp.scale();
+               const double offset = scaledTimeStamp.offset();
+               const int64_t minimum = scaledTimeStamp.minimum();
+               const int64_t maximum = scaledTimeStamp.maximum();
+
+               data3DHeader.pointFields.timeMinimum = static_cast<double>( minimum ) * scale + offset;
+               data3DHeader.pointFields.timeMaximum = static_cast<double>( maximum ) * scale + offset;
+
+               data3DHeader.pointFields.timeNodeType = NumericalNodeType::ScaledInteger;
+               data3DHeader.pointFields.timeScale = scale;
+
+               break;
+            }
+
+            case TypeFloat:
+            {
+               const FloatNode floatTimeStamp( timeStampProto );
+
+               data3DHeader.pointFields.timeMinimum = floatTimeStamp.minimum();
+               data3DHeader.pointFields.timeMaximum = floatTimeStamp.maximum();
+
+               if ( floatTimeStamp.precision() == PrecisionSingle )
+               {
+                  data3DHeader.pointFields.timeNodeType = NumericalNodeType::Float;
+               }
+               else
+               {
+                  data3DHeader.pointFields.timeNodeType = NumericalNodeType::Double;
+               }
+
+               break;
+            }
+
+            default:
+               throw E57_EXCEPTION2( ErrorInvalidNodeType, "invalid node type reading timeStamp field: " +
+                                                              toString( timeStampProto.type() ) );
+               break;
          }
       }
 
@@ -1034,46 +1133,67 @@ namespace e57
       {
          const auto intensityProto = proto.get( "intensity" );
 
-         if ( intensityProto.type() == TypeInteger )
+         switch ( intensityProto.type() )
          {
-            const IntegerNode integerIntensity( intensityProto );
-
-            if ( data3DHeader.intensityLimits.intensityMaximum == 0.0 )
+            case TypeInteger:
             {
-               data3DHeader.intensityLimits.intensityMinimum = static_cast<double>( integerIntensity.minimum() );
-               data3DHeader.intensityLimits.intensityMaximum = static_cast<double>( integerIntensity.maximum() );
+               const IntegerNode integerIntensity( intensityProto );
+
+               if ( data3DHeader.intensityLimits.intensityMaximum == 0.0 )
+               {
+                  data3DHeader.intensityLimits.intensityMinimum = static_cast<double>( integerIntensity.minimum() );
+                  data3DHeader.intensityLimits.intensityMaximum = static_cast<double>( integerIntensity.maximum() );
+               }
+
+               data3DHeader.pointFields.intensityNodeType = NumericalNodeType::Integer;
+
+               break;
             }
 
-            data3DHeader.pointFields.intensityScaledInteger = E57_NOT_SCALED_USE_INTEGER;
-         }
-         else if ( intensityProto.type() == TypeScaledInteger )
-         {
-            const ScaledIntegerNode scaledIntensity( intensityProto );
-            double scale = scaledIntensity.scale();
-            double offset = scaledIntensity.offset();
-
-            if ( data3DHeader.intensityLimits.intensityMaximum == 0.0 )
+            case TypeScaledInteger:
             {
-               const int64_t minimum = scaledIntensity.minimum();
-               const int64_t maximum = scaledIntensity.maximum();
+               const ScaledIntegerNode scaledIntensity( intensityProto );
+               double scale = scaledIntensity.scale();
+               double offset = scaledIntensity.offset();
 
-               data3DHeader.intensityLimits.intensityMinimum = static_cast<double>( minimum ) * scale + offset;
-               data3DHeader.intensityLimits.intensityMaximum = static_cast<double>( maximum ) * scale + offset;
+               if ( data3DHeader.intensityLimits.intensityMaximum == 0.0 )
+               {
+                  const int64_t minimum = scaledIntensity.minimum();
+                  const int64_t maximum = scaledIntensity.maximum();
+
+                  data3DHeader.intensityLimits.intensityMinimum = static_cast<double>( minimum ) * scale + offset;
+                  data3DHeader.intensityLimits.intensityMaximum = static_cast<double>( maximum ) * scale + offset;
+               }
+
+               data3DHeader.pointFields.intensityNodeType = NumericalNodeType::ScaledInteger;
+               data3DHeader.pointFields.intensityScale = scale;
+
+               break;
             }
 
-            data3DHeader.pointFields.intensityScaledInteger = scale;
-         }
-         else if ( proto.get( "intensity" ).type() == TypeFloat )
-         {
-            if ( data3DHeader.intensityLimits.intensityMaximum == 0.0 )
+            case TypeFloat:
             {
                const FloatNode floatIntensity( intensityProto );
 
                data3DHeader.intensityLimits.intensityMinimum = floatIntensity.minimum();
                data3DHeader.intensityLimits.intensityMaximum = floatIntensity.maximum();
+
+               if ( floatIntensity.precision() == PrecisionSingle )
+               {
+                  data3DHeader.pointFields.intensityNodeType = NumericalNodeType::Float;
+               }
+               else
+               {
+                  data3DHeader.pointFields.intensityNodeType = NumericalNodeType::Double;
+               }
+
+               break;
             }
 
-            data3DHeader.pointFields.intensityScaledInteger = E57_NOT_SCALED_USE_FLOAT;
+            default:
+               throw E57_EXCEPTION2( ErrorInvalidNodeType, "invalid node type reading intensity field: " +
+                                                              toString( intensityProto.type() ) );
+               break;
          }
       }
 

--- a/test/src/test_SimpleData.cpp
+++ b/test/src/test_SimpleData.cpp
@@ -10,11 +10,45 @@
 #include "Helpers.h"
 #include "TestData.h"
 
-TEST( SimpleDataHeader, InvalidPointSize )
+TEST( SimpleDataHeader, InvalidPointCount )
 {
    e57::Data3D dataHeader;
 
    E57_ASSERT_THROW( e57::Data3DPointsData pointsData( dataHeader ) );
+}
+
+TEST( SimpleDataHeader, InvalidPointRangeNodeType )
+{
+   e57::Data3D dataHeader;
+
+   dataHeader.pointCount = 1;
+   dataHeader.pointFields.pointRangeNodeType = e57::NumericalNodeType::Integer;
+
+   E57_ASSERT_THROW( e57::Data3DPointsData pointsData( dataHeader ) );
+}
+
+TEST( SimpleDataHeader, InvalidAngleNodeType )
+{
+   e57::Data3D dataHeader;
+
+   dataHeader.pointCount = 1;
+   dataHeader.pointFields.angleNodeType = e57::NumericalNodeType::Integer;
+
+   E57_ASSERT_THROW( e57::Data3DPointsData pointsData( dataHeader ) );
+}
+
+TEST( SimpleDataHeader, AutoSetNodeTypes )
+{
+   e57::Data3D dataHeader;
+
+   dataHeader.pointCount = 1;
+
+   // dataHeader.pointFields.pointRangeNodeType and dataHeader.pointFields.angleNodeType default to Float but we are
+   // using a double structure. The constructor should correct these and set them to Double.
+   e57::Data3DPointsData_d pointsData( dataHeader );
+
+   EXPECT_EQ( dataHeader.pointFields.pointRangeNodeType, e57::NumericalNodeType::Double );
+   EXPECT_EQ( dataHeader.pointFields.angleNodeType, e57::NumericalNodeType::Double );
 }
 
 TEST( SimpleDataHeader, HeaderMinMaxFloat )
@@ -155,12 +189,13 @@ TEST( SimpleData, ReadWrite )
 
    EXPECT_EQ( originalData3DHeader.pointFields.pointRangeMinimum, copyData3DHeader.pointFields.pointRangeMinimum );
    EXPECT_EQ( originalData3DHeader.pointFields.pointRangeMaximum, copyData3DHeader.pointFields.pointRangeMaximum );
-   EXPECT_EQ( originalData3DHeader.pointFields.pointRangeScaledInteger,
-              copyData3DHeader.pointFields.pointRangeScaledInteger );
+
+   EXPECT_EQ( originalData3DHeader.pointFields.pointRangeNodeType, copyData3DHeader.pointFields.pointRangeNodeType );
+   EXPECT_EQ( originalData3DHeader.pointFields.pointRangeScale, copyData3DHeader.pointFields.pointRangeScale );
 
    EXPECT_EQ( originalData3DHeader.pointFields.angleMinimum, copyData3DHeader.pointFields.angleMinimum );
    EXPECT_EQ( originalData3DHeader.pointFields.angleMaximum, copyData3DHeader.pointFields.angleMaximum );
-   EXPECT_EQ( originalData3DHeader.pointFields.angleScaledInteger, copyData3DHeader.pointFields.angleScaledInteger );
+   EXPECT_EQ( originalData3DHeader.pointFields.angleScale, copyData3DHeader.pointFields.angleScale );
 
    EXPECT_EQ( originalData3DHeader.pointFields.rowIndexField, copyData3DHeader.pointFields.rowIndexField );
    EXPECT_EQ( originalData3DHeader.pointFields.rowIndexMaximum, copyData3DHeader.pointFields.rowIndexMaximum );
@@ -181,8 +216,7 @@ TEST( SimpleData, ReadWrite )
    EXPECT_EQ( originalData3DHeader.pointFields.intensityField, copyData3DHeader.pointFields.intensityField );
    EXPECT_EQ( originalData3DHeader.pointFields.isIntensityInvalidField,
               copyData3DHeader.pointFields.isIntensityInvalidField );
-   EXPECT_EQ( originalData3DHeader.pointFields.intensityScaledInteger,
-              copyData3DHeader.pointFields.intensityScaledInteger );
+   EXPECT_EQ( originalData3DHeader.pointFields.intensityScale, copyData3DHeader.pointFields.intensityScale );
 
    EXPECT_EQ( originalData3DHeader.pointFields.colorRedField, copyData3DHeader.pointFields.colorRedField );
    EXPECT_EQ( originalData3DHeader.pointFields.colorGreenField, copyData3DHeader.pointFields.colorGreenField );

--- a/test/src/test_SimpleWriter.cpp
+++ b/test/src/test_SimpleWriter.cpp
@@ -162,9 +162,6 @@ TEST( SimpleWriter, ColouredCubeDouble )
    header.description = "libE57Format test: cube of coloured points using doubles";
    header.pointCount = cNumPoints;
 
-   // setting this to < 0.0 indicates we want to write doubles
-   header.pointFields.pointRangeScaledInteger = -1.0;
-
    setUsingColouredCartesianPoints( header );
 
    e57::Data3DPointsData_d pointsData( header );
@@ -275,8 +272,8 @@ TEST( SimpleWriter, ColouredCubeScaledInt )
    header.description = "libE57Format test: cube of coloured points using scaled integers";
    header.pointCount = cNumPoints;
 
-   // setting this to > 0.0 indicates we want to write scaled ints and to use this as the scale
-   header.pointFields.pointRangeScaledInteger = 0.001;
+   header.pointFields.pointRangeNodeType = e57::NumericalNodeType::ScaledInteger;
+   header.pointFields.pointRangeScale = 0.001;
 
    setUsingColouredCartesianPoints( header );
 
@@ -462,11 +459,14 @@ TEST( SimpleWriter, MinMaxIssuesCartesianFloat )
    header.pointFields.cartesianZField = true;
 
    // Using any of these without setting their min/max explicitly should not fail
-   header.pointFields.pointRangeScaledInteger = 0.1;
+   header.pointFields.pointRangeNodeType = e57::NumericalNodeType::ScaledInteger;
+   header.pointFields.pointRangeScale = 0.1;
    header.pointFields.timeStampField = true;
-   header.pointFields.timeScaledInteger = 0.1;
+   header.pointFields.timeNodeType = e57::NumericalNodeType::ScaledInteger;
+   header.pointFields.timeScale = 0.1;
    header.pointFields.intensityField = true;
-   header.pointFields.intensityScaledInteger = 0.1;
+   header.pointFields.intensityNodeType = e57::NumericalNodeType::ScaledInteger;
+   header.pointFields.intensityScale = 0.1;
 
    e57::Data3DPointsData pointsData( header );
 
@@ -521,11 +521,14 @@ TEST( SimpleWriter, MinMaxIssuesSpericalDouble )
    header.pointFields.sphericalElevationField = true;
 
    // Using any of these without setting their min/max explicitly should not fail
-   header.pointFields.pointRangeScaledInteger = 0.1;
+   header.pointFields.pointRangeNodeType = e57::NumericalNodeType::ScaledInteger;
+   header.pointFields.pointRangeScale = 0.1;
    header.pointFields.timeStampField = true;
-   header.pointFields.timeScaledInteger = 0.1;
+   header.pointFields.timeNodeType = e57::NumericalNodeType::ScaledInteger;
+   header.pointFields.timeScale = 0.1;
    header.pointFields.intensityField = true;
-   header.pointFields.intensityScaledInteger = 0.1;
+   header.pointFields.intensityNodeType = e57::NumericalNodeType::ScaledInteger;
+   header.pointFields.intensityScale = 0.1;
 
    e57::Data3DPointsData_d pointsData( header );
 


### PR DESCRIPTION
Instead of using one field to indicate the node type & set the scale if the type is ScaledInteger, split it into two fields. This makes the node type selection explicit and easier to understand. 

Note that this is an API-breaking change.

As discussed in [#126](https://github.com/asmaloney/libE57Format/issues/126), the current setup is very confusing. Right now these fields mean [several different things](https://github.com/asmaloney/libE57Format/issues/157) depending on which one we are using.

If not using ScaledInteger, it also has the advantage of automatically choosing float or double point types based on whether we are using `e57::Data3DPointsData` or `e57::Data3DPointsData_d` (if we use the new constructor).

To see how it changes things, please see the updated tests.

@ptc-jhoerner @nigels-com @MCVin Once we've settled on an implementation, I will change the other fields in `e57::PointStandardizedFieldsAvailable` to use the same method so everything is consistent.

Once all fields are converted, `E57_NOT_SCALED_USE_FLOAT` and `E57_NOT_SCALED_USE_INTEGER` will go away.