### PR TITLE
Major formatting & doxygen pass

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -49,8 +49,8 @@ BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: AfterColon
 BreakStringLiterals: true
-ColumnLimit: 120
-CommentPragmas: '^ IWYU pragma:'
+ColumnLimit: 100
+CommentPragmas: '@copydetails '
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 3

--- a/include/E57Exception.h
+++ b/include/E57Exception.h
@@ -27,7 +27,7 @@
 
 #pragma once
 
-//! @file E57Exception.h Exception handling for E57 API.
+/// @file E57Exception.h Exception handling for E57 API.
 
 #include <exception>
 #include <iostream>
@@ -37,201 +37,263 @@
 
 namespace e57
 {
-   //! @brief Numeric error identifiers used in E57Exception
+   /// @brief Numeric error identifiers used in E57Exception
    enum ErrorCode
    {
-      // NOTE: When changing error strings here, remember to update the error strings in E57Exception.cpp
+      // NOTE: When changing error strings here, remember to update the error strings in
+      // E57Exception.cpp
 
-      Success = 0,                          //!< operation was successful
-      ErrorBadCVHeader = 1,                 //!< a CompressedVector binary header was bad
-      ErrorBadCVPacket = 2,                 //!< a CompressedVector binary packet was bad
-      ErrorChildIndexOutOfBounds = 3,       //!< a numerical index identifying a child was out of bounds
-      ErrorSetTwice = 4,                    //!< attempted to set an existing child element to a new value
-      ErrorHomogeneousViolation = 5,        //!< attempted to add an element that would have made the children of a
-                                            //!< homogeneous ::TypeVector have different types
-      ErrorValueNotRepresentable = 6,       //!< a value could not be represented in the requested type
-      ErrorScaledValueNotRepresentable = 7, //!< after scaling the result could not be represented in the requested type
-      ErrorReal64TooLarge = 8,              //!< a 64 bit IEEE float was too large to store in a 32 bit IEEE float
-      ErrorExpectingNumeric = 9,            //!< Expecting numeric representation in user's buffer, found ustring
-      ErrorExpectingUString = 10,           //!< Expecting string representation in user's buffer, found numeric
-      ErrorInternal = 11,                   //!< An unrecoverable inconsistent internal state was detected
-      ErrorBadXMLFormat = 12,               //!< E57 primitive not encoded in XML correctly
-      ErrorXMLParser = 13,                  //!< XML not well formed
-      ErrorBadAPIArgument = 14,             //!< bad API function argument provided by user
-      ErrorFileReadOnly = 15,               //!< can't modify read only file
-      ErrorBadChecksum = 16,                //!< checksum mismatch, file is corrupted
-      ErrorOpenFailed = 17,                 //!< open() failed
-      ErrorCloseFailed = 18,                //!< close() failed
-      ErrorReadFailed = 19,                 //!< read() failed
-      ErrorWriteFailed = 20,                //!< write() failed
-      ErrorSeekFailed = 21,                 //!< lseek() failed
-      ErrorPathUndefined = 22,              //!< element path well formed but not defined
-      ErrorBadBuffer = 23,                  //!< bad SourceDestBuffer
-      ErrorNoBufferForElement = 24,         //!< no buffer specified for an element in CompressedVectorNode during write
-      ErrorBufferSizeMismatch = 25,         //!< SourceDestBuffers not all same size
-      ErrorBufferDuplicatePathName = 26,    //!< duplicate pathname in CompressedVectorNode read/write
-      ErrorBadFileSignature = 27,           //!< file signature not "ASTM-E57"
-      ErrorUnknownFileVersion = 28,         //!< incompatible file version
-      ErrorBadFileLength = 29,              //!< size in file header not same as actual
-      ErrorXMLParserInit = 30,              //!< XML parser failed to initialize
-      ErrorDuplicateNamespacePrefix = 31,   //!< namespace prefix already defined
-      ErrorDuplicateNamespaceURI = 32,      //!< namespace URI already defined
-      ErrorBadPrototype = 33,               //!< bad prototype in CompressedVectorNode
-      ErrorBadCodecs = 34,                  //!< bad codecs in CompressedVectorNode
-      ErrorValueOutOfBounds = 35,           //!< element value out of min/max bounds
-      ErrorConversionRequired = 36,         //!< conversion required to assign element value, but not requested
-      ErrorBadPathName = 37,                //!< E57 path name is not well formed
-      ErrorNotImplemented = 38,             //!< functionality not implemented
-      ErrorBadNodeDowncast = 39,            //!< bad downcast from Node to specific node type
-      ErrorWriterNotOpen = 40,              //!< CompressedVectorWriter is no longer open
-      ErrorReaderNotOpen = 41,              //!< CompressedVectorReader is no longer open
-      ErrorNodeUnattached = 42,             //!< node is not yet attached to tree of ImageFile
-      ErrorAlreadyHasParent = 43,           //!< node already has a parent
-      ErrorDifferentDestImageFile = 44,     //!< nodes were constructed with different destImageFiles
-      ErrorImageFileNotOpen = 45,           //!< destImageFile is no longer open
-      ErrorBuffersNotCompatible = 46,       //!< SourceDestBuffers not compatible with previously given ones
-      ErrorTooManyWriters = 47,             //!< too many open CompressedVectorWriters of an ImageFile
-      ErrorTooManyReaders = 48,             //!< too many open CompressedVectorReaders of an ImageFile
-      ErrorBadConfiguration = 49,           //!< bad configuration string
-      ErrorInvarianceViolation = 50,        //!< class invariance constraint violation in debug mode
+      Success = 0, ///< operation was successful
 
-      ErrorInvalidNodeType = 51, ///< an invalid note type was passed in Data3D pointFields
+      ErrorBadCVHeader = 1,           ///< a CompressedVector binary header was bad
+      ErrorBadCVPacket = 2,           ///< a CompressedVector binary packet was bad
+      ErrorChildIndexOutOfBounds = 3, ///< a numerical index identifying a child was out of bounds
+      ErrorSetTwice = 4,              ///< attempted to set an existing child element to a new value
+
+      /// @brief attempted to add an element that would have made the children of a homogeneous
+      /// ::TypeVector have different types
+      ErrorHomogeneousViolation = 5,
+
+      /// a value could not be represented in the requested type
+      ErrorValueNotRepresentable = 6,
+
+      /// after scaling the result could not be represented in the requested type
+      ErrorScaledValueNotRepresentable = 7,
+
+      /// a 64 bit IEEE float was too large to store in a 32 bit IEEE float
+      ErrorReal64TooLarge = 8,
+
+      /// expecting numeric representation in user's buffer, found ustring
+      ErrorExpectingNumeric = 9,
+
+      /// expecting string representation in user's buffer, found numeric
+      ErrorExpectingUString = 10,
+
+      ErrorInternal = 11,       ///< An unrecoverable inconsistent internal state was detected
+      ErrorBadXMLFormat = 12,   ///< E57 primitive not encoded in XML correctly
+      ErrorXMLParser = 13,      ///< XML not well formed
+      ErrorBadAPIArgument = 14, ///< bad API function argument provided by user
+      ErrorFileReadOnly = 15,   ///< can't modify read only file
+      ErrorBadChecksum = 16,    ///< checksum mismatch, file is corrupted
+      ErrorOpenFailed = 17,     ///< open() failed
+      ErrorCloseFailed = 18,    ///< close() failed
+      ErrorReadFailed = 19,     ///< read() failed
+      ErrorWriteFailed = 20,    ///< write() failed
+      ErrorSeekFailed = 21,     ///< lseek() failed
+      ErrorPathUndefined = 22,  ///< element path well formed but not defined
+      ErrorBadBuffer = 23,      ///< bad SourceDestBuffer
+
+      /// no buffer specified for an element in CompressedVectorNode during write
+      ErrorNoBufferForElement = 24,
+
+      ErrorBufferSizeMismatch = 25,       ///< SourceDestBuffers not all same size
+      ErrorBufferDuplicatePathName = 26,  ///< duplicate pathname in CompressedVectorNode read/write
+      ErrorBadFileSignature = 27,         ///< file signature not "ASTM-E57"
+      ErrorUnknownFileVersion = 28,       ///< incompatible file version
+      ErrorBadFileLength = 29,            ///< size in file header not same as actual
+      ErrorXMLParserInit = 30,            ///< XML parser failed to initialize
+      ErrorDuplicateNamespacePrefix = 31, ///< namespace prefix already defined
+      ErrorDuplicateNamespaceURI = 32,    ///< namespace URI already defined
+      ErrorBadPrototype = 33,             ///< bad prototype in CompressedVectorNode
+      ErrorBadCodecs = 34,                ///< bad codecs in CompressedVectorNode
+      ErrorValueOutOfBounds = 35,         ///< element value out of min/max bounds
+
+      /// conversion required to assign element value, but not requested
+      ErrorConversionRequired = 36,
+
+      ErrorBadPathName = 37,            ///< E57 path name is not well formed
+      ErrorNotImplemented = 38,         ///< functionality not implemented
+      ErrorBadNodeDowncast = 39,        ///< bad downcast from Node to specific node type
+      ErrorWriterNotOpen = 40,          ///< CompressedVectorWriter is no longer open
+      ErrorReaderNotOpen = 41,          ///< CompressedVectorReader is no longer open
+      ErrorNodeUnattached = 42,         ///< node is not yet attached to tree of ImageFile
+      ErrorAlreadyHasParent = 43,       ///< node already has a parent
+      ErrorDifferentDestImageFile = 44, ///< nodes were constructed with different destImageFiles
+      ErrorImageFileNotOpen = 45,       ///< destImageFile is no longer open
+
+      /// SourceDestBuffers not compatible with previously given ones
+      ErrorBuffersNotCompatible = 46,
+
+      ErrorTooManyWriters = 47,      ///< too many open CompressedVectorWriters of an ImageFile
+      ErrorTooManyReaders = 48,      ///< too many open CompressedVectorReaders of an ImageFile
+      ErrorBadConfiguration = 49,    ///< bad configuration string
+      ErrorInvarianceViolation = 50, ///< class invariance constraint violation in debug mode
+
+      /// an invalid node type was passed in Data3D pointFields
+      ErrorInvalidNodeType = 51,
 
       /// @deprecated Will be removed in 4.0. Use e57::Success.
       E57_SUCCESS [[deprecated( "Will be removed in 4.0. Use Success." )]] = Success,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadCVHeader.
-      E57_ERROR_BAD_CV_HEADER [[deprecated( "Will be removed in 4.0. Use ErrorBadCVHeader." )]] = ErrorBadCVHeader,
+      E57_ERROR_BAD_CV_HEADER [[deprecated( "Will be removed in 4.0. Use ErrorBadCVHeader." )]] =
+         ErrorBadCVHeader,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadCVPacket.
-      E57_ERROR_BAD_CV_PACKET [[deprecated( "Will be removed in 4.0. Use ErrorBadCVPacket." )]] = ErrorBadCVPacket,
+      E57_ERROR_BAD_CV_PACKET [[deprecated( "Will be removed in 4.0. Use ErrorBadCVPacket." )]] =
+         ErrorBadCVPacket,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorChildIndexOutOfBounds.
-      E57_ERROR_CHILD_INDEX_OUT_OF_BOUNDS [[deprecated( "Will be removed in 4.0. Use ErrorChildIndexOutOfBounds." )]] =
+      E57_ERROR_CHILD_INDEX_OUT_OF_BOUNDS
+      [[deprecated( "Will be removed in 4.0. Use ErrorChildIndexOutOfBounds." )]] =
          ErrorChildIndexOutOfBounds,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorSetTwice.
-      E57_ERROR_SET_TWICE [[deprecated( "Will be removed in 4.0. Use ErrorSetTwice." )]] = ErrorSetTwice,
+      E57_ERROR_SET_TWICE [[deprecated( "Will be removed in 4.0. Use ErrorSetTwice." )]] =
+         ErrorSetTwice,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorHomogeneousViolation.
-      E57_ERROR_HOMOGENEOUS_VIOLATION [[deprecated( "Will be removed in 4.0. Use ErrorHomogeneousViolation." )]] =
+      E57_ERROR_HOMOGENEOUS_VIOLATION
+      [[deprecated( "Will be removed in 4.0. Use ErrorHomogeneousViolation." )]] =
          ErrorHomogeneousViolation,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorValueNotRepresentable.
-      E57_ERROR_VALUE_NOT_REPRESENTABLE [[deprecated( "Will be removed in 4.0. Use ErrorValueNotRepresentable." )]] =
+      E57_ERROR_VALUE_NOT_REPRESENTABLE
+      [[deprecated( "Will be removed in 4.0. Use ErrorValueNotRepresentable." )]] =
          ErrorValueNotRepresentable,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorScaledValueNotRepresentable.
       E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE
       [[deprecated( "Will be removed in 4.0. Use ErrorScaledValueNotRepresentable." )]] =
          ErrorScaledValueNotRepresentable,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorReal64TooLarge.
-      E57_ERROR_REAL64_TOO_LARGE [[deprecated( "Will be removed in 4.0. Use ErrorReal64TooLarge." )]] =
-         ErrorReal64TooLarge,
+      E57_ERROR_REAL64_TOO_LARGE
+      [[deprecated( "Will be removed in 4.0. Use ErrorReal64TooLarge." )]] = ErrorReal64TooLarge,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorExpectingNumeric.
-      E57_ERROR_EXPECTING_NUMERIC [[deprecated( "Will be removed in 4.0. Use ErrorExpectingNumeric." )]] =
+      E57_ERROR_EXPECTING_NUMERIC
+      [[deprecated( "Will be removed in 4.0. Use ErrorExpectingNumeric." )]] =
          ErrorExpectingNumeric,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorExpectingUString.
-      E57_ERROR_EXPECTING_USTRING [[deprecated( "Will be removed in 4.0. Use ErrorExpectingUString." )]] =
+      E57_ERROR_EXPECTING_USTRING
+      [[deprecated( "Will be removed in 4.0. Use ErrorExpectingUString." )]] =
          ErrorExpectingUString,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorInternal.
-      E57_ERROR_INTERNAL [[deprecated( "Will be removed in 4.0. Use ErrorInternal." )]] = ErrorInternal,
+      E57_ERROR_INTERNAL [[deprecated( "Will be removed in 4.0. Use ErrorInternal." )]] =
+         ErrorInternal,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadXMLFormat.
-      E57_ERROR_BAD_XML_FORMAT [[deprecated( "Will be removed in 4.0. Use ErrorBadXMLFormat." )]] = ErrorBadXMLFormat,
+      E57_ERROR_BAD_XML_FORMAT [[deprecated( "Will be removed in 4.0. Use ErrorBadXMLFormat." )]] =
+         ErrorBadXMLFormat,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorXMLParser.
-      E57_ERROR_XML_PARSER [[deprecated( "Will be removed in 4.0. Use ErrorXMLParser." )]] = ErrorXMLParser,
+      E57_ERROR_XML_PARSER [[deprecated( "Will be removed in 4.0. Use ErrorXMLParser." )]] =
+         ErrorXMLParser,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadAPIArgument.
-      E57_ERROR_BAD_API_ARGUMENT [[deprecated( "Will be removed in 4.0. Use ErrorBadAPIArgument." )]] =
-         ErrorBadAPIArgument,
+      E57_ERROR_BAD_API_ARGUMENT
+      [[deprecated( "Will be removed in 4.0. Use ErrorBadAPIArgument." )]] = ErrorBadAPIArgument,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorFileReadOnly.
-      E57_ERROR_FILE_IS_READ_ONLY [[deprecated( "Will be removed in 4.0. Use ErrorFileReadOnly." )]] =
-         ErrorFileReadOnly,
+      E57_ERROR_FILE_IS_READ_ONLY
+      [[deprecated( "Will be removed in 4.0. Use ErrorFileReadOnly." )]] = ErrorFileReadOnly,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadChecksum.
-      E57_ERROR_BAD_CHECKSUM [[deprecated( "Will be removed in 4.0. Use ErrorBadChecksum." )]] = ErrorBadChecksum,
+      E57_ERROR_BAD_CHECKSUM [[deprecated( "Will be removed in 4.0. Use ErrorBadChecksum." )]] =
+         ErrorBadChecksum,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorOpenFailed.
-      E57_ERROR_OPEN_FAILED [[deprecated( "Will be removed in 4.0. Use ErrorOpenFailed." )]] = ErrorOpenFailed,
+      E57_ERROR_OPEN_FAILED [[deprecated( "Will be removed in 4.0. Use ErrorOpenFailed." )]] =
+         ErrorOpenFailed,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorCloseFailed.
-      E57_ERROR_CLOSE_FAILED [[deprecated( "Will be removed in 4.0. Use ErrorCloseFailed." )]] = ErrorCloseFailed,
+      E57_ERROR_CLOSE_FAILED [[deprecated( "Will be removed in 4.0. Use ErrorCloseFailed." )]] =
+         ErrorCloseFailed,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorReadFailed.
-      E57_ERROR_READ_FAILED [[deprecated( "Will be removed in 4.0. Use ErrorReadFailed." )]] = ErrorReadFailed,
+      E57_ERROR_READ_FAILED [[deprecated( "Will be removed in 4.0. Use ErrorReadFailed." )]] =
+         ErrorReadFailed,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorWriteFailed.
-      E57_ERROR_WRITE_FAILED [[deprecated( "Will be removed in 4.0. Use ErrorWriteFailed." )]] = ErrorWriteFailed,
+      E57_ERROR_WRITE_FAILED [[deprecated( "Will be removed in 4.0. Use ErrorWriteFailed." )]] =
+         ErrorWriteFailed,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorSeekFailed.
-      E57_ERROR_LSEEK_FAILED [[deprecated( "Will be removed in 4.0. Use ErrorSeekFailed." )]] = ErrorSeekFailed,
+      E57_ERROR_LSEEK_FAILED [[deprecated( "Will be removed in 4.0. Use ErrorSeekFailed." )]] =
+         ErrorSeekFailed,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorPathUndefined.
-      E57_ERROR_PATH_UNDEFINED [[deprecated( "Will be removed in 4.0. Use ErrorPathUndefined." )]] = ErrorPathUndefined,
+      E57_ERROR_PATH_UNDEFINED [[deprecated( "Will be removed in 4.0. Use ErrorPathUndefined." )]] =
+         ErrorPathUndefined,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadBuffer.
-      E57_ERROR_BAD_BUFFER [[deprecated( "Will be removed in 4.0. Use ErrorBadBuffer." )]] = ErrorBadBuffer,
+      E57_ERROR_BAD_BUFFER [[deprecated( "Will be removed in 4.0. Use ErrorBadBuffer." )]] =
+         ErrorBadBuffer,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorNoBufferForElement.
-      E57_ERROR_NO_BUFFER_FOR_ELEMENT [[deprecated( "Will be removed in 4.0. Use ErrorNoBufferForElement." )]] =
+      E57_ERROR_NO_BUFFER_FOR_ELEMENT
+      [[deprecated( "Will be removed in 4.0. Use ErrorNoBufferForElement." )]] =
          ErrorNoBufferForElement,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBufferSizeMismatch.
-      E57_ERROR_BUFFER_SIZE_MISMATCH [[deprecated( "Will be removed in 4.0. Use ErrorBufferSizeMismatch." )]] =
+      E57_ERROR_BUFFER_SIZE_MISMATCH
+      [[deprecated( "Will be removed in 4.0. Use ErrorBufferSizeMismatch." )]] =
          ErrorBufferSizeMismatch,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBufferDuplicatePathName.
       E57_ERROR_BUFFER_DUPLICATE_PATHNAME
-      [[deprecated( "Will be removed in 4.0. Use ErrorBufferDuplicatePathName." )]] = ErrorBufferDuplicatePathName,
+      [[deprecated( "Will be removed in 4.0. Use ErrorBufferDuplicatePathName." )]] =
+         ErrorBufferDuplicatePathName,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadFileSignature.
-      E57_ERROR_BAD_FILE_SIGNATURE [[deprecated( "Will be removed in 4.0. Use ErrorBadFileSignature." )]] =
+      E57_ERROR_BAD_FILE_SIGNATURE
+      [[deprecated( "Will be removed in 4.0. Use ErrorBadFileSignature." )]] =
          ErrorBadFileSignature,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorUnknownFileVersion.
-      E57_ERROR_UNKNOWN_FILE_VERSION [[deprecated( "Will be removed in 4.0. Use ErrorUnknownFileVersion." )]] =
+      E57_ERROR_UNKNOWN_FILE_VERSION
+      [[deprecated( "Will be removed in 4.0. Use ErrorUnknownFileVersion." )]] =
          ErrorUnknownFileVersion,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadFileLength.
-      E57_ERROR_BAD_FILE_LENGTH [[deprecated( "Will be removed in 4.0. Use ErrorBadFileLength." )]] =
-         ErrorBadFileLength,
+      E57_ERROR_BAD_FILE_LENGTH
+      [[deprecated( "Will be removed in 4.0. Use ErrorBadFileLength." )]] = ErrorBadFileLength,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorXMLParserInit.
-      E57_ERROR_XML_PARSER_INIT [[deprecated( "Will be removed in 4.0. Use ErrorXMLParserInit." )]] =
-         ErrorXMLParserInit,
+      E57_ERROR_XML_PARSER_INIT
+      [[deprecated( "Will be removed in 4.0. Use ErrorXMLParserInit." )]] = ErrorXMLParserInit,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorDuplicateNamespacePrefix.
       E57_ERROR_DUPLICATE_NAMESPACE_PREFIX
-      [[deprecated( "Will be removed in 4.0. Use ErrorDuplicateNamespacePrefix." )]] = ErrorDuplicateNamespacePrefix,
+      [[deprecated( "Will be removed in 4.0. Use ErrorDuplicateNamespacePrefix." )]] =
+         ErrorDuplicateNamespacePrefix,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorDuplicateNamespaceURI.
-      E57_ERROR_DUPLICATE_NAMESPACE_URI [[deprecated( "Will be removed in 4.0. Use ErrorDuplicateNamespaceURI." )]] =
+      E57_ERROR_DUPLICATE_NAMESPACE_URI
+      [[deprecated( "Will be removed in 4.0. Use ErrorDuplicateNamespaceURI." )]] =
          ErrorDuplicateNamespaceURI,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadPrototype.
-      E57_ERROR_BAD_PROTOTYPE [[deprecated( "Will be removed in 4.0. Use ErrorBadPrototype." )]] = ErrorBadPrototype,
+      E57_ERROR_BAD_PROTOTYPE [[deprecated( "Will be removed in 4.0. Use ErrorBadPrototype." )]] =
+         ErrorBadPrototype,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadCodecs.
-      E57_ERROR_BAD_CODECS [[deprecated( "Will be removed in 4.0. Use ErrorBadCodecs." )]] = ErrorBadCodecs,
+      E57_ERROR_BAD_CODECS [[deprecated( "Will be removed in 4.0. Use ErrorBadCodecs." )]] =
+         ErrorBadCodecs,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorValueOutOfBounds.
-      E57_ERROR_VALUE_OUT_OF_BOUNDS [[deprecated( "Will be removed in 4.0. Use ErrorValueOutOfBounds." )]] =
+      E57_ERROR_VALUE_OUT_OF_BOUNDS
+      [[deprecated( "Will be removed in 4.0. Use ErrorValueOutOfBounds." )]] =
          ErrorValueOutOfBounds,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorConversionRequired.
-      E57_ERROR_CONVERSION_REQUIRED [[deprecated( "Will be removed in 4.0. Use ErrorConversionRequired." )]] =
+      E57_ERROR_CONVERSION_REQUIRED
+      [[deprecated( "Will be removed in 4.0. Use ErrorConversionRequired." )]] =
          ErrorConversionRequired,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadPathName.
-      E57_ERROR_BAD_PATH_NAME [[deprecated( "Will be removed in 4.0. Use ErrorBadPathName." )]] = ErrorBadPathName,
+      E57_ERROR_BAD_PATH_NAME [[deprecated( "Will be removed in 4.0. Use ErrorBadPathName." )]] =
+         ErrorBadPathName,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorNotImplemented.
-      E57_ERROR_NOT_IMPLEMENTED [[deprecated( "Will be removed in 4.0. Use ErrorNotImplemented." )]] =
-         ErrorNotImplemented,
+      E57_ERROR_NOT_IMPLEMENTED
+      [[deprecated( "Will be removed in 4.0. Use ErrorNotImplemented." )]] = ErrorNotImplemented,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadNodeDowncast.
-      E57_ERROR_BAD_NODE_DOWNCAST [[deprecated( "Will be removed in 4.0. Use ErrorBadNodeDowncast." )]] =
-         ErrorBadNodeDowncast,
+      E57_ERROR_BAD_NODE_DOWNCAST
+      [[deprecated( "Will be removed in 4.0. Use ErrorBadNodeDowncast." )]] = ErrorBadNodeDowncast,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorWriterNotOpen.
-      E57_ERROR_WRITER_NOT_OPEN [[deprecated( "Will be removed in 4.0. Use ErrorWriterNotOpen." )]] =
-         ErrorWriterNotOpen,
+      E57_ERROR_WRITER_NOT_OPEN
+      [[deprecated( "Will be removed in 4.0. Use ErrorWriterNotOpen." )]] = ErrorWriterNotOpen,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorReaderNotOpen.
-      E57_ERROR_READER_NOT_OPEN [[deprecated( "Will be removed in 4.0. Use ErrorReaderNotOpen." )]] =
-         ErrorReaderNotOpen,
+      E57_ERROR_READER_NOT_OPEN
+      [[deprecated( "Will be removed in 4.0. Use ErrorReaderNotOpen." )]] = ErrorReaderNotOpen,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorNodeUnattached.
-      E57_ERROR_NODE_UNATTACHED [[deprecated( "Will be removed in 4.0. Use ErrorNodeUnattached." )]] =
-         ErrorNodeUnattached,
+      E57_ERROR_NODE_UNATTACHED
+      [[deprecated( "Will be removed in 4.0. Use ErrorNodeUnattached." )]] = ErrorNodeUnattached,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorAlreadyHasParent.
-      E57_ERROR_ALREADY_HAS_PARENT [[deprecated( "Will be removed in 4.0. Use ErrorAlreadyHasParent." )]] =
+      E57_ERROR_ALREADY_HAS_PARENT
+      [[deprecated( "Will be removed in 4.0. Use ErrorAlreadyHasParent." )]] =
          ErrorAlreadyHasParent,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorDifferentDestImageFile.
-      E57_ERROR_DIFFERENT_DEST_IMAGEFILE [[deprecated( "Will be removed in 4.0. Use ErrorDifferentDestImageFile." )]] =
+      E57_ERROR_DIFFERENT_DEST_IMAGEFILE
+      [[deprecated( "Will be removed in 4.0. Use ErrorDifferentDestImageFile." )]] =
          ErrorDifferentDestImageFile,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorImageFileNotOpen.
-      E57_ERROR_IMAGEFILE_NOT_OPEN [[deprecated( "Will be removed in 4.0. Use ErrorImageFileNotOpen." )]] =
+      E57_ERROR_IMAGEFILE_NOT_OPEN
+      [[deprecated( "Will be removed in 4.0. Use ErrorImageFileNotOpen." )]] =
          ErrorImageFileNotOpen,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBuffersNotCompatible.
-      E57_ERROR_BUFFERS_NOT_COMPATIBLE [[deprecated( "Will be removed in 4.0. Use ErrorBuffersNotCompatible." )]] =
+      E57_ERROR_BUFFERS_NOT_COMPATIBLE
+      [[deprecated( "Will be removed in 4.0. Use ErrorBuffersNotCompatible." )]] =
          ErrorBuffersNotCompatible,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorTooManyWriters.
-      E57_ERROR_TOO_MANY_WRITERS [[deprecated( "Will be removed in 4.0. Use ErrorTooManyWriters." )]] =
-         ErrorTooManyWriters,
+      E57_ERROR_TOO_MANY_WRITERS
+      [[deprecated( "Will be removed in 4.0. Use ErrorTooManyWriters." )]] = ErrorTooManyWriters,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorTooManyReaders.
-      E57_ERROR_TOO_MANY_READERS [[deprecated( "Will be removed in 4.0. Use ErrorTooManyReaders." )]] =
-         ErrorTooManyReaders,
+      E57_ERROR_TOO_MANY_READERS
+      [[deprecated( "Will be removed in 4.0. Use ErrorTooManyReaders." )]] = ErrorTooManyReaders,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadConfiguration.
-      E57_ERROR_BAD_CONFIGURATION [[deprecated( "Will be removed in 4.0. Use ErrorBadConfiguration." )]] =
+      E57_ERROR_BAD_CONFIGURATION
+      [[deprecated( "Will be removed in 4.0. Use ErrorBadConfiguration." )]] =
          ErrorBadConfiguration,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorInvarianceViolation.
-      E57_ERROR_INVARIANCE_VIOLATION [[deprecated( "Will be removed in 4.0. Use ErrorInvarianceViolation." )]] =
+      E57_ERROR_INVARIANCE_VIOLATION
+      [[deprecated( "Will be removed in 4.0. Use ErrorInvarianceViolation." )]] =
          ErrorInvarianceViolation,
    };
 
@@ -241,7 +303,8 @@ namespace e57
       const char *what() const noexcept override;
 
       void report( const char *reportingFileName = nullptr, int reportingLineNumber = 0,
-                   const char *reportingFunctionName = nullptr, std::ostream &os = std::cout ) const noexcept;
+                   const char *reportingFunctionName = nullptr,
+                   std::ostream &os = std::cout ) const noexcept;
 
       ErrorCode errorCode() const noexcept;
       std::string errorStr() const noexcept;
@@ -253,10 +316,10 @@ namespace e57
       const char *sourceFunctionName() const noexcept;
       int sourceLineNumber() const noexcept;
 
-      //! \cond documentNonPublic   The following isn't part of the API, and isn't documented.
+      /// \cond documentNonPublic   The following isn't part of the API, and isn't documented.
       E57Exception() = delete;
-      E57Exception( ErrorCode ecode, std::string context, const char *srcFileName = nullptr, int srcLineNumber = 0,
-                    const char *srcFunctionName = nullptr );
+      E57Exception( ErrorCode ecode, std::string context, const char *srcFileName = nullptr,
+                    int srcLineNumber = 0, const char *srcFunctionName = nullptr );
 
    private:
       ErrorCode errorCode_;
@@ -264,7 +327,7 @@ namespace e57
       std::string sourceFileName_;
       const char *sourceFunctionName_;
       int sourceLineNumber_;
-      //! \endcond
+      /// \endcond
    };
 
    namespace Utilities

--- a/include/E57Format.h
+++ b/include/E57Format.h
@@ -29,7 +29,7 @@
 
 #pragma once
 
-//! @file  E57Format.h Header file for the E57 API.
+/// @file  E57Format.h Header file for the E57 API.
 
 #include <cfloat>
 #include <cstdint>
@@ -50,20 +50,20 @@ namespace e57
    using std::uint8_t;
 
    // Shorthand for unicode string
-   //! @brief UTF-8 encoded Unicode string
+   /// @brief UTF-8 encoded Unicode string
    using ustring = std::string;
 
-   //! @brief Identifiers for types of E57 elements
+   /// @brief Identifiers for types of E57 elements
    enum NodeType
    {
-      TypeStructure = 1,        //!< StructureNode class
-      TypeVector = 2,           //!< VectorNode class
-      TypeCompressedVector = 3, //!< CompressedVectorNode class
-      TypeInteger = 4,          //!< IntegerNode class
-      TypeScaledInteger = 5,    //!< ScaledIntegerNode class
-      TypeFloat = 6,            //!< FloatNode class
-      TypeString = 7,           //!< StringNode class
-      TypeBlob = 8,             //!< BlobNode class
+      TypeStructure = 1,        ///< StructureNode class
+      TypeVector = 2,           ///< VectorNode class
+      TypeCompressedVector = 3, ///< CompressedVectorNode class
+      TypeInteger = 4,          ///< IntegerNode class
+      TypeScaledInteger = 5,    ///< ScaledIntegerNode class
+      TypeFloat = 6,            ///< FloatNode class
+      TypeString = 7,           ///< StringNode class
+      TypeBlob = 8,             ///< BlobNode class
 
       /// @deprecated Will be removed in 4.0. Use e57::TypeStructure.
       E57_STRUCTURE [[deprecated( "Will be removed in 4.0. Use TypeStructure." )]] = TypeStructure,
@@ -75,7 +75,8 @@ namespace e57
       /// @deprecated Will be removed in 4.0. Use e57::TypeInteger.
       E57_INTEGER [[deprecated( "Will be removed in 4.0. Use TypeInteger." )]] = TypeInteger,
       /// @deprecated Will be removed in 4.0. Use e57::TypeScaledInteger.
-      E57_SCALED_INTEGER [[deprecated( "Will be removed in 4.0. Use TypeScaledInteger." )]] = TypeScaledInteger,
+      E57_SCALED_INTEGER [[deprecated( "Will be removed in 4.0. Use TypeScaledInteger." )]] =
+         TypeScaledInteger,
       /// @deprecated Will be removed in 4.0. Use e57::TypeFloat.
       E57_FLOAT [[deprecated( "Will be removed in 4.0. Use TypeFloat." )]] = TypeFloat,
       /// @deprecated Will be removed in 4.0. Use e57::TypeString.
@@ -84,11 +85,11 @@ namespace e57
       E57_BLOB [[deprecated( "Will be removed in 4.0. Use TypeBlob." )]] = TypeBlob
    };
 
-   //! @brief The IEEE floating point number precisions supported
+   /// @brief The IEEE floating point number precisions supported
    enum FloatPrecision
    {
-      PrecisionSingle = 1, //!< 32 bit IEEE floating point number format
-      PrecisionDouble = 2, //!< 64 bit IEEE floating point number format
+      PrecisionSingle = 1, ///< 32 bit IEEE floating point number format
+      PrecisionDouble = 2, ///< 64 bit IEEE floating point number format
 
       /// @deprecated Will be removed in 4.0. Use e57::PrecisionSingle.
       E57_SINGLE [[deprecated( "Will be removed in 4.0. Use PrecisionSingle." )]] = PrecisionSingle,
@@ -96,20 +97,20 @@ namespace e57
       E57_DOUBLE [[deprecated( "Will be removed in 4.0. Use PrecisionDouble." )]] = PrecisionDouble
    };
 
-   //! @brief Identifies the representations of memory elements API can transfer data to/from
+   /// @brief Identifies the representations of memory elements API can transfer data to/from
    enum MemoryRepresentation
    {
-      Int8 = 1,     //!< 8 bit signed integer
-      UInt8 = 2,    //!< 8 bit unsigned integer
-      Int16 = 3,    //!< 16 bit signed integer
-      UInt16 = 4,   //!< 16 bit unsigned integer
-      Int32 = 5,    //!< 32 bit signed integer
-      UInt32 = 6,   //!< 32 bit unsigned integer
-      Int64 = 7,    //!< 64 bit signed integer
-      Bool = 8,     //!< C++ boolean type
-      Real32 = 9,   //!< C++ float type
-      Real64 = 10,  //!< C++ double type
-      UString = 11, //!< Unicode UTF-8 std::string
+      Int8 = 1,     ///< 8 bit signed integer
+      UInt8 = 2,    ///< 8 bit unsigned integer
+      Int16 = 3,    ///< 16 bit signed integer
+      UInt16 = 4,   ///< 16 bit unsigned integer
+      Int32 = 5,    ///< 32 bit signed integer
+      UInt32 = 6,   ///< 32 bit unsigned integer
+      Int64 = 7,    ///< 64 bit signed integer
+      Bool = 8,     ///< C++ boolean type
+      Real32 = 9,   ///< C++ float type
+      Real64 = 10,  ///< C++ double type
+      UString = 11, ///< Unicode UTF-8 std::string
 
       /// @deprecated Will be removed in 4.0. Use e57::Int8.
       E57_INT8 [[deprecated( "Will be removed in 4.0. Use Int8." )]] = Int8,
@@ -135,8 +136,9 @@ namespace e57
       E57_USTRING [[deprecated( "Will be removed in 4.0. Use UString." )]] = UString
    };
 
-   //! @brief Default checksum policies for e57::ReadChecksumPolicy
-   //! @details These are some convenient default checksum policies, though you can use any value you want (0-100).
+   /// @brief Default checksum policies for e57::ReadChecksumPolicy
+   /// @details These are some convenient default checksum policies, though you can use any value
+   /// you want (0-100).
    enum ChecksumPolicy
    {
       ChecksumNone = 0,    ///< Do not verify the checksums. (fast)
@@ -145,47 +147,47 @@ namespace e57
       ChecksumAll = 100    ///< Verify all checksums. This is the default. (slow)
    };
 
-   //! @brief Specifies the percentage of checksums which are verified when reading
-   //! an ImageFile (0-100%).
-   //! @see e57::ChecksumPolicy
+   /// @brief Specifies the percentage of checksums which are verified when reading an ImageFile
+   /// (0-100%).
+   /// @see e57::ChecksumPolicy
    using ReadChecksumPolicy = int;
 
-   //! @name Deprecated Checksum Policies
-   //! These have been replaced by the enum e57::ChecksumPolicy.
-   //!@{
+   /// @name Deprecated Checksum Policies
+   /// These have been replaced by the enum e57::ChecksumPolicy.
+   ///@{
 
-   //! Do not verify the checksums. (fast)
-   //! @deprecated Will be removed in 4.0. Use ChecksumPolicy::ChecksumNone.
-   [[deprecated( "Will be removed in 4.0. Use ChecksumPolicy::ChecksumNone." )]] // TODO Remove in 4.0
+   /// @deprecated Will be removed in 4.0. Use ChecksumPolicy::ChecksumNone.
+   [[deprecated(
+      "Will be removed in 4.0. Use ChecksumPolicy::ChecksumNone." )]] // TODO Remove in 4.0
    constexpr ReadChecksumPolicy CHECKSUM_POLICY_NONE = ChecksumNone;
 
-   //! Only verify 25% of the checksums. The last block is always verified.
-   //! @deprecated Will be removed in 4.0. Use ChecksumPolicy::ChecksumSparse.
-   [[deprecated( "Will be removed in 4.0. Use ChecksumPolicy::ChecksumSparse." )]] // TODO Remove in 4.0
+   /// @deprecated Will be removed in 4.0. Use ChecksumPolicy::ChecksumSparse.
+   [[deprecated(
+      "Will be removed in 4.0. Use ChecksumPolicy::ChecksumSparse." )]] // TODO Remove in 4.0
    constexpr ReadChecksumPolicy CHECKSUM_POLICY_SPARSE = ChecksumSparse;
 
-   //! Only verify 50% of the checksums. The last block is always verified.
-   //! @deprecated Will be removed in 4.0. Use ChecksumPolicy::ChecksumHalf.
-   [[deprecated( "Will be removed in 4.0. Use ChecksumPolicy::ChecksumHalf." )]] // TODO Remove in 4.0
+   /// @deprecated Will be removed in 4.0. Use ChecksumPolicy::ChecksumHalf.
+   [[deprecated(
+      "Will be removed in 4.0. Use ChecksumPolicy::ChecksumHalf." )]] // TODO Remove in 4.0
    constexpr ReadChecksumPolicy CHECKSUM_POLICY_HALF = ChecksumHalf;
 
-   //! Verify all checksums. This is the default. (slow)
-   //! @deprecated Will be removed in 4.0. Use ChecksumPolicy::ChecksumAll.
-   [[deprecated( "Will be removed in 4.0. Use ChecksumPolicy::ChecksumAll." )]] // TODO Remove in 4.0
+   /// @deprecated Will be removed in 4.0. Use ChecksumPolicy::ChecksumAll.
+   [[deprecated(
+      "Will be removed in 4.0. Use ChecksumPolicy::ChecksumAll." )]] // TODO Remove in 4.0
    constexpr ReadChecksumPolicy CHECKSUM_POLICY_ALL = ChecksumAll;
 
-   //!@}
+   ///@}
 
-   //! @brief The URI of ASTM E57 v1.0 standard XML namespace
-   //! @note Even though this URI does not point to a valid document, the standard (section 8.4.2.3)
-   //! says that this is the required namespace.
+   /// @brief The URI of ASTM E57 v1.0 standard XML namespace
+   /// @note Even though this URI does not point to a valid document, the standard (section 8.4.2.3)
+   /// says that this is the required namespace.
    constexpr char VERSION_1_0_URI[] = "http://www.astm.org/COMMIT/E57/2010-e57-v1.0";
 
    /// @deprecated Will be removed in 4.0. Use e57::VERSION_1_0_URI.
    [[deprecated( "Will be removed in 4.0. Use e57::VERSION_1_0_URI." )]] // TODO Remove in 4.0
    constexpr auto E57_V1_0_URI = VERSION_1_0_URI;
 
-   //! @cond documentNonPublic   The following aren't documented
+   /// @cond documentNonPublic   The following aren't documented
    // Minimum and maximum values for integers
    constexpr uint8_t UINT8_MIN = 0U;
    constexpr uint16_t UINT16_MIN = 0U;
@@ -196,30 +198,28 @@ namespace e57
    constexpr float FLOAT_MAX = FLT_MAX;
    constexpr double DOUBLE_MIN = -DBL_MAX;
    constexpr double DOUBLE_MAX = DBL_MAX;
-//! @endcond
+   /// @endcond
 
-//! @cond documentNonPublic   The following isn't part of the API, and isn't
-//! documented.
-// Internal implementation files should include Common.h first which
-// defines symbol E57_INTERNAL_IMPLEMENTATION_ENABLE. Normal API users should
-// not define this symbol. Basically the internal version allows access to the
-// pointer to the implementation (impl_)
+   /// @cond documentNonPublic   The following isn't part of the API, and isn't documented.
+   // Internal implementation files should include Common.h first which defines symbol
+   // E57_INTERNAL_IMPLEMENTATION_ENABLE. Normal API users should not define this symbol.
+   // Basically the internal version allows access to the pointer to the implementation (impl_)
 #ifdef E57_INTERNAL_IMPLEMENTATION_ENABLE
-#define E57_OBJECT_IMPLEMENTATION( T )                                                                                 \
-public:                                                                                                                \
-   std::shared_ptr<T##Impl> impl() const                                                                               \
-   {                                                                                                                   \
-      return ( impl_ );                                                                                                \
-   }                                                                                                                   \
-                                                                                                                       \
-protected:                                                                                                             \
+#define E57_OBJECT_IMPLEMENTATION( T )                                                             \
+public:                                                                                            \
+   std::shared_ptr<T##Impl> impl() const                                                           \
+   {                                                                                               \
+      return ( impl_ );                                                                            \
+   }                                                                                               \
+                                                                                                   \
+protected:                                                                                         \
    std::shared_ptr<T##Impl> impl_;
 #else
-#define E57_OBJECT_IMPLEMENTATION( T )                                                                                 \
-protected:                                                                                                             \
+#define E57_OBJECT_IMPLEMENTATION( T )                                                             \
+protected:                                                                                         \
    std::shared_ptr<T##Impl> impl_;
 #endif
-   //! @endcond
+   /// @endcond
 
    class BlobNode;
    class BlobNodeImpl;
@@ -265,18 +265,18 @@ protected:                                                                      
       bool operator==( Node n2 ) const;
       bool operator!=( Node n2 ) const;
 
-//! \cond documentNonPublic   The following isn't part of the API, and isn't
-//! documented.
+      /// @cond documentNonPublic   The following isn't part of the API, and isn't documented.
 #ifdef E57_INTERNAL_IMPLEMENTATION_ENABLE
       explicit Node( std::shared_ptr<NodeImpl> ); // internal use only
 #endif
+      /// @endcond
 
    private:
+      /// @cond documentNonPublic   The following isn't part of the API, and isn't documented.
       friend class NodeImpl;
 
-      E57_OBJECT_IMPLEMENTATION( Node ) // Internal implementation details, not
-                                        // part of API, must be last in object
-      //! \endcond
+      E57_OBJECT_IMPLEMENTATION( Node ) // must be last in object
+      /// @endcond
    };
 
    class E57_DLL StructureNode
@@ -307,17 +307,15 @@ protected:                                                                      
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
       void checkInvariant( bool doRecurse = true, bool doUpcast = true );
 
-      //! \cond documentNonPublic   The following isn't part of the API, and isn't
-      //! documented.
    private:
+      /// @cond documentNonPublic   The following isn't part of the API, and isn't documented.
       friend class ImageFile;
 
-      explicit StructureNode( std::shared_ptr<StructureNodeImpl> ni );   // internal use only
-      explicit StructureNode( std::weak_ptr<ImageFileImpl> fileParent ); // internal use only
+      explicit StructureNode( std::shared_ptr<StructureNodeImpl> ni );
+      explicit StructureNode( std::weak_ptr<ImageFileImpl> fileParent );
 
-      E57_OBJECT_IMPLEMENTATION( StructureNode ) // Internal implementation details, not part of API, must
-                                                 // be last in object
-      //! \endcond
+      E57_OBJECT_IMPLEMENTATION( StructureNode ) // must be last in object
+      /// @endcond
    };
 
    class E57_DLL VectorNode
@@ -350,42 +348,51 @@ protected:                                                                      
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
       void checkInvariant( bool doRecurse = true, bool doUpcast = true );
 
-      //! \cond documentNonPublic   The following isn't part of the API, and isn't
-      //! documented.
    private:
+      /// @cond documentNonPublic   The following isn't part of the API, and isn't documented.
       friend class CompressedVectorNode;
 
       explicit VectorNode( std::shared_ptr<VectorNodeImpl> ni ); // internal use only
 
-      E57_OBJECT_IMPLEMENTATION( VectorNode ) // Internal implementation details, not part of API, must be
-                                              // last in object
-      //! \endcond
+      E57_OBJECT_IMPLEMENTATION(
+         VectorNode ) // Internal implementation details - must be last in object
+      /// @endcond
    };
 
    class E57_DLL SourceDestBuffer
    {
    public:
       SourceDestBuffer() = delete;
-      SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, int8_t *b, size_t capacity,
-                        bool doConversion = false, bool doScaling = false, size_t stride = sizeof( int8_t ) );
-      SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, uint8_t *b, size_t capacity,
-                        bool doConversion = false, bool doScaling = false, size_t stride = sizeof( uint8_t ) );
-      SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, int16_t *b, size_t capacity,
-                        bool doConversion = false, bool doScaling = false, size_t stride = sizeof( int16_t ) );
-      SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, uint16_t *b, size_t capacity,
-                        bool doConversion = false, bool doScaling = false, size_t stride = sizeof( uint16_t ) );
-      SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, int32_t *b, size_t capacity,
-                        bool doConversion = false, bool doScaling = false, size_t stride = sizeof( int32_t ) );
-      SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, uint32_t *b, size_t capacity,
-                        bool doConversion = false, bool doScaling = false, size_t stride = sizeof( uint32_t ) );
-      SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, int64_t *b, size_t capacity,
-                        bool doConversion = false, bool doScaling = false, size_t stride = sizeof( int64_t ) );
+      SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, int8_t *b,
+                        size_t capacity, bool doConversion = false, bool doScaling = false,
+                        size_t stride = sizeof( int8_t ) );
+      SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, uint8_t *b,
+                        size_t capacity, bool doConversion = false, bool doScaling = false,
+                        size_t stride = sizeof( uint8_t ) );
+      SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, int16_t *b,
+                        size_t capacity, bool doConversion = false, bool doScaling = false,
+                        size_t stride = sizeof( int16_t ) );
+      SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, uint16_t *b,
+                        size_t capacity, bool doConversion = false, bool doScaling = false,
+                        size_t stride = sizeof( uint16_t ) );
+      SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, int32_t *b,
+                        size_t capacity, bool doConversion = false, bool doScaling = false,
+                        size_t stride = sizeof( int32_t ) );
+      SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, uint32_t *b,
+                        size_t capacity, bool doConversion = false, bool doScaling = false,
+                        size_t stride = sizeof( uint32_t ) );
+      SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, int64_t *b,
+                        size_t capacity, bool doConversion = false, bool doScaling = false,
+                        size_t stride = sizeof( int64_t ) );
       SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, bool *b, size_t capacity,
-                        bool doConversion = false, bool doScaling = false, size_t stride = sizeof( bool ) );
+                        bool doConversion = false, bool doScaling = false,
+                        size_t stride = sizeof( bool ) );
       SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, float *b, size_t capacity,
-                        bool doConversion = false, bool doScaling = false, size_t stride = sizeof( float ) );
-      SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, double *b, size_t capacity,
-                        bool doConversion = false, bool doScaling = false, size_t stride = sizeof( double ) );
+                        bool doConversion = false, bool doScaling = false,
+                        size_t stride = sizeof( float ) );
+      SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, double *b,
+                        size_t capacity, bool doConversion = false, bool doScaling = false,
+                        size_t stride = sizeof( double ) );
       SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, std::vector<ustring> *b );
 
       ustring pathName() const;
@@ -399,12 +406,10 @@ protected:                                                                      
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
       void checkInvariant( bool doRecurse = true ) const;
 
-      //! \cond documentNonPublic   The following isn't part of the API, and isn't
-      //! documented.
    private:
-      E57_OBJECT_IMPLEMENTATION( SourceDestBuffer ) // Internal implementation details, not part of
-                                                    // API, must be last in object
-      //! \endcond
+      /// @cond documentNonPublic   The following isn't part of the API, and isn't documented.
+      E57_OBJECT_IMPLEMENTATION( SourceDestBuffer ) // must be last in object
+      /// @endcond
    };
 
    class E57_DLL CompressedVectorReader
@@ -422,16 +427,14 @@ protected:                                                                      
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
       void checkInvariant( bool doRecurse = true );
 
-      //! \cond documentNonPublic   The following isn't part of the API, and isn't
-      //! documented.
    private:
+      /// @cond documentNonPublic   The following isn't part of the API, and isn't  documented.
       friend class CompressedVectorNode;
 
       explicit CompressedVectorReader( std::shared_ptr<CompressedVectorReaderImpl> ni );
 
-      E57_OBJECT_IMPLEMENTATION( CompressedVectorReader ) // Internal implementation details, not
-                                                          // part of API, must be last in object
-      //! \endcond
+      E57_OBJECT_IMPLEMENTATION( CompressedVectorReader ) // must be last in object
+      /// @endcond
    };
 
    class E57_DLL CompressedVectorWriter
@@ -448,23 +451,22 @@ protected:                                                                      
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
       void checkInvariant( bool doRecurse = true );
 
-      //! \cond documentNonPublic   The following isn't part of the API, and isn't
-      //! documented.
    private:
+      /// @cond documentNonPublic   The following isn't part of the API, and isn't documented.
       friend class CompressedVectorNode;
 
       explicit CompressedVectorWriter( std::shared_ptr<CompressedVectorWriterImpl> ni );
 
-      E57_OBJECT_IMPLEMENTATION( CompressedVectorWriter ) // Internal implementation details, not
-                                                          // part of API, must be last in object
-      //! \endcond
+      E57_OBJECT_IMPLEMENTATION( CompressedVectorWriter ) // must be last in object
+      /// @endcond
    };
 
    class E57_DLL CompressedVectorNode
    {
    public:
       CompressedVectorNode() = delete;
-      explicit CompressedVectorNode( ImageFile destImageFile, const Node &prototype, const VectorNode &codecs );
+      explicit CompressedVectorNode( ImageFile destImageFile, const Node &prototype,
+                                     const VectorNode &codecs );
 
       int64_t childCount() const;
       Node prototype() const;
@@ -490,18 +492,16 @@ protected:                                                                      
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
       void checkInvariant( bool doRecurse = true, bool doUpcast = true );
 
-      //! \cond documentNonPublic   The following isn't part of the API, and isn't
-      //! documented.
    private:
+      /// @cond documentNonPublic   The following isn't part of the API, and isn't documented.
       friend class CompressedVectorReader;
       friend class CompressedVectorWriter;
       friend class E57XmlParser;
 
-      CompressedVectorNode( std::shared_ptr<CompressedVectorNodeImpl> ni ); // internal use only
+      CompressedVectorNode( std::shared_ptr<CompressedVectorNodeImpl> ni );
 
-      E57_OBJECT_IMPLEMENTATION( CompressedVectorNode ) // Internal implementation details, not part
-                                                        // of API, must be last in object
-      //! \endcond
+      E57_OBJECT_IMPLEMENTATION( CompressedVectorNode ) // must be last in object
+      /// @endcond
    };
 
    class E57_DLL IntegerNode
@@ -531,26 +531,24 @@ protected:                                                                      
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
       void checkInvariant( bool doRecurse = true, bool doUpcast = true );
 
-      //! \cond documentNonPublic   The following isn't part of the API, and isn't
-      //! documented.
    private:
-      explicit IntegerNode( std::shared_ptr<IntegerNodeImpl> ni ); // internal use only
+      /// @cond documentNonPublic   The following isn't part of the API, and isn't documented.
+      explicit IntegerNode( std::shared_ptr<IntegerNodeImpl> ni );
 
-      E57_OBJECT_IMPLEMENTATION( IntegerNode ) // Internal implementation details, not part of API, must be
-                                               // last in object
-      //! \endcond
+      E57_OBJECT_IMPLEMENTATION( IntegerNode ) // must be last in object
+      /// @endcond
    };
 
    class E57_DLL ScaledIntegerNode
    {
    public:
       ScaledIntegerNode() = delete;
-      explicit ScaledIntegerNode( ImageFile destImageFile, int64_t rawValue, int64_t minimum, int64_t maximum,
+      explicit ScaledIntegerNode( ImageFile destImageFile, int64_t rawValue, int64_t minimum,
+                                  int64_t maximum, double scale = 1.0, double offset = 0.0 );
+      explicit ScaledIntegerNode( ImageFile destImageFile, int rawValue, int64_t minimum,
+                                  int64_t maximum, double scale = 1.0, double offset = 0.0 );
+      explicit ScaledIntegerNode( ImageFile destImageFile, int rawValue, int minimum, int maximum,
                                   double scale = 1.0, double offset = 0.0 );
-      explicit ScaledIntegerNode( ImageFile destImageFile, int rawValue, int64_t minimum, int64_t maximum,
-                                  double scale = 1.0, double offset = 0.0 );
-      explicit ScaledIntegerNode( ImageFile destImageFile, int rawValue, int minimum, int maximum, double scale = 1.0,
-                                  double offset = 0.0 );
       explicit ScaledIntegerNode( ImageFile destImageFile, double scaledValue, double scaledMinimum,
                                   double scaledMaximum, double scale = 1.0, double offset = 0.0 );
 
@@ -579,22 +577,21 @@ protected:                                                                      
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
       void checkInvariant( bool doRecurse = true, bool doUpcast = true );
 
-      //! \cond documentNonPublic   The following isn't part of the API, and isn't
-      //! documented.
    private:
-      explicit ScaledIntegerNode( std::shared_ptr<ScaledIntegerNodeImpl> ni ); // internal use only
+      /// @cond documentNonPublic   The following isn't part of the API, and isn't documented.
+      explicit ScaledIntegerNode( std::shared_ptr<ScaledIntegerNodeImpl> ni );
 
-      E57_OBJECT_IMPLEMENTATION( ScaledIntegerNode ) // Internal implementation details, not part of
-                                                     // API, must be last in object
-      //! \endcond
+      E57_OBJECT_IMPLEMENTATION( ScaledIntegerNode ) // must be last in object
+      /// @endcond
    };
 
    class E57_DLL FloatNode
    {
    public:
       FloatNode() = delete;
-      explicit FloatNode( ImageFile destImageFile, double value = 0.0, FloatPrecision precision = PrecisionDouble,
-                          double minimum = DOUBLE_MIN, double maximum = DOUBLE_MAX );
+      explicit FloatNode( ImageFile destImageFile, double value = 0.0,
+                          FloatPrecision precision = PrecisionDouble, double minimum = DOUBLE_MIN,
+                          double maximum = DOUBLE_MAX );
 
       double value() const;
       FloatPrecision precision() const;
@@ -617,14 +614,12 @@ protected:                                                                      
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
       void checkInvariant( bool doRecurse = true, bool doUpcast = true );
 
-      //! \cond documentNonPublic   The following isn't part of the API, and isn't
-      //! documented.
    private:
-      explicit FloatNode( std::shared_ptr<FloatNodeImpl> ni ); // internal use only
+      /// @cond documentNonPublic   The following isn't part of the API, and isn't documented.
+      explicit FloatNode( std::shared_ptr<FloatNodeImpl> ni );
 
-      E57_OBJECT_IMPLEMENTATION( FloatNode ) // Internal implementation details, not part of API, must be
-                                             // last in object
-      //! \endcond
+      E57_OBJECT_IMPLEMENTATION( FloatNode ) // must be last in object
+      /// @endcond
    };
 
    class E57_DLL StringNode
@@ -651,15 +646,14 @@ protected:                                                                      
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
       void checkInvariant( bool doRecurse = true, bool doUpcast = true );
 
-      //! \cond documentNonPublic   The following isn't part of the API, and isn't
-      //! documented.
    private:
+      /// @cond documentNonPublic   The following isn't part of the API, and isn't documented.
       friend class StringNodeImpl;
-      explicit StringNode( std::shared_ptr<StringNodeImpl> ni ); // internal use only
 
-      E57_OBJECT_IMPLEMENTATION( StringNode ) // Internal implementation details, not part of API, must be
-                                              // last in object
-      //! \endcond
+      explicit StringNode( std::shared_ptr<StringNodeImpl> ni );
+
+      E57_OBJECT_IMPLEMENTATION( StringNode ) // must be last in object
+      /// @endcond
    };
 
    class E57_DLL BlobNode
@@ -688,27 +682,27 @@ protected:                                                                      
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
       void checkInvariant( bool doRecurse = true, bool doUpcast = true );
 
-      //! \cond documentNonPublic   The following isn't part of the API, and isn't
-      //! documented.
    private:
+      /// @cond documentNonPublic   The following isn't part of the API, and isn't documented.
       friend class E57XmlParser;
 
-      explicit BlobNode( std::shared_ptr<BlobNodeImpl> ni ); // internal use only
+      explicit BlobNode( std::shared_ptr<BlobNodeImpl> ni );
 
-      // Internal use only, create blob already in a file
+      // create blob already in a file
       BlobNode( ImageFile destImageFile, int64_t fileOffset, int64_t length );
 
-      E57_OBJECT_IMPLEMENTATION( BlobNode ) // Internal implementation details, not
-                                            // part of API, must be last in object
-      //! \endcond
+      E57_OBJECT_IMPLEMENTATION( BlobNode ) // must be last in object
+      /// @endcond
    };
 
    class E57_DLL ImageFile
    {
    public:
       ImageFile() = delete;
-      ImageFile( const ustring &fname, const ustring &mode, ReadChecksumPolicy checksumPolicy = ChecksumAll );
-      ImageFile( const char *input, uint64_t size, ReadChecksumPolicy checksumPolicy = ChecksumAll );
+      ImageFile( const ustring &fname, const ustring &mode,
+                 ReadChecksumPolicy checksumPolicy = ChecksumAll );
+      ImageFile( const char *input, uint64_t size,
+                 ReadChecksumPolicy checksumPolicy = ChecksumAll );
 
       StructureNode root() const;
       void close();
@@ -730,7 +724,8 @@ protected:                                                                      
 
       // Field name functions:
       bool isElementNameExtended( const ustring &elementName ) const;
-      void elementNameParse( const ustring &elementName, ustring &prefix, ustring &localPart ) const;
+      void elementNameParse( const ustring &elementName, ustring &prefix,
+                             ustring &localPart ) const;
 
       // Diagnostic functions:
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
@@ -738,11 +733,9 @@ protected:                                                                      
       bool operator==( ImageFile imf2 ) const;
       bool operator!=( ImageFile imf2 ) const;
 
-      //! \cond documentNonPublic   The following isn't part of the API, and isn't
-      //! documented.
    private:
-      explicit ImageFile( double ); // Give a second dummy constructor, better error msg
-                                    // for: ImageFile(0)
+      /// @cond documentNonPublic   The following isn't part of the API, and isn't documented.
+      explicit ImageFile( double ); // Dummy constructor for better error msg for: ImageFile(0)
 
       friend class Node;
       friend class StructureNode;
@@ -754,10 +747,9 @@ protected:                                                                      
       friend class StringNode;
       friend class BlobNode;
 
-      explicit ImageFile( std::shared_ptr<ImageFileImpl> imfi ); // internal use only
+      explicit ImageFile( std::shared_ptr<ImageFileImpl> imfi );
 
-      E57_OBJECT_IMPLEMENTATION( ImageFile ) // Internal implementation details, not part of API, must be
-                                             // last in object
-      //! \endcond
+      E57_OBJECT_IMPLEMENTATION( ImageFile ) //  must be last in object
+      /// @endcond
    };
 }

--- a/include/E57SimpleData.h
+++ b/include/E57SimpleData.h
@@ -30,24 +30,29 @@
 
 #pragma once
 
-//! @file
-//! @brief Data structures for E57 Simple API
+/// @file
+/// @brief Data structures for E57 Simple API
 
 #include "E57Format.h"
 
 namespace e57
 {
-   //! @cond documentNonPublic   The following isn't part of the API, and isn't documented.
+   /// @cond documentNonPublic The following isn't part of the API, and isn't documented.
    class ReaderImpl;
    class WriterImpl;
-   //! @endcond
+   /// @endcond
 
-   //! @brief Defines a rigid body translation in Cartesian coordinates.
+   /// @brief Defines a rigid body translation in Cartesian coordinates.
    struct E57_DLL Translation
    {
-      double x = 0.0; //!< The X coordinate of the translation (in meters)
-      double y = 0.0; //!< The Y coordinate of the translation (in meters)
-      double z = 0.0; //!< The Z coordinate of the translation (in meters)
+      /// The X coordinate of the translation (in meters)
+      double x = 0.0;
+
+      /// The Y coordinate of the translation (in meters)
+      double y = 0.0;
+
+      /// The Z coordinate of the translation (in meters)
+      double z = 0.0;
 
       bool operator==( const Translation &rhs ) const
       {
@@ -59,19 +64,28 @@ namespace e57
          return !operator==( rhs );
       }
 
+      /// @brief Return "no translation".
+      /// @returns A translation of (0.0, 0.0, 0.0).
       static Translation identity()
       {
          return {};
       }
    };
 
-   //! @brief Represents a rigid body rotation.
+   /// @brief Represents a rigid body rotation.
    struct E57_DLL Quaternion
    {
-      double w = 1.0; //!< The real part of the quaternion (shall be nonnegative)
-      double x = 0.0; //!< The i coefficient of the quaternion
-      double y = 0.0; //!< The j coefficient of the quaternion
-      double z = 0.0; //!< The k coefficient of the quaternion
+      /// The real part of the quaternion (shall be nonnegative)
+      double w = 1.0;
+
+      /// The i coefficient of the quaternion
+      double x = 0.0;
+
+      /// The j coefficient of the quaternion
+      double y = 0.0;
+
+      /// The k coefficient of the quaternion
+      double z = 0.0;
 
       bool operator==( const Quaternion &rhs ) const
       {
@@ -83,17 +97,22 @@ namespace e57
          return !operator==( rhs );
       }
 
+      /// @brief Return the identity quaternion.
+      /// @returns A quaternion of (1.0, 0.0, 0.0, 0.0).
       static Quaternion identity()
       {
          return {};
       }
    };
 
-   //! @brief Defines a rigid body transform in cartesian coordinates.
+   /// @brief Defines a rigid body transform in cartesian coordinates.
    struct E57_DLL RigidBodyTransform
    {
-      Quaternion rotation;     //!< A unit quaternion representing the rotation, R, of the transform
-      Translation translation; //!< The translation point vector, t, of the transform
+      /// A unit quaternion representing the rotation, R, of the transform
+      Quaternion rotation;
+
+      /// The translation point vector, t, of the transform
+      Translation translation;
 
       bool operator==( const RigidBodyTransform &rhs ) const
       {
@@ -105,26 +124,36 @@ namespace e57
          return !operator==( rhs );
       }
 
+      /// @brief Returns a RigidBodyTransform without rotation or translation.
       static RigidBodyTransform identity()
       {
          return { Quaternion::identity(), Translation::identity() };
       }
    };
 
-   //! @brief Specifies an axis-aligned box in local cartesian coordinates.
+   /// @brief Specifies an axis-aligned box in local cartesian coordinates.
    struct E57_DLL CartesianBounds
    {
-      double xMinimum = -DOUBLE_MAX; //!< The minimum extent of the bounding box in the X direction
-      double xMaximum = DOUBLE_MAX;  //!< The maximum extent of the bounding box in the X direction
-      double yMinimum = -DOUBLE_MAX; //!< The minimum extent of the bounding box in the Y direction
-      double yMaximum = DOUBLE_MAX;  //!< The maximum extent of the bounding box in the Y direction
-      double zMinimum = -DOUBLE_MAX; //!< The minimum extent of the bounding box in the Z direction
-      double zMaximum = DOUBLE_MAX;  //!< The maximum extent of the bounding box in the Z direction
+      /// The minimum extent of the bounding box in the X direction
+      double xMinimum = -DOUBLE_MAX;
+      /// The maximum extent of the bounding box in the X direction
+      double xMaximum = DOUBLE_MAX;
+
+      /// The minimum extent of the bounding box in the Y direction
+      double yMinimum = -DOUBLE_MAX;
+      /// The maximum extent of the bounding box in the Y direction
+      double yMaximum = DOUBLE_MAX;
+
+      /// The minimum extent of the bounding box in the Z direction
+      double zMinimum = -DOUBLE_MAX;
+      /// The maximum extent of the bounding box in the Z direction
+      double zMaximum = DOUBLE_MAX;
 
       bool operator==( const CartesianBounds &rhs ) const
       {
-         return ( xMinimum == rhs.xMinimum ) && ( xMaximum == rhs.xMaximum ) && ( yMinimum == rhs.yMinimum ) &&
-                ( yMaximum == rhs.yMaximum ) && ( zMinimum == rhs.zMinimum ) && ( zMaximum == rhs.zMaximum );
+         return ( xMinimum == rhs.xMinimum ) && ( xMaximum == rhs.xMaximum ) &&
+                ( yMinimum == rhs.yMinimum ) && ( yMaximum == rhs.yMaximum ) &&
+                ( zMinimum == rhs.zMinimum ) && ( zMaximum == rhs.zMaximum );
       }
 
       bool operator!=( const CartesianBounds &rhs ) const
@@ -133,21 +162,31 @@ namespace e57
       }
    };
 
-   //! @brief Stores the bounds of some data in spherical coordinates.
+   /// @brief Stores the bounds of some data in spherical coordinates.
    struct E57_DLL SphericalBounds
    {
-      SphericalBounds();       // constructor in the cpp to avoid exposing M_PI
-      double rangeMinimum;     //!< The minimum extent of the bounding region in the r direction
-      double rangeMaximum;     //!< The maximum extent of the bounding region in the r direction
-      double elevationMinimum; //!< The minimum extent of the bounding region from the horizontal plane
-      double elevationMaximum; //!< The maximum extent of the bounding region from the horizontal plane
-      double azimuthStart; //!< The starting azimuth angle defining the extent of the bounding region around the z axis
-      double azimuthEnd;   //!< The ending azimuth angle defining the extent of the bounding region around the z axis
+      SphericalBounds(); // constructor in the cpp to avoid exposing M_PI
+
+      /// The minimum extent of the bounding region in the r direction
+      double rangeMinimum;
+      /// The maximum extent of the bounding region in the r direction
+      double rangeMaximum;
+
+      /// The minimum extent of the bounding region from the horizontal plane
+      double elevationMinimum;
+      /// The maximum extent of the bounding region from the horizontal plane
+      double elevationMaximum;
+
+      ///< The starting azimuth angle defining the extent of the bounding region around the z axis
+      double azimuthStart;
+      ///< The ending azimuth angle defining the extent of the bounding region  around the z axis
+      double azimuthEnd;
 
       bool operator==( const SphericalBounds &rhs ) const
       {
          return ( rangeMinimum == rhs.rangeMinimum ) && ( rangeMaximum == rhs.rangeMaximum ) &&
-                ( elevationMinimum == rhs.elevationMinimum ) && ( elevationMaximum == rhs.elevationMaximum ) &&
+                ( elevationMinimum == rhs.elevationMinimum ) &&
+                ( elevationMaximum == rhs.elevationMaximum ) &&
                 ( azimuthStart == rhs.azimuthStart ) && ( azimuthEnd == rhs.azimuthEnd );
       }
 
@@ -157,17 +196,24 @@ namespace e57
       }
    };
 
-   //! @brief Stores the minimum and maximum of rowIndex, columnIndex, and returnIndex fields for a set of points.
+   /// @brief Stores the minimum and maximum of rowIndex, columnIndex, and returnIndex fields for a
+   /// set of points.
    struct E57_DLL IndexBounds
    {
-      int64_t rowMinimum = 0; //!< The minimum rowIndex value of any point represented by this IndexBounds object
-      int64_t rowMaximum = 0; //!< The maximum rowIndex value of any point represented by this IndexBounds object
+      /// The minimum rowIndex value of any point represented by this IndexBounds object
+      int64_t rowMinimum = 0;
+      /// The maximum rowIndex value of any point represented by this IndexBounds object
+      int64_t rowMaximum = 0;
 
-      int64_t columnMinimum = 0; //!< The minimum columnIndex value of any point represented by this IndexBounds object
-      int64_t columnMaximum = 0; //!< The maximum columnIndex value of any point represented by this IndexBounds object
+      /// The minimum columnIndex value of any point represented by this IndexBounds object
+      int64_t columnMinimum = 0;
+      /// The maximum columnIndex value of any point represented by this IndexBounds object
+      int64_t columnMaximum = 0;
 
-      int64_t returnMinimum = 0; //!< The minimum returnIndex value of any point represented by this IndexBounds object
-      int64_t returnMaximum = 0; //!< The maximum returnIndex value of any point represented by this IndexBounds object
+      /// The minimum returnIndex value of any point represented by this IndexBounds object
+      int64_t returnMinimum = 0;
+      /// The maximum returnIndex value of any point represented by this IndexBounds object
+      int64_t returnMaximum = 0;
 
       bool operator==( const IndexBounds &rhs ) const
       {
@@ -182,15 +228,19 @@ namespace e57
       }
    };
 
-   //! @brief Specifies the limits for the value of signal intensity that a sensor is capable of producing
+   /// @brief Specifies the limits for the value of signal intensity that a sensor is capable of
+   /// producing
    struct E57_DLL IntensityLimits
    {
-      double intensityMinimum = 0.0; //!< The minimum producible intensity value. Unit is unspecified.
-      double intensityMaximum = 0.0; //!< The maximum producible intensity value. Unit is unspecified.
+      /// The minimum producible intensity value. Unit is unspecified.
+      double intensityMinimum = 0.0;
+      /// The maximum producible intensity value. Unit is unspecified.
+      double intensityMaximum = 0.0;
 
       bool operator==( const IntensityLimits &rhs ) const
       {
-         return ( intensityMinimum == rhs.intensityMinimum ) && ( intensityMaximum == rhs.intensityMaximum );
+         return ( intensityMinimum == rhs.intensityMinimum ) &&
+                ( intensityMaximum == rhs.intensityMaximum );
       }
 
       bool operator!=( const IntensityLimits &rhs ) const
@@ -199,23 +249,33 @@ namespace e57
       }
    };
 
-   //! @brief Specifies the limits for the value of red, green, and blue color that a sensor is capable of producing.
+   /// @brief Specifies the limits for the value of red, green, and blue color that a sensor is
+   /// capable of producing.
    struct E57_DLL ColorLimits
    {
-      double colorRedMinimum = 0.0; //!< The minimum producible red color value. Unit is unspecified.
-      double colorRedMaximum = 0.0; //!< The maximum producible red color value. Unit is unspecified.
+      /// The minimum producible red color value. Unit is unspecified.
+      double colorRedMinimum = 0.0;
+      /// The maximum producible red color value. Unit is unspecified.
+      double colorRedMaximum = 0.0;
 
-      double colorGreenMinimum = 0.0; //!< The minimum producible green color value. Unit is unspecified.
-      double colorGreenMaximum = 0.0; //!< The maximum producible green color value. Unit is unspecified.
+      /// The minimum producible green color value. Unit is unspecified.
+      double colorGreenMinimum = 0.0;
+      /// The maximum producible green color value. Unit is unspecified.
+      double colorGreenMaximum = 0.0;
 
-      double colorBlueMinimum = 0.0; //!< The minimum producible blue color value. Unit is unspecified.
-      double colorBlueMaximum = 0.0; //!< The maximum producible blue color value. Unit is unspecified.
+      /// The minimum producible blue color value. Unit is unspecified.
+      double colorBlueMinimum = 0.0;
+      /// The maximum producible blue color value. Unit is unspecified.
+      double colorBlueMaximum = 0.0;
 
       bool operator==( const ColorLimits &rhs ) const
       {
-         return ( colorRedMinimum == rhs.colorRedMinimum ) && ( colorRedMaximum == rhs.colorRedMaximum ) &&
-                ( colorGreenMinimum == rhs.colorGreenMinimum ) && ( colorGreenMaximum == rhs.colorGreenMaximum ) &&
-                ( colorBlueMinimum == rhs.colorBlueMinimum ) && ( colorBlueMaximum == rhs.colorBlueMaximum );
+         return ( colorRedMinimum == rhs.colorRedMinimum ) &&
+                ( colorRedMaximum == rhs.colorRedMaximum ) &&
+                ( colorGreenMinimum == rhs.colorGreenMinimum ) &&
+                ( colorGreenMaximum == rhs.colorGreenMaximum ) &&
+                ( colorBlueMinimum == rhs.colorBlueMinimum ) &&
+                ( colorBlueMaximum == rhs.colorBlueMaximum );
       }
 
       bool operator!=( const ColorLimits &rhs ) const
@@ -224,21 +284,24 @@ namespace e57
       }
    };
 
-   //! @brief Encodes date and time.
-   //! @details The date and time is encoded using a single floating point number, stored as an E57 Float element which
-   //! is based on the Global Positioning System (GPS) time scale.
+   /// @brief Encodes date and time.
+   /// @details The date and time is encoded using a single floating point number, stored as an E57
+   /// Float element which is based on the Global Positioning System (GPS) time scale.
    struct E57_DLL DateTime
    {
-      //! The time, in seconds, since GPS time was zero. This time specification may include fractions of a second.
+      /// @brief The time, in seconds, since GPS time was zero.
+      /// @details This time specification may include fractions of a second.
       double dateTimeValue = 0.0;
 
-      //! This element should be present, and its value set to 1 if, and only if, the time stored in the
-      //! dateTimeValue element is obtained from an atomic clock time source. Shall be either 0 or 1.
+      /// @brief This element should be present, and its value set to 1 if, and only if, the time
+      /// stored in the dateTimeValue element is obtained from an atomic clock time source.
+      /// @details Shall be either 0 or 1.
       int32_t isAtomicClockReferenced = 0;
 
       bool operator==( const DateTime &rhs ) const
       {
-         return ( dateTimeValue == rhs.dateTimeValue ) && ( isAtomicClockReferenced == rhs.isAtomicClockReferenced );
+         return ( dateTimeValue == rhs.dateTimeValue ) &&
+                ( isAtomicClockReferenced == rhs.isAtomicClockReferenced );
       }
 
       bool operator!=( const DateTime &rhs ) const
@@ -247,59 +310,83 @@ namespace e57
       }
    };
 
-   //! @brief Stores the top-level information for the XML section of the file.
+   /// @brief Stores the top-level information for the XML section of the file.
    struct E57_DLL E57Root
    {
-      ustring formatName;        //!< Must contain the string "ASTM E57 3D Imaging Data File"
-      ustring guid;              //!< A globally unique identification string for the current version of the file
-      uint32_t versionMajor = 1; //!< Major version number (should be 1)
-      uint32_t versionMinor = 0; //!< Minor version number (should be 0)
-      ustring e57LibraryVersion; //!< The version identifier for the E57 file format library that wrote the file.
-      DateTime creationDateTime; //!< Date/time that the file was created
-      int64_t data3DSize = 0;    //!< Size of the Data3D vector for storing 3D imaging data
-      int64_t images2DSize = 0;  //!< Size of the Images2D vector for storing 2D images from a camera or similar device.
-      ustring coordinateMetadata; //!< Information describing the Coordinate Reference System to be used for the file
+      /// Must contain the string "ASTM E57 3D Imaging Data File"
+      ustring formatName;
+
+      /// A globally unique identification string for the current version of the file
+      ustring guid;
+
+      /// Major version number (should be 1)
+      uint32_t versionMajor = 1;
+      /// Minor version number (should be 0)
+      uint32_t versionMinor = 0;
+
+      /// The version identifier for the E57 file format library which wrote the file.
+      ustring e57LibraryVersion;
+
+      /// Date/time that the file was created
+      DateTime creationDateTime;
+
+      /// Size of the Data3D vector for storing 3D imaging data
+      int64_t data3DSize = 0;
+
+      /// Size of the Images2D vector for storing 2D images from a camera or similar device.
+      int64_t images2DSize = 0;
+
+      /// Information describing the Coordinate Reference System to be used for the file
+      ustring coordinateMetadata;
    };
 
-   //! @brief Stores information about a single group of points in a row or column
+   /// @brief Stores information about a single group of points in a row or column
    struct E57_DLL LineGroupRecord
    {
-      //! The value of the identifying element of all members in this group. Shall be in the interval [0, 2^63).
+      /// @brief The value of the identifying element of all members in this group.
+      /// @details Shall be in the interval [0, 2^63).
       int64_t idElementValue = 0;
 
-      //! The record number of the first point in the continuous interval. Shall be in the interval [0, 2^63).
+      /// @brief The record number of the first point in the continuous interval.
+      /// @details Shall be in the interval [0, 2^63).
       int64_t startPointIndex = 0;
 
-      //! The number of PointRecords in the group. Shall be in the interval [1, 2^63). May be zero.
+      /// @brief The number of PointRecords in the group.
+      /// @details Shall be in the interval [1, 2^63). May be zero.
       int64_t pointCount = 0;
 
-      //! The bounding box (in Cartesian coordinates) of all points in the group (in the local coordinate system of the
-      //! points).
+      /// @brief The bounding box (in Cartesian coordinates) of all points in the group.
+      /// @details These are in the local coordinate system of the points.
       CartesianBounds cartesianBounds;
 
-      //! The bounding region (in spherical coordinates) of all the points in the group (in the local coordinate system
-      //! of the points).
+      /// @brief The bounding region (in spherical coordinates) of all the points in the group.
+      /// @details These are in the local coordinate system of the points.
       SphericalBounds sphericalBounds;
    };
 
-   //! @brief Stores a set of point groups organized by the rowIndex or columnIndex attribute of the PointRecord
+   /// @brief Stores a set of point groups organized by the rowIndex or columnIndex attribute of the
+   /// PointRecord
    struct E57_DLL GroupingByLine
    {
-      //! The name of the PointRecord element that identifies which group the point is in. The value of this string must
-      //! be "rowIndex" or "columnIndex".
+      /// @brief The name of the PointRecord element that identifies which group the point is in.
+      /// @details The value of this string must be "rowIndex" or "columnIndex".
       ustring idElementName;
 
-      int64_t groupsSize = 0;     //!< Size of the groups compressedVector of LineGroupRecord structures
-      int64_t pointCountSize = 0; //!< The size value for the LineGroupRecord::pointCount.
+      /// @brief Size of the groups compressedVector of LineGroupRecord structures.
+      int64_t groupsSize = 0;
+
+      /// @brief The size value for the LineGroupRecord::pointCount.
+      int64_t pointCountSize = 0;
    };
 
-   //! @brief Supports the division of points within an Data3D into logical groupings
+   /// @brief Supports the division of points within an Data3D into logical groupings
    struct E57_DLL PointGroupingSchemes
    {
-      GroupingByLine groupingByLine; //!< Grouping information by row or column index
+      /// @brief Grouping information by row or column index
+      GroupingByLine groupingByLine;
    };
 
-   //! @brief Used to set the type of node in some PointStandardizedFieldsAvailable fields.
+   /// @brief Used to set the type of node in some PointStandardizedFieldsAvailable fields.
    enum class NumericalNodeType
    {
       Integer = 0,   ///< Use IntegerNode
@@ -308,25 +395,35 @@ namespace e57
       Double,        ///< Use FloatNode with doubles
    };
 
-   //! @brief Used to interrogate if standardized fields are available
+   /// @brief Used to interrogate if standardized fields are available
    struct E57_DLL PointStandardizedFieldsAvailable
    {
-      bool cartesianXField = false;            //!< Indicates that the PointRecord cartesianX field is active
-      bool cartesianYField = false;            //!< Indicates that the PointRecord cartesianY field is active
-      bool cartesianZField = false;            //!< Indicates that the PointRecord cartesianZ field is active
-      bool cartesianInvalidStateField = false; //!< Indicates that the PointRecord cartesianInvalidState field is active
+      /// Indicates that the PointRecord cartesianX field is active
+      bool cartesianXField = false;
+      /// Indicates that the PointRecord cartesianY field is active
+      bool cartesianYField = false;
+      /// Indicates that the PointRecord cartesianZ field is active
+      bool cartesianZField = false;
+      /// Indicates that the PointRecord cartesianInvalidState field is active
+      bool cartesianInvalidStateField = false;
 
-      bool sphericalRangeField = false;        //!< Indicates that the PointRecord sphericalRange field is active
-      bool sphericalAzimuthField = false;      //!< Indicates that the PointRecord sphericalAzimuth field is active
-      bool sphericalElevationField = false;    //!< Indicates that the PointRecord sphericalElevation field is active
-      bool sphericalInvalidStateField = false; //!< Indicates that the PointRecord sphericalInvalidState field is active
+      /// Indicates that the PointRecord sphericalRange field is active
+      bool sphericalRangeField = false;
+      /// Indicates that the PointRecord sphericalAzimuth field is active
+      bool sphericalAzimuthField = false;
+      /// Indicates that the PointRecord sphericalElevation field is active
+      bool sphericalElevationField = false;
+      /// Indicates that the PointRecord sphericalInvalidState field is active
+      bool sphericalInvalidStateField = false;
 
-      //! Indicates that the PointRecord cartesian and range fields should be configured with this minimum value e.g.
-      //! E57_FLOAT_MIN or E57_DOUBLE_MIN. If using a ScaledIntegerNode then this needs to be a minimum range value.
+      /// @brief Indicates that the PointRecord cartesian and range fields should be configured with
+      /// this minimum value e.g. E57_FLOAT_MIN or E57_DOUBLE_MIN.
+      /// @details If using a ScaledIntegerNode then this needs to be a minimum range value.
       double pointRangeMinimum = DOUBLE_MIN;
 
-      //! Indicates that the PointRecord cartesian and range fields should be configured with this maximum value e.g.
-      //! E57_FLOAT_MAX or E57_DOUBLE_MAX. If using a ScaledIntegerNode then this needs to be a maximum range value.
+      /// @brief Indicates that the PointRecord cartesian and range fields should be configured with
+      /// this maximum value e.g. E57_FLOAT_MAX or E57_DOUBLE_MAX.
+      /// @details If using a ScaledIntegerNode then this needs to be a maximum range value.
       double pointRangeMaximum = DOUBLE_MAX;
 
       /// @brief Controls the type of Node used for the PointRecord cartesian and range fields
@@ -339,12 +436,14 @@ namespace e57
       /// to scale the numbers and it must be > 0.0.
       double pointRangeScale = 0.0;
 
-      //! Indicates that the PointRecord angle fields should be configured with this minimum value E57_FLOAT_MIN or
-      //! E57_DOUBLE_MIN. If using a ScaledIntegerNode then this needs to be a minimum angle value.
+      /// @brief Indicates that the PointRecord angle fields should be configured with this minimum
+      /// value E57_FLOAT_MIN or E57_DOUBLE_MIN.
+      /// @details If using a ScaledIntegerNode then this needs to be a minimum angle value.
       double angleMinimum = DOUBLE_MIN;
 
-      //! Indicates that the PointRecord angle fields should be configured with this maximum value e.g. E57_FLOAT_MAX or
-      //! E57_DOUBLE_MAX. If using a ScaledIntegerNode then this needs to be a maximum angle value.
+      /// @brief Indicates that the PointRecord angle fields should be configured with this maximum
+      /// value e.g. E57_FLOAT_MAX or E57_DOUBLE_MAX.
+      /// @details If using a ScaledIntegerNode then this needs to be a maximum angle value.
       double angleMaximum = DOUBLE_MAX;
 
       /// @brief Controls the type of Node used for the PointRecord angle fields
@@ -357,38 +456,45 @@ namespace e57
       /// to scale the numbers and it must be > 0.0.
       double angleScale = 0.0;
 
-      bool rowIndexField = false; //!< Indicates that the PointRecord @a rowIndex field is active
+      /// Indicates that the PointRecord @a rowIndex field is active
+      bool rowIndexField = false;
 
-      //! Indicates that the PointRecord @a rowIndex fields should be configured with this maximum value where the
-      //! minimum will be set to 0.
+      /// Indicates that the PointRecord @a rowIndex fields should be configured with this maximum
+      /// value where the minimum will be set to 0.
       uint32_t rowIndexMaximum = UINT32_MAX;
 
-      bool columnIndexField = false; //!< Indicates that the PointRecord @a columnIndex field is active
+      /// Indicates that the PointRecord @a columnIndex field is active
+      bool columnIndexField = false;
 
-      //! Indicates that the PointRecord @a columnIndex fields should be configured with this maximum value where the
-      //! minimum will be set to 0.
+      /// Indicates that the PointRecord @a columnIndex fields should be configured with this
+      /// maximum value where the minimum will be set to 0.
       uint32_t columnIndexMaximum = UINT32_MAX;
 
-      bool returnIndexField = false;     //!< Indicates that the PointRecord @a returnIndex field is active
-      bool returnCountField = false;     //!< Indicates that the PointRecord @a returnCount field is active
-      uint8_t returnMaximum = UINT8_MAX; //!< Indicates that the PointRecord return fields should be configured
-                                         //!< with this maximum value where the minimum will be set to 0.
+      /// Indicates that the PointRecord @a returnIndex field is active
+      bool returnIndexField = false;
+      /// Indicates that the PointRecord @a returnCount field is active
+      bool returnCountField = false;
+      /// Indicates that the PointRecord return fields should be configured  with this maximum value
+      /// where the minimum will be set to 0.
+      uint8_t returnMaximum = UINT8_MAX;
 
-      bool timeStampField = false;          //!< Indicates that the PointRecord @a timeStamp field is active
-      bool isTimeStampInvalidField = false; //!< Indicates that the PointRecord @a isTimeStampInvalid field is active
+      /// Indicates that the PointRecord @a timeStamp field is active
+      bool timeStampField = false;
+      /// Indicates that the PointRecord @a isTimeStampInvalid field is active
+      bool isTimeStampInvalidField = false;
 
-      //! Indicates that the PointRecord @a timeStamp fields should be configured with this minimum value e.g.
-      //! E57_UINT32_MIN, E57_DOUBLE_MIN or E57_DOUBLE_MIN. If using a ScaledIntegerNode then this needs to be a minimum
-      //! time value.
+      /// @brief Indicates that the PointRecord @a timeStamp fields should be configured with this
+      /// minimum value e.g. E57_UINT32_MIN, E57_DOUBLE_MIN or E57_DOUBLE_MIN.
+      /// @details If using a ScaledIntegerNode then this needs to be a minimum time value.
       double timeMinimum = DOUBLE_MIN;
 
-      //! Indicates that the PointRecord @a timeStamp fields should be configured with this maximum value. e.g.
-      //! E57_UINT32_MAX, E57_DOUBLE_MAX or E57_DOUBLE_MAX.
+      /// Indicates that the PointRecord @a timeStamp fields should be configured with this maximum
+      /// value. e.g. E57_UINT32_MAX, E57_DOUBLE_MAX or E57_DOUBLE_MAX.
       double timeMaximum = DOUBLE_MAX;
 
       /// @brief Controls the type of Node used for the PointRecord time fields
-      /// @details Accepts NumericalNodeType::Integer, NumericalNodeType::ScaledInteger, NumericalNodeType::Float, and
-      /// NumericalNodeType::Double.
+      /// @details Accepts NumericalNodeType::Integer, NumericalNodeType::ScaledInteger,
+      /// NumericalNodeType::Float, and NumericalNodeType::Double.
       NumericalNodeType timeNodeType = NumericalNodeType::Float;
 
       /// @brief Sets the scale if using scaled integers for time fields
@@ -402,8 +508,8 @@ namespace e57
       bool isIntensityInvalidField = false;
 
       /// @brief Controls the type of Node used for the PointRecord intensity fields
-      /// @details Accepts NumericalNodeType::Integer, NumericalNodeType::ScaledInteger, NumericalNodeType::Float, and
-      /// NumericalNodeType::Double.
+      /// @details Accepts NumericalNodeType::Integer, NumericalNodeType::ScaledInteger,
+      /// NumericalNodeType::Float, and NumericalNodeType::Double.
       NumericalNodeType intensityNodeType = NumericalNodeType::Float;
 
       /// @brief Sets the scale if using scaled integers for intensity fields
@@ -428,151 +534,201 @@ namespace e57
       bool normalZField = false;
    };
 
-   //! @brief Stores the top-level information for a single lidar scan
+   /// @brief Stores the top-level information for a single lidar scan
    struct E57_DLL Data3D
    {
-      ustring name; //!< A user-defined name for the Data3D.
-      ustring guid; //!< A globally unique identification string for the current version of the Data3D object
+      /// A user-defined name for the Data3D.
+      ustring name;
 
-      //! A vector of globally unique identification Strings from which the points in this Data3D originated.
+      /// A globally unique identification string for the current version of the  Data3D object
+      ustring guid;
+
+      /// @brief A vector of globally unique identification Strings from which the points in this
+      /// Data3D originated.
       std::vector<ustring> originalGuids;
 
-      ustring description; //!< A user-defined description of the Image
+      /// A user-defined description of the Image
+      ustring description;
 
-      ustring sensorVendor; //!< The name of the manufacturer for the sensor used to collect the points in this Data3D.
-      ustring sensorModel;  //!< The model name or number for the sensor.
-      ustring sensorSerialNumber;    //!< The serial number for the sensor.
-      ustring sensorHardwareVersion; //!< The version number for the sensor hardware at the time of data collection.
-      ustring sensorSoftwareVersion; //!< The version number for the software used for the data collection.
-      ustring sensorFirmwareVersion; //!< The version number for the firmware installed in the sensor at the time of
-                                     //!< data collection.
+      /// The name of the manufacturer for the sensor used to collect the  points in this Data3D.
+      ustring sensorVendor;
+      /// The model name or number for the sensor.
+      ustring sensorModel;
+      /// The serial number for the sensor.
+      ustring sensorSerialNumber;
+      /// The version number for the sensor hardware at the time of data collection.
+      ustring sensorHardwareVersion;
+      /// The version number for the software used for the data  collection.
+      ustring sensorSoftwareVersion;
+      /// @brief The version number for the firmware installed in the sensor at the time of data
+      /// collection.
+      ustring sensorFirmwareVersion;
 
-      //! The ambient temperature, measured at the sensor, at the time of data collection (in degrees Celsius).
+      /// @brief The ambient temperature, measured at the sensor, at the time of data collection.
+      /// @details This units are degrees Celsius.
       float temperature = FLOAT_MAX;
 
-      //! The percentage relative humidity, measured at the sensor, at the time of data collection. Shall be in the
-      //! interval [0, 100].
+      /// @brief The percentage relative humidity, measured at the sensor, at the time of data
+      /// collection.
+      /// @details Shall be in the interval [0, 100].
       float relativeHumidity = FLOAT_MAX;
 
-      //! The atmospheric pressure, measured at the sensor, at the time of data collection (in Pascals). Shall be
-      //! positive.
+      /// @brief The atmospheric pressure, measured at the sensor, at the time of data collection
+      /// @details The units are Pascals. Shall be positive.
       float atmosphericPressure = FLOAT_MAX;
 
-      DateTime acquisitionStart; //!< The start date and time that the data was acquired.
-      DateTime acquisitionEnd;   //!< The end date and time that the data was acquired.
+      /// The start date and time that the data was acquired.
+      DateTime acquisitionStart;
+      /// The end date and time that the data was acquired.
+      DateTime acquisitionEnd;
 
-      //! A rigid body transform that describes the coordinate frame of the 3D imaging system origin in the file-level
-      //! coordinate system.
+      /// @brief A rigid body transform that describes the coordinate frame of the 3D imaging system
+      /// origin.
+      /// @details These are in the file-level coordinate system.
       RigidBodyTransform pose;
 
-      IndexBounds indexBounds; //!< The bounds of the row, column, and return number of all the points in this Data3D.
+      /// The bounds of the row, column, and return number of all the  points in this Data3D.
+      IndexBounds indexBounds;
 
-      //! The bounding region (in cartesian coordinates) of all the points in this Data3D (in the local coordinate
-      //! system of the points).
+      /// @brief The bounding region (in cartesian coordinates) of all the points in this Data3D.
+      /// @details These are in the local coordinate system of the points.
       CartesianBounds cartesianBounds;
 
-      //! The bounding region (in spherical coordinates) of all the points in this Data3D (in the local coordinate
-      //! system of the points).
+      /// @brief The bounding region (in spherical coordinates) of all the points in this Data3D.
+      /// @details These are in the local coordinate system of the points.
       SphericalBounds sphericalBounds;
 
-      //! The limits for the value of signal intensity that the sensor is capable of producing.
+      /// The limits for the value of signal intensity that the sensor is capable of producing.
       IntensityLimits intensityLimits;
 
-      //! The limits for the value of red, green, and blue color that the sensor is capable of producing.
+      /// @brief The limits for the value of red, green, and blue color that the sensor is capable
+      /// of producing.
       ColorLimits colorLimits;
 
-      PointGroupingSchemes pointGroupingSchemes;    //!< The defined schemes that group points in different ways
-      PointStandardizedFieldsAvailable pointFields; //!< The active fields used in the WritePoints function.
+      /// The defined schemes that group points in different ways
+      PointGroupingSchemes pointGroupingSchemes;
+      /// The active fields used in the WritePoints function.
+      PointStandardizedFieldsAvailable pointFields;
 
-      //! The number of points in the Data3D.
+      /// The number of points in the Data3D.
       int64_t pointCount = 0;
    };
 
-   //! @brief Stores pointers to user-provided buffers
+   /// @brief Stores pointers to user-provided buffers
    template <typename COORDTYPE = float> struct E57_DLL Data3DPointsData_t
    {
       static_assert( std::is_floating_point<COORDTYPE>::value, "Floating point type required." );
 
-      //! @brief Default constructor does not manage any memory, adjust min/max for floats, or validate data.
+      /// @brief Default constructor does not manage any memory, adjust min/max for floats, or
+      /// validate data.
       Data3DPointsData_t() = default;
 
-      /// @brief Constructor which allocates buffers for all valid fields in the given Data3D header.
-      /// @details This constructor will also adjust the min/max fields in the data3D pointFields if we are using
-      /// floats, and run some validation on the Data3D.
-      /// @param [in] data3D Completed header which indicates the fields we are using
-      /// @throw ::ErrorValueOutOfBounds
-      /// @throw ::ErrorInvalidNodeType
+      /*!
+      @brief Constructor which allocates buffers for all valid fields in the given Data3D header.
+
+      @details
+      This constructor will also adjust the min/max fields in the data3D pointFields if
+      we are using floats, and run some validation on the Data3D.
+
+      @param [in] data3D Completed header which indicates the fields we are using
+
+      @throw ::ErrorValueOutOfBounds
+      @throw ::ErrorInvalidNodeType
+      */
       explicit Data3DPointsData_t( e57::Data3D &data3D );
 
-      //! @brief Destructor will delete any memory allocated using the Data3DPointsData_t( const e57::Data3D & )
-      //! constructor
+      /// @brief Destructor will delete any memory allocated using the Data3DPointsData_t( const
+      /// e57::Data3D & ) constructor
       ~Data3DPointsData_t();
 
-      //! Pointer to a buffer with the X coordinate (in meters) of the point in Cartesian coordinates
+      /// @brief Pointer to a buffer with the X coordinate (in meters) of the point in Cartesian
+      /// coordinates
       COORDTYPE *cartesianX = nullptr;
 
-      //! Pointer to a buffer with the Y coordinate (in meters) of the point in Cartesian coordinates
+      /// @brief Pointer to a buffer with the Y coordinate (in meters) of the point in Cartesian
+      /// coordinates
       COORDTYPE *cartesianY = nullptr;
 
-      //! Pointer to a buffer with the Z coordinate (in meters) of the point in Cartesian coordinates
+      /// @brief Pointer to a buffer with the Z coordinate (in meters) of the point in Cartesian
+      /// coordinates
       COORDTYPE *cartesianZ = nullptr;
 
-      //! Value = 0 if the point is considered valid, 1 otherwise
+      /// @brief Value = 0 if the point is considered valid, 1 otherwise
       int8_t *cartesianInvalidState = nullptr;
 
       /// @brief Pointer to a buffer with the Point response intensity. Unit is unspecified.
       double *intensity = nullptr;
 
-      //! Value = 0 if the intensity is considered valid, 1 otherwise
+      /// @brief Value = 0 if the intensity is considered valid, 1 otherwise
       int8_t *isIntensityInvalid = nullptr;
 
-      uint16_t *colorRed = nullptr;     //!< Pointer to a buffer with the Red color coefficient. Unit is unspecified
-      uint16_t *colorGreen = nullptr;   //!< Pointer to a buffer with the Green color coefficient. Unit is unspecified
-      uint16_t *colorBlue = nullptr;    //!< Pointer to a buffer with the Blue color coefficient. Unit is unspecified
-      int8_t *isColorInvalid = nullptr; //!< Value = 0 if the color is considered valid, 1 otherwise
+      /// @brief Pointer to a buffer with the Red color coefficient. Unit is unspecified
+      uint16_t *colorRed = nullptr;
+      /// @brief Pointer to a buffer with the Green color coefficient. Unit is unspecified
+      uint16_t *colorGreen = nullptr;
+      /// @brief Pointer to a buffer with the Blue color coefficient. Unit is unspecified
+      uint16_t *colorBlue = nullptr;
+      /// @brief Value = 0 if the color is considered valid, 1 otherwise
+      int8_t *isColorInvalid = nullptr;
 
-      //! Pointer to a buffer with the range (in meters) of points in spherical coordinates.
+      /// @brief Pointer to a buffer with the range (in meters) of points in spherical coordinates.
       COORDTYPE *sphericalRange = nullptr;
 
-      //! Pointer to a buffer with the Azimuth angle (in radians) of point in spherical coordinates
+      /// @brief Pointer to a buffer with the Azimuth angle (in radians) of point in spherical
+      /// coordinates
       COORDTYPE *sphericalAzimuth = nullptr;
 
-      //! Pointer to a buffer with the Elevation angle (in radians) of point in spherical coordinates
+      /// @brief Pointer to a buffer with the Elevation angle (in radians) of point in spherical
+      /// coordinates
       COORDTYPE *sphericalElevation = nullptr;
 
-      //!< Value = 0 if the range is considered valid, 1 otherwise
+      /// @brief Value = 0 if the range is considered valid, 1 otherwise
       int8_t *sphericalInvalidState = nullptr;
 
-      //! Pointer to a buffer with the row number of point (zero based). This is useful for data that is stored in a
-      //! regular grid.  Shall be in the interval (0, 2^31).
+      /// @brief Pointer to a buffer with the row number of point (zero based).
+      /// @details This is useful for data that is stored in a regular grid. Shall be in the
+      /// interval (0, 2^31).
       int32_t *rowIndex = nullptr;
 
-      //! Pointer to a buffer with the column number of point (zero based). This is useful for data that is stored in a
-      //! regular grid. Shall be in the interval (0, 2^31).
+      /// @brief Pointer to a buffer with the column number of point (zero based).
+      /// @details This is useful for data that is stored in a regular grid. Shall be in the
+      /// interval (0, 2^31).
       int32_t *columnIndex = nullptr;
 
-      //! Pointer to a buffer with the number of this return (zero based). That is, 0 is the first return, 1 is the
-      //! second, and so on. Shall be in the interval (0, returnCount). Only for multi-return sensors.
+      /// @brief Pointer to a buffer with the number of this return (zero based).
+      /// @details That is, 0 is the first return, 1 is the second, and so on. Shall be in the
+      /// interval (0, returnCount). Only for multi-return sensors.
       int8_t *returnIndex = nullptr;
 
-      //! Pointer to a buffer with the total number of returns for the pulse that this corresponds to. Shall be in the
-      //! interval (0, 2^7). Only for multi-return sensors.
+      /// @brief Pointer to a buffer with the total number of returns for the pulse that this
+      /// corresponds to.
+      /// @details Shall be in the interval (0, 2^7). Only for multi-return sensors.
       int8_t *returnCount = nullptr;
 
-      //! Pointer to a buffer with the time (in seconds) since the start time for the data, which is given by
-      //! acquisitionStart in the parent Data3D Structure.
+      /// @brief Pointer to a buffer with the time (in seconds) since the start time for the data.
+      /// @details This is given by acquisitionStart in the parent Data3D Structure.
       double *timeStamp = nullptr;
 
-      //!< Value = 0 if the timeStamp is considered valid, 1 otherwise
+      /// @brief Value = 0 if the timeStamp is considered valid, 1 otherwise
       int8_t *isTimeStampInvalid = nullptr;
 
-      // E57_EXT_surface_normals
-      float *normalX = nullptr; //!< The X component of a surface normal vector (E57_EXT_surface_normals extension).
-      float *normalY = nullptr; //!< The Y component of a surface normal vector (E57_EXT_surface_normals extension).
-      float *normalZ = nullptr; //!< The Z component of a surface normal vector (E57_EXT_surface_normals extension).
+      /// @name Extension: E57_EXT_surface_normals
+      /// The following fields are part of the
+      /// [E57_EXT_surface_normals](http://www.libe57.org/E57_EXT_surface_normals.txt) extension.
+      ///@{
+
+      /// @brief The X component of a surface normal vector.
+      float *normalX = nullptr;
+      /// @brief The Y component of a surface normal vector.
+      float *normalY = nullptr;
+      /// @brief The Z component of a surface normal vector.
+      float *normalZ = nullptr;
+
+      ///@}
 
    private:
-      //! Keeps track of whether we used the Data3D constructor or not so we can free our memory.
+      /// @brief Keeps track of whether we used the Data3D constructor or not so we can free our
+      /// memory.
       bool _selfAllocated = false;
    };
 
@@ -585,14 +741,23 @@ namespace e57
    extern template Data3DPointsData_t<float>::~Data3DPointsData_t();
    extern template Data3DPointsData_t<double>::~Data3DPointsData_t();
 
-   //! @brief Stores an image that is to be used only as a visual reference.
+   /// @brief Stores an image that is to be used only as a visual reference.
    struct E57_DLL VisualReferenceRepresentation
    {
-      int64_t jpegImageSize = 0; //!< Size of JPEG format image data in BlobNode.
-      int64_t pngImageSize = 0;  //!< Size of PNG format image data in BlobNode.
-      int64_t imageMaskSize = 0; //!< Size of PNG format image mask in BlobNode.
-      int32_t imageWidth = 0;    //!< The image width (in pixels). Shall be positive.
-      int32_t imageHeight = 0;   //!< The image height (in pixels). Shall be positive.
+      /// Size of JPEG format image data in BlobNode.
+      int64_t jpegImageSize = 0;
+
+      /// Size of PNG format image data in BlobNode.
+      int64_t pngImageSize = 0;
+
+      /// Size of PNG format image mask in BlobNode.
+      int64_t imageMaskSize = 0;
+
+      /// The image width (in pixels). Shall be positive.
+      int32_t imageWidth = 0;
+
+      /// The image height (in pixels). Shall be positive.
+      int32_t imageHeight = 0;
 
       bool operator==( const VisualReferenceRepresentation &rhs ) const
       {
@@ -607,22 +772,37 @@ namespace e57
       }
    };
 
-   //! @brief Stores an image that is mapped from 3D using the pinhole camera projection model.
+   /// @brief Stores an image that is mapped from 3D using the pinhole camera projection model.
    struct E57_DLL PinholeRepresentation
    {
-      int64_t jpegImageSize = 0; //!< Size of JPEG format image data in BlobNode.
-      int64_t pngImageSize = 0;  //!< Size of PNG format image data in BlobNode.
-      int64_t imageMaskSize = 0; //!< Size of PNG format image mask in BlobNode.
-      int32_t imageWidth = 0;    //!< The image width (in pixels). Shall be positive.
-      int32_t imageHeight = 0;   //!< The image height (in pixels). Shall be positive.
-      double focalLength = 0.0;  //!< The camera's focal length (in meters). Shall be positive.
-      double pixelWidth = 0.0;   //!< The width of the pixels in the camera (in meters). Shall be positive.
-      double pixelHeight = 0.0;  //!< The height of the pixels in the camera (in meters). Shall be positive.
+      /// Size of JPEG format image data in BlobNode.
+      int64_t jpegImageSize = 0;
 
-      //! The X coordinate in the image of the principal point, (in pixels). The principal point is the intersection of
-      //! the z axis of the camera coordinate frame with the image plane.
+      /// Size of PNG format image data in BlobNode.
+      int64_t pngImageSize = 0;
+
+      /// Size of PNG format image mask in BlobNode.
+      int64_t imageMaskSize = 0;
+
+      /// The image width (in pixels). Shall be positive.
+      int32_t imageWidth = 0;
+      /// The image height (in pixels). Shall be positive.
+      int32_t imageHeight = 0;
+
+      /// The camera's focal length (in meters). Shall be positive.
+      double focalLength = 0.0;
+
+      /// The width of the pixels in the camera (in meters). Shall be positive.
+      double pixelWidth = 0.0;
+      /// The height of the pixels in the camera (in meters). Shall be positive.
+      double pixelHeight = 0.0;
+
+      /// @brief The X coordinate in the image of the principal point, (in pixels).
+      /// @details The principal point is the intersection of the z axis of the camera coordinate
+      /// frame with the image plane.
       double principalPointX = 0.0;
-      double principalPointY = 0.0; //!< The Y coordinate in the image of the principal point (in pixels).
+      /// The Y coordinate in the image of the principal point (in pixels).
+      double principalPointY = 0.0;
 
       bool operator==( const PinholeRepresentation &rhs ) const
       {
@@ -630,7 +810,8 @@ namespace e57
                 ( imageMaskSize == rhs.imageMaskSize ) && ( imageWidth == rhs.imageWidth ) &&
                 ( imageHeight == rhs.imageHeight ) && ( focalLength == rhs.focalLength ) &&
                 ( pixelWidth == rhs.pixelWidth ) && ( pixelHeight == rhs.pixelHeight ) &&
-                ( principalPointX == rhs.principalPointX ) && ( principalPointY == rhs.principalPointY );
+                ( principalPointX == rhs.principalPointX ) &&
+                ( principalPointY == rhs.principalPointY );
       }
 
       bool operator!=( const PinholeRepresentation &rhs ) const
@@ -639,16 +820,27 @@ namespace e57
       }
    };
 
-   //! @brief Stores an image that is mapped from 3D using a spherical projection model
+   /// @brief Stores an image that is mapped from 3D using a spherical projection model
    struct E57_DLL SphericalRepresentation
    {
-      int64_t jpegImageSize = 0; //!< Size of JPEG format image data in BlobNode.
-      int64_t pngImageSize = 0;  //!< Size of PNG format image data in BlobNode.
-      int64_t imageMaskSize = 0; //!< Size of PNG format image mask in BlobNode.
-      int32_t imageWidth = 0;    //!< The image width (in pixels). Shall be positive
-      int32_t imageHeight = 0;   //!< The image height (in pixels). Shall be positive
-      double pixelWidth = 0.0;   //!< The width of a pixel in the image (in radians). Shall be positive
-      double pixelHeight = 0.0;  //!< The height of a pixel in the image (in radians). Shall be positive.
+      /// Size of JPEG format image data in BlobNode.
+      int64_t jpegImageSize = 0;
+
+      /// Size of PNG format image data in BlobNode.
+      int64_t pngImageSize = 0;
+
+      /// Size of PNG format image mask in BlobNode.
+      int64_t imageMaskSize = 0;
+
+      /// The image width (in pixels). Shall be positive
+      int32_t imageWidth = 0;
+      /// The image height (in pixels). Shall be positive
+      int32_t imageHeight = 0;
+
+      /// The width of a pixel in the image (in radians). Shall be positive
+      double pixelWidth = 0.0;
+      /// The height of a pixel in the image (in radians). Shall be positive.
+      double pixelHeight = 0.0;
 
       bool operator==( const SphericalRepresentation &rhs ) const
       {
@@ -664,23 +856,35 @@ namespace e57
       }
    };
 
-   //! @brief Stores an image that is mapped from 3D using a cylindrical projection model.
+   /// @brief Stores an image that is mapped from 3D using a cylindrical projection model.
    struct E57_DLL CylindricalRepresentation
    {
-      int64_t jpegImageSize = 0; //!< Size of JPEG format image data in Blob.
-      int64_t pngImageSize = 0;  //!< Size of PNG format image data in Blob.
-      int64_t imageMaskSize = 0; //!< Size of PNG format image mask in Blob.
-      int32_t imageWidth = 0;    //!< The image width (in pixels). Shall be positive
-      int32_t imageHeight = 0;   //!< The image height (in pixels). Shall be positive
-      double pixelWidth = 0.0;   //!< The width of a pixel in the image (in radians). Shall be positive.
-      double pixelHeight = 0.0;  //!< The height of a pixel in the image (in meters). Shall be positive.
+      /// Size of JPEG format image data in Blob.
+      int64_t jpegImageSize = 0;
 
-      //! The closest distance from the cylindrical image surface to the center of projection (that is, the radius of
-      //! the cylinder) (in meters). Shall be non-negative.
+      /// Size of PNG format image data in Blob.
+      int64_t pngImageSize = 0;
+
+      /// Size of PNG format image mask in Blob.
+      int64_t imageMaskSize = 0;
+
+      /// The image width (in pixels). Shall be positive
+      int32_t imageWidth = 0;
+      /// The image height (in pixels). Shall be positive
+      int32_t imageHeight = 0;
+
+      /// The width of a pixel in the image (in radians). Shall be positive.
+      double pixelWidth = 0.0;
+      /// The height of a pixel in the image (in meters). Shall be positive.
+      double pixelHeight = 0.0;
+
+      /// @brief The closest distance from the cylindrical image surface to the center of projection
+      /// (that is, the radius of the cylinder) (in meters).
+      /// @details Shall be non-negative.
       double radius = 0.0;
 
-      //! The Y coordinate in the image of the principal point (in pixels). This is the intersection of the z = 0 plane
-      //! with the image.
+      /// @brief The Y coordinate in the image of the principal point (in pixels).
+      /// @details This is the intersection of the z = 0 plane with the image.
       double principalPointY = 0.0;
 
       bool operator==( const CylindricalRepresentation &rhs ) const
@@ -698,46 +902,57 @@ namespace e57
       }
    };
 
-   //! @brief Stores an image from a camera
+   /// @brief Stores an image from a camera
    struct E57_DLL Image2D
    {
-      ustring name;        //!< A user-defined name for the Image2D.
-      ustring guid;        //!< A globally unique identification string for the current version of the Image2D object
-      ustring description; //!< A user-defined description of the Image2D
-      DateTime acquisitionDateTime; //!< The date and time that the image was taken
+      /// A user-defined name for the Image2D.
+      ustring name;
 
-      //! The globally unique identification string (guid element) for the Data3D that was being acquired when the
-      //! picture was taken
+      /// A globally unique identification string for the current version of the  Image2D object
+      ustring guid;
+
+      /// A user-defined description of the Image2D
+      ustring description;
+
+      /// The date and time that the image was taken
+      DateTime acquisitionDateTime;
+
+      /// The globally unique identification string (guid element) for the Data3D that was being
+      /// acquired when the picture was taken
       ustring associatedData3DGuid;
 
-      ustring sensorVendor; //!< The name of the manufacturer for the sensor used to collect the points in this Data3D.
-      ustring sensorModel;  //!< The model name or number for the sensor.
-      ustring sensorSerialNumber; //!< The serial number for the sensor.
+      /// The name of the manufacturer for the sensor used to collect the points in this Data3D.
+      ustring sensorVendor;
+      /// The model name or number for the sensor.
+      ustring sensorModel;
+      /// The serial number for the sensor.
+      ustring sensorSerialNumber;
 
-      //! A rigid body transform that describes the coordinate frame of the camera in the file-level coordinate system
+      /// A rigid body transform that describes the coordinate frame of the camera in the file-level
+      /// coordinate system
       RigidBodyTransform pose;
 
-      //! Representation for an image that does not define any camera projection model.
-      //! The image is to be used for visual reference only
+      /// Representation for an image that does not define any camera projection model.
+      /// The image is to be used for visual reference only
       VisualReferenceRepresentation visualReferenceRepresentation;
 
-      //! Representation for an image using the pinhole camera projection model.
+      /// Representation for an image using the pinhole camera projection model.
       PinholeRepresentation pinholeRepresentation;
 
-      //! Representation for an image using the spherical camera projection model.
+      /// Representation for an image using the spherical camera projection model.
       SphericalRepresentation sphericalRepresentation;
 
-      //! Representation for an image using the cylindrical camera projection model.
+      /// Representation for an image using the cylindrical camera projection model.
       CylindricalRepresentation cylindricalRepresentation;
    };
 
-   //! @brief Identifies the format representation for the image data
+   /// @brief Identifies the format representation for the image data
    enum Image2DType
    {
-      ImageNone = 0,    //!< No image data
-      ImageJPEG = 1,    //!< JPEG format image data.
-      ImagePNG = 2,     //!< PNG format image data.
-      ImageMaskPNG = 3, //!< PNG format image mask.
+      ImageNone = 0,    ///< No image data
+      ImageJPEG = 1,    ///< JPEG format image data.
+      ImagePNG = 2,     ///< PNG format image data.
+      ImageMaskPNG = 3, ///< PNG format image mask.
 
       /// @deprecated Will be removed in 4.0. Use e57::ImageNone.
       E57_NO_IMAGE [[deprecated( "Will be removed in 4.0. Use ImageNone." )]] = ImageNone,
@@ -746,27 +961,33 @@ namespace e57
       /// @deprecated Will be removed in 4.0. Use e57::ImagePNG.
       E57_PNG_IMAGE [[deprecated( "Will be removed in 4.0. Use ImagePNG." )]] = ImagePNG,
       /// @deprecated Will be removed in 4.0. Use e57::ImageMaskPNG.
-      E57_PNG_IMAGE_MASK [[deprecated( "Will be removed in 4.0. Use ImageMaskPNG." )]] = ImageMaskPNG,
+      E57_PNG_IMAGE_MASK [[deprecated( "Will be removed in 4.0. Use ImageMaskPNG." )]] =
+         ImageMaskPNG,
    };
 
-   //! @brief Identifies the representation for the image data
+   /// @brief Identifies the representation for the image data
    enum Image2DProjection
    {
-      ProjectionNone = 0,        //!< No representation for the image data is present
-      ProjectionVisual = 1,      //!< VisualReferenceRepresentation for the image data
-      ProjectionPinhole = 2,     //!< PinholeRepresentation for the image data
-      ProjectionSpherical = 3,   //!< SphericalRepresentation for the image data
-      ProjectionCylindrical = 4, //!< CylindricalRepresentation for the image data
+      ProjectionNone = 0,        ///< No representation for the image data is present
+      ProjectionVisual = 1,      ///< VisualReferenceRepresentation for the image data
+      ProjectionPinhole = 2,     ///< PinholeRepresentation for the image data
+      ProjectionSpherical = 3,   ///< SphericalRepresentation for the image data
+      ProjectionCylindrical = 4, ///< CylindricalRepresentation for the image data
 
       /// @deprecated Will be removed in 4.0. Use e57::ProjectionNone.
-      E57_NO_PROJECTION [[deprecated( "Will be removed in 4.0. Use ProjectionNone." )]] = ProjectionNone,
+      E57_NO_PROJECTION [[deprecated( "Will be removed in 4.0. Use ProjectionNone." )]] =
+         ProjectionNone,
       /// @deprecated Will be removed in 4.0. Use e57::ProjectionVisual.
-      E57_VISUAL [[deprecated( "Will be removed in 4.0. Use ProjectionVisual." )]] = ProjectionVisual,
+      E57_VISUAL [[deprecated( "Will be removed in 4.0. Use ProjectionVisual." )]] =
+         ProjectionVisual,
       /// @deprecated Will be removed in 4.0. Use e57::ProjectionPinhole.
-      E57_PINHOLE [[deprecated( "Will be removed in 4.0. Use ProjectionPinhole." )]] = ProjectionPinhole,
+      E57_PINHOLE [[deprecated( "Will be removed in 4.0. Use ProjectionPinhole." )]] =
+         ProjectionPinhole,
       /// @deprecated Will be removed in 4.0. Use e57::ProjectionSpherical.
-      E57_SPHERICAL [[deprecated( "Will be removed in 4.0. Use ProjectionSpherical." )]] = ProjectionSpherical,
+      E57_SPHERICAL [[deprecated( "Will be removed in 4.0. Use ProjectionSpherical." )]] =
+         ProjectionSpherical,
       /// @deprecated Will be removed in 4.0. Use e57::ProjectionCylindrical.
-      E57_CYLINDRICAL [[deprecated( "Will be removed in 4.0. Use ProjectionCylindrical." )]] = ProjectionCylindrical,
+      E57_CYLINDRICAL [[deprecated( "Will be removed in 4.0. Use ProjectionCylindrical." )]] =
+         ProjectionCylindrical,
    };
 } // end namespace e57

--- a/include/E57SimpleReader.h
+++ b/include/E57SimpleReader.h
@@ -30,172 +30,182 @@
 
 #pragma once
 
-//! @file
-//! @brief E57 Simple API for reading E57.
-//! @details This includes support for the [E57_EXT_surface_normals](http://www.libe57.org/E57_EXT_surface_normals.txt)
-//! extension.
+/// @file
+/// @brief E57 Simple API for reading E57.
+/// @details This includes support for the
+/// [E57_EXT_surface_normals](http://www.libe57.org/E57_EXT_surface_normals.txt) extension.
 
 #include "E57SimpleData.h"
 
 namespace e57
 {
-   //! Options to the Reader constructor
+   /// Options to the Reader constructor
    struct E57_DLL ReaderOptions
    {
-      //! Set how frequently to verify the checksums (see ReadChecksumPolicy).
+      /// Set how frequently to verify the checksums (see ReadChecksumPolicy).
       ReadChecksumPolicy checksumPolicy = ChecksumAll;
    };
 
-   //! @brief Used for reading an E57 file using E57 Simple API.
-   //!
-   //! The Reader includes support for the [E57_EXT_surface_normals](http://www.libe57.org/E57_EXT_surface_normals.txt)
-   //! extension.
+   /// @brief Used for reading an E57 file using E57 Simple API.
+   ///
+   /// The Reader includes support for the
+   /// [E57_EXT_surface_normals](http://www.libe57.org/E57_EXT_surface_normals.txt) extension.
    class E57_DLL Reader
    {
    public:
-      //! @brief Reader constructor
-      //! @param [in] filePath Path to E57 file
-      //! @param [in] options Options to be used for the file
+      /// @brief Reader constructor
+      /// @param [in] filePath Path to E57 file
+      /// @param [in] options Options to be used for the file
       Reader( const ustring &filePath, const ReaderOptions &options );
 
-      //! @brief Reader constructor (deprecated)
-      //! @param [in] filePath Path to E57 file
-      //! @deprecated Will be removed in 4.0. Use Reader( const ustring &, const ReaderOptions & ) instead.
-      [[deprecated(
-         "Will be removed in 4.0. Use Reader( const ustring, const ReaderOptions & )." )]] // TODO Remove in 4.0
+      /// @brief Reader constructor (deprecated)
+      /// @param [in] filePath Path to E57 file
+      /// @deprecated Will be removed in 4.0. Use Reader( const ustring &, const ReaderOptions & )
+      /// instead.
+      [[deprecated( "Will be removed in 4.0. Use Reader( const ustring, const ReaderOptions & "
+                    ")." )]] // TODO Remove in 4.0
       explicit Reader( const ustring &filePath );
 
-      //! @brief Returns true if the file is open
+      /// @brief Returns true if the file is open
       bool IsOpen() const;
 
-      //! @brief Closes the file
+      /// @brief Closes the file
       bool Close();
 
-      //! @name File information
-      //!@{
+      /// @name File information
+      ///@{
 
-      //! @brief Returns the file header information
-      //! @param [out] fileHeader is the main header information
-      //! @return Returns true if successful
+      /// @brief Returns the file header information
+      /// @param [out] fileHeader is the main header information
+      /// @return Returns true if successful
       bool GetE57Root( E57Root &fileHeader ) const;
 
-      //!@}
+      ///@}
 
-      //! @name Image2D
-      //!@{
+      /// @name Image2D
+      ///@{
 
-      //! @brief Returns the total number of Picture Blocks
-      //! @return Returns the number of Image2D blocks
+      /// @brief Returns the total number of Picture Blocks
+      /// @return Returns the number of Image2D blocks
       int64_t GetImage2DCount() const;
 
-      //! @brief Returns the image2D header and positions the cursor
-      //! @param [in] imageIndex This in the index into the image2D vector
-      //! @param [out] image2DHeader pointer to the Image2D structure to receive the picture information
-      //! @return Returns true if successful
+      /// @brief Returns the image2D header and positions the cursor
+      /// @param [in] imageIndex This in the index into the image2D vector
+      /// @param [out] image2DHeader pointer to the Image2D structure to receive the picture
+      /// information
+      /// @return Returns true if successful
       bool ReadImage2D( int64_t imageIndex, Image2D &image2DHeader ) const;
 
-      //! @brief Returns the size of the image data
-      //! @param [in] imageIndex This in the index into the image2D vector
-      //! @param [out] imageProjection identifies the projection in the image2D.
-      //! @param [out] imageType identifies the image format of the projection.
-      //! @param [out] imageWidth The image width (in pixels).
-      //! @param [out] imageHeight The image height (in pixels).
-      //! @param [out] imageSize This is the total number of bytes for the image blob.
-      //! @param [out] imageMaskType This is E57_PNG_IMAGE_MASK if "imageMask" is defined in the projection
-      //! @param [out] imageVisualType This is image type of the VisualReferenceRepresentation if given.
-      //! @return Returns true if successful
-      bool GetImage2DSizes( int64_t imageIndex, Image2DProjection &imageProjection, Image2DType &imageType,
-                            int64_t &imageWidth, int64_t &imageHeight, int64_t &imageSize, Image2DType &imageMaskType,
+      /// @brief Returns the size of the image data
+      /// @param [in] imageIndex This in the index into the image2D vector
+      /// @param [out] imageProjection identifies the projection in the image2D.
+      /// @param [out] imageType identifies the image format of the projection.
+      /// @param [out] imageWidth The image width (in pixels).
+      /// @param [out] imageHeight The image height (in pixels).
+      /// @param [out] imageSize This is the total number of bytes for the image blob.
+      /// @param [out] imageMaskType This is E57_PNG_IMAGE_MASK if "imageMask" is defined in the
+      /// projection
+      /// @param [out] imageVisualType This is image type of the VisualReferenceRepresentation if
+      /// given.
+      /// @return Returns true if successful
+      bool GetImage2DSizes( int64_t imageIndex, Image2DProjection &imageProjection,
+                            Image2DType &imageType, int64_t &imageWidth, int64_t &imageHeight,
+                            int64_t &imageSize, Image2DType &imageMaskType,
                             Image2DType &imageVisualType ) const;
 
-      //! @brief Reads an image
-      //! @param [in] imageIndex index of the image. Must be less than GetImage2DCount()
-      //! @param [in] imageProjection identifies the projection desired.
-      //! @param [in] imageType identifies the image format desired.
-      //! @param [out] buffer pointer the raw image buffer
-      //! @param [in] start position in the block to start reading
-      //! @param [in] count size of desired chuck or buffer size
-      //! @return Returns the number of bytes transferred.
-      int64_t ReadImage2DData( int64_t imageIndex, Image2DProjection imageProjection, Image2DType imageType,
-                               void *buffer, int64_t start, int64_t count ) const;
+      /// @brief Reads an image
+      /// @param [in] imageIndex index of the image. Must be less than GetImage2DCount()
+      /// @param [in] imageProjection identifies the projection desired.
+      /// @param [in] imageType identifies the image format desired.
+      /// @param [out] buffer pointer the raw image buffer
+      /// @param [in] start position in the block to start reading
+      /// @param [in] count size of desired chuck or buffer size
+      /// @return Returns the number of bytes transferred.
+      int64_t ReadImage2DData( int64_t imageIndex, Image2DProjection imageProjection,
+                               Image2DType imageType, void *buffer, int64_t start,
+                               int64_t count ) const;
 
-      //!@}
+      ///@}
 
-      //! @name Data3D
-      //!@{
+      /// @name Data3D
+      ///@{
 
-      //! @brief Returns the total number of Data3D Blocks
-      //! @return Returns number of Data3D blocks.
+      /// @brief Returns the total number of Data3D Blocks
+      /// @return Returns number of Data3D blocks.
       int64_t GetData3DCount() const;
 
-      //! @brief Returns the Data3D header
-      //! @param [in] dataIndex This in the index into the images3D vector. Must be less than GetData3DCount().
-      //! @param [out] data3DHeader Data3D header
-      //! @return Returns true if successful
+      /// @brief Returns the Data3D header
+      /// @param [in] dataIndex This in the index into the images3D vector. Must be less than
+      /// GetData3DCount().
+      /// @param [out] data3DHeader Data3D header
+      /// @return Returns true if successful
       bool ReadData3D( int64_t dataIndex, Data3D &data3DHeader ) const;
 
-      //! @brief Returns the size of the point data
-      //! @param [in] dataIndex This in the index into the images3D vector. Must be less than GetData3DCount().
-      //! @param [out] rowMax This is the maximum row size
-      //! @param [out] columnMax This is the maximum column size
-      //! @param [out] pointsSize This is the total number of point records
-      //! @param [out] groupsSize This is the total number of group records
-      //! @param [out] countSize This is the maximum point count per group
-      //! @param [out] columnIndex This indicates that the idElementName is "columnIndex"
-      //! @return Return true if successful, false otherwise
-      bool GetData3DSizes( int64_t dataIndex, int64_t &rowMax, int64_t &columnMax, int64_t &pointsSize,
-                           int64_t &groupsSize, int64_t &countSize, bool &columnIndex ) const;
+      /// @brief Returns the size of the point data
+      /// @param [in] dataIndex This in the index into the images3D vector. Must be less than
+      /// GetData3DCount().
+      /// @param [out] rowMax This is the maximum row size
+      /// @param [out] columnMax This is the maximum column size
+      /// @param [out] pointsSize This is the total number of point records
+      /// @param [out] groupsSize This is the total number of group records
+      /// @param [out] countSize This is the maximum point count per group
+      /// @param [out] columnIndex This indicates that the idElementName is "columnIndex"
+      /// @return Return true if successful, false otherwise
+      bool GetData3DSizes( int64_t dataIndex, int64_t &rowMax, int64_t &columnMax,
+                           int64_t &pointsSize, int64_t &groupsSize, int64_t &countSize,
+                           bool &columnIndex ) const;
 
-      //! @brief Reads the group data into the provided buffers.
-      //! @param [in] dataIndex This in the index into the images3D vector. Must be less than GetData3DCount().
-      //! @param [in] groupCount size of each of the buffers given
-      //! @param [out] idElementValue pointer to the buffer holding indices index for this group
-      //! @param [out] startPointIndex pointer to the buffer holding Starting index in to the "points" data vector for
-      //! the groups
-      //! @param [out] pointCount pointer to the buffer holding size of the groups given
-      //! @return Return true if successful, false otherwise
+      /// @brief Reads the group data into the provided buffers.
+      /// @param [in] dataIndex This in the index into the images3D vector. Must be less than
+      /// GetData3DCount().
+      /// @param [in] groupCount size of each of the buffers given
+      /// @param [out] idElementValue pointer to the buffer holding indices index for this group
+      /// @param [out] startPointIndex pointer to the buffer holding Starting index in to the
+      /// "points" data vector for the groups
+      /// @param [out] pointCount pointer to the buffer holding size of the groups given
+      /// @return Return true if successful, false otherwise
       bool ReadData3DGroupsData( int64_t dataIndex, int64_t groupCount, int64_t *idElementValue,
                                  int64_t *startPointIndex, int64_t *pointCount ) const;
 
-      //! @brief Use this to read the actual 3D data
-      //! @details All the non-NULL buffers in buffers have number of elements = pointCount.
-      //!          Call the CompressedVectorReader::read() until all data is read.
-      //! @param [in] dataIndex data block index
-      //! @param [in] pointCount size of each element buffer.
-      //! @param [in] buffers pointers to user-provided buffers
-      //! @return vector reader setup to read the selected data into the provided buffers
+      /// @brief Use this to read the actual 3D data
+      /// @details All the non-NULL buffers in buffers have number of elements = pointCount.
+      ///          Call the CompressedVectorReader::read() until all data is read.
+      /// @param [in] dataIndex data block index
+      /// @param [in] pointCount size of each element buffer.
+      /// @param [in] buffers pointers to user-provided buffers
+      /// @return vector reader setup to read the selected data into the provided buffers
       CompressedVectorReader SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
                                                     const Data3DPointsData &buffers ) const;
 
-      //! @overload
+      /// @overload
       CompressedVectorReader SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
                                                     const Data3DPointsData_d &buffers ) const;
 
-      //!@}
+      ///@}
 
-      //! @name Foundation API file information
-      //!@{
+      /// @name File information
+      ///@{
 
-      //! @brief Returns the file raw E57Root Structure Node
+      /// @brief Returns the file raw E57Root Structure Node
       StructureNode GetRawE57Root() const;
 
-      //! @brief Returns the raw Data3D Vector Node
+      /// @brief Returns the raw Data3D Vector Node
       VectorNode GetRawData3D() const;
 
-      //! @brief Returns the raw Image2D Vector Node
+      /// @brief Returns the raw Image2D Vector Node
       VectorNode GetRawImages2D() const;
 
-      //! @brief Returns the ram ImageFile Node which is need to add enhancements
+      /// @brief Returns the ram ImageFile Node which is need to add enhancements
       ImageFile GetRawIMF() const;
 
-      //!@}
+      ///@}
 
-      //! @cond documentNonPublic   The following isn't part of the API, and isn't documented.
    protected:
+      /// @cond documentNonPublic   The following isn't part of the API, and isn't documented.
       friend class ReaderImpl;
 
-      E57_OBJECT_IMPLEMENTATION( Reader ) // Internal implementation details, not part of API, must be last in object
-      //! @endcond
+      E57_OBJECT_IMPLEMENTATION( Reader ) // must be last in object
+      /// @endcond
    }; // end Reader class
 
 } // end namespace e57

--- a/include/E57SimpleWriter.h
+++ b/include/E57SimpleWriter.h
@@ -30,164 +30,180 @@
 
 #pragma once
 
-//! @file
-//! @brief E57 Simple API for writing E57.
-//! @details This includes support for the [E57_EXT_surface_normals](http://www.libe57.org/E57_EXT_surface_normals.txt)
-//! extension.
+/// @file
+/// @brief E57 Simple API for writing E57.
+/// @details This includes support for the
+/// [E57_EXT_surface_normals](http://www.libe57.org/E57_EXT_surface_normals.txt) extension.
 
 #include "E57SimpleData.h"
 
 namespace e57
 {
-   //! Options to the Writer constructor
+   /// Options to the Writer constructor
    struct E57_DLL WriterOptions
    {
-      ustring guid;               //!< Optional file guid
-      ustring coordinateMetadata; //!< Information describing the Coordinate Reference System to be used for the file
+      /// Optional file guid
+      ustring guid;
+
+      /// Information describing the Coordinate Reference System to be used for the file
+      ustring coordinateMetadata;
    };
 
-   //! @brief Used for writing an E57 file using the E57 Simple API.
-   //!
-   //! The Writer includes support for the [E57_EXT_surface_normals](http://www.libe57.org/E57_EXT_surface_normals.txt)
-   //! extension.
+   /// @brief Used for writing an E57 file using the E57 Simple API.
+   ///
+   /// The Writer includes support for the
+   /// [E57_EXT_surface_normals](http://www.libe57.org/E57_EXT_surface_normals.txt) extension.
    class E57_DLL Writer
    {
    public:
-      //! @brief Writer constructor
-      //! @param [in] filePath Path to E57 file
-      //! @param [in] options Options to be used for the file
+      /// @brief Writer constructor
+      /// @param [in] filePath Path to E57 file
+      /// @param [in] options Options to be used for the file
       Writer( const ustring &filePath, const WriterOptions &options );
 
-      //! @brief Writer constructor (deprecated)
-      //! @param [in] filePath Path to E57 file
-      //! @param [in] coordinateMetadata Information describing the Coordinate Reference System to be used for the file
-      //! @deprecated Will be removed in 4.0. Use Writer( const ustring &filePath, const WriterOptions &options )
-      //! instead.
-      [[deprecated( "Will be removed in 4.0. Use Writer( ustring, WriterOptions )." )]] // TODO Remove in 4.0
+      /// @brief Writer constructor (deprecated)
+      /// @param [in] filePath Path to E57 file
+      /// @param [in] coordinateMetadata Information describing the Coordinate Reference System to
+      /// be used for the file
+      /// @deprecated Will be removed in 4.0. Use Writer( const ustring &filePath, const
+      /// WriterOptions &options ) instead.
+      [[deprecated(
+         "Will be removed in 4.0. Use Writer( ustring, WriterOptions )." )]] // TODO Remove in 4.0
       explicit Writer( const ustring &filePath, const ustring &coordinateMetadata = {} );
 
-      //! @brief Returns true if the file is open
+      /// @brief Returns true if the file is open
       bool IsOpen() const;
 
-      //! @brief Closes the file
+      /// @brief Closes the file
       bool Close();
 
-      //! @name Image2D
-      //!@{
+      /// @name Image2D
+      ///@{
 
-      //! @brief This function writes the Image2D data to the file
-      //! @details The user needs to config a Image2D structure with all the camera information before making this call.
-      //! @note @p image2DHeader may be modified (adding a guid or adding missing, required fields).
-      //! @param [in,out] image2DHeader header metadata
-      //! @param [in] imageType identifies the image format
-      //! @param [in] imageProjection identifies the projection
-      //! @param [in] startPos position in the block to start writing
-      //! @param [in] buffer pointer the data buffer
-      //! @param [in] byteCount buffer size
-      //! @return Returns the number of bytes written
-      int64_t WriteImage2DData( Image2D &image2DHeader, Image2DType imageType, Image2DProjection imageProjection,
-                                int64_t startPos, void *buffer, int64_t byteCount );
+      /// @brief This function writes the Image2D data to the file
+      /// @details The user needs to config a Image2D structure with all the camera information
+      /// before making this call.
+      /// @note @p image2DHeader may be modified (adding a guid or adding missing, required fields).
+      /// @param [in,out] image2DHeader header metadata
+      /// @param [in] imageType identifies the image format
+      /// @param [in] imageProjection identifies the projection
+      /// @param [in] startPos position in the block to start writing
+      /// @param [in] buffer pointer the data buffer
+      /// @param [in] byteCount buffer size
+      /// @return Returns the number of bytes written
+      int64_t WriteImage2DData( Image2D &image2DHeader, Image2DType imageType,
+                                Image2DProjection imageProjection, int64_t startPos, void *buffer,
+                                int64_t byteCount );
 
-      //! @brief Writes a new Image2D header
-      //! @details The user needs to config a Image2D structure with all the camera information before making this call.
-      //! @param [in,out] image2DHeader header metadata
-      //! @return Returns the image2D index
-      //! @deprecated Will be removed in 4.0. Use WriteImage2DData(Image2D &,Image2DType,Image2DProjection,int64_t,void
-      //! *,int64_t) instead.
+      /// @brief Writes a new Image2D header
+      /// @details The user needs to config a Image2D structure with all the camera information
+      /// before making this call.
+      /// @param [in,out] image2DHeader header metadata
+      /// @return Returns the image2D index
+      /// @deprecated Will be removed in 4.0. Use WriteImage2DData(Image2D
+      /// &,Image2DType,Image2DProjection,int64_t,void
+      /// *,int64_t) instead.
       [[deprecated( "Will be removed in 4.0. Use WriteImage2DData()." )]] // TODO Remove in 4.0
       int64_t
          NewImage2D( Image2D &image2DHeader );
 
-      //! @brief Writes the actual image data
-      //! @param [in] imageIndex picture block index given by the NewImage2D
-      //! @param [in] imageType identifies the image format desired.
-      //! @param [in] imageProjection identifies the projection desired.
-      //! @param [in] buffer pointer the buffer
-      //! @param [in] start position in the block to start writing
-      //! @param [in] count size of desired chunk or buffer size
-      //! @return Returns the number of bytes written
-      //! @deprecated Will be removed in 4.0. Use WriteImage2DData(Image2D &,Image2DType,Image2DProjection,int64_t,void
-      //! *,int64_t) instead.
-      [[deprecated( "Will be removed in 4.0. Use WriteImage2DData(Image2D &,Image2DType,Image2DProjection,int64_t,void "
+      /// @brief Writes the actual image data
+      /// @param [in] imageIndex picture block index given by the NewImage2D
+      /// @param [in] imageType identifies the image format desired.
+      /// @param [in] imageProjection identifies the projection desired.
+      /// @param [in] buffer pointer the buffer
+      /// @param [in] start position in the block to start writing
+      /// @param [in] count size of desired chunk or buffer size
+      /// @return Returns the number of bytes written
+      /// @deprecated Will be removed in 4.0. Use WriteImage2DData(Image2D
+      /// &,Image2DType,Image2DProjection,int64_t,void
+      /// *,int64_t) instead.
+      [[deprecated( "Will be removed in 4.0. Use WriteImage2DData(Image2D "
+                    "&,Image2DType,Image2DProjection,int64_t,void "
                     "*,int64_t)." )]] // TODO Remove in 4.0
       int64_t
-         WriteImage2DData( int64_t imageIndex, Image2DType imageType, Image2DProjection imageProjection, void *buffer,
-                           int64_t start, int64_t count );
+         WriteImage2DData( int64_t imageIndex, Image2DType imageType,
+                           Image2DProjection imageProjection, void *buffer, int64_t start,
+                           int64_t count );
 
-      //!@}
+      ///@}
 
-      //! @name Data3D
-      //!@{
+      /// @name Data3D
+      ///@{
 
-      //! @brief This function writes the Data3D data to the file
-      //! @details The user needs to config a Data3D structure with all the scanning information before making this
-      //! call.
-      //! @note @p data3DHeader may be modified (adding a guid or adding missing, required fields).
-      //! @param [in,out] data3DHeader metadata about what is included in the buffers
-      //! @param [in] buffers pointers to user-provided buffers containing the actual data
-      //! @return Returns the index of the new scan's data3D block.
+      /// @brief This function writes the Data3D data to the file
+      /// @details The user needs to config a Data3D structure with all the scanning information
+      /// before making this call.
+      /// @note @p data3DHeader may be modified (adding a guid or adding missing, required fields).
+      /// @param [in,out] data3DHeader metadata about what is included in the buffers
+      /// @param [in] buffers pointers to user-provided buffers containing the actual data
+      /// @return Returns the index of the new scan's data3D block.
       int64_t WriteData3DData( Data3D &data3DHeader, const Data3DPointsData &buffers );
 
-      //! @overload
+      /// @overload
       int64_t WriteData3DData( Data3D &data3DHeader, const Data3DPointsData_d &buffers );
 
-      //! @brief Writes a new Data3D header
-      //! @details The user needs to config a Data3D structure with all the scanning information before making this
-      //! call.
-      //! @param [in,out] data3DHeader scan metadata
-      //! @return Returns the index of the new scan's data3D block.
-      //! @deprecated Will be removed in 4.0. Use WriteData3DData() instead.
+      /// @brief Writes a new Data3D header
+      /// @details The user needs to config a Data3D structure with all the scanning information
+      /// before making this call.
+      /// @param [in,out] data3DHeader scan metadata
+      /// @return Returns the index of the new scan's data3D block.
+      /// @deprecated Will be removed in 4.0. Use WriteData3DData() instead.
       [[deprecated( "Will be removed in 4.0. Use WriteData3DData()." )]] // TODO Remove in 4.0
       int64_t
          NewData3D( Data3D &data3DHeader );
 
-      //! @brief Sets up a writer to write the actual scan data
-      //! @param [in] dataIndex index returned by NewData3D
-      //! @param [in] pointCount Number of points to write (number of elements in each of the buffers)
-      //! @param [in] buffers pointers to user-provided buffers
-      //! @return returns a vector writer setup to write the selected scan data
-      //! @deprecated Will be removed in 4.0. Use WriteData3DData() instead.
+      /// @brief Sets up a writer to write the actual scan data
+      /// @param [in] dataIndex index returned by NewData3D
+      /// @param [in] pointCount Number of points to write (number of elements in each of the
+      /// buffers)
+      /// @param [in] buffers pointers to user-provided buffers
+      /// @return returns a vector writer setup to write the selected scan data
+      /// @deprecated Will be removed in 4.0. Use WriteData3DData() instead.
       [[deprecated( "Will be removed in 4.0. Use WriteData3DData()." )]] // TODO Remove in 4.0
       CompressedVectorWriter
-         SetUpData3DPointsData( int64_t dataIndex, size_t pointCount, const Data3DPointsData &buffers );
+         SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
+                                const Data3DPointsData &buffers );
 
-      //! @overload
+      /// @overload
       [[deprecated( "Will be removed in 4.0. Use WriteData3DData()." )]] // TODO Remove in 4.0
       CompressedVectorWriter
-         SetUpData3DPointsData( int64_t dataIndex, size_t pointCount, const Data3DPointsData_d &buffers );
+         SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
+                                const Data3DPointsData_d &buffers );
 
-      //! @brief Writes out the group data
-      //! @param [in] dataIndex data block index given by the NewData3D
-      //! @param [in] groupCount size of each of the buffers given
-      //! @param [in] idElementValue buffer with idElementValue indices for this group
-      //! @param [in] startPointIndex buffer with starting indices in to the "points" data vector for the groups
-      //! @param [in] pointCount buffer with sizes of the groups given
-      //! @return Return true if successful, false otherwise
+      /// @brief Writes out the group data
+      /// @param [in] dataIndex data block index given by the NewData3D
+      /// @param [in] groupCount size of each of the buffers given
+      /// @param [in] idElementValue buffer with idElementValue indices for this group
+      /// @param [in] startPointIndex buffer with starting indices in to the "points" data vector
+      /// for the groups
+      /// @param [in] pointCount buffer with sizes of the groups given
+      /// @return Return true if successful, false otherwise
       bool WriteData3DGroupsData( int64_t dataIndex, int64_t groupCount, int64_t *idElementValue,
                                   int64_t *startPointIndex, int64_t *pointCount );
 
-      //!@}
+      ///@}
 
-      //! @name Foundation API file information
-      //!@{
+      /// @name File information
+      ///@{
 
-      //! @brief Returns the file raw E57Root Structure Node
+      /// @brief Returns the file raw E57Root Structure Node
       StructureNode GetRawE57Root();
-      //! @brief Returns the raw Data3D Vector Node
+      /// @brief Returns the raw Data3D Vector Node
       VectorNode GetRawData3D();
-      //! @brief Returns the raw Image2D Vector Node
+      /// @brief Returns the raw Image2D Vector Node
       VectorNode GetRawImages2D();
-      //! @brief Returns the ram ImageFile Node which is need to add enhancements
+      /// @brief Returns the ram ImageFile Node which is need to add enhancements
       ImageFile GetRawIMF();
 
-      //!@}
+      ///@}
 
-      //! @cond documentNonPublic   The following isn't part of the API, and isn't documented.
    protected:
+      /// @cond documentNonPublic   The following isn't part of the API, and isn't documented.
       friend class WriterImpl;
 
-      E57_OBJECT_IMPLEMENTATION( Writer ) // Internal implementation details, not part of API, must be last in object
-      //! @endcond
+      E57_OBJECT_IMPLEMENTATION( Writer ) //  must be last in object
+      /// @endcond
    }; // end Writer class
 
 } // end namespace e57

--- a/src/BlobNode.cpp
+++ b/src/BlobNode.cpp
@@ -27,253 +27,21 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-//! @file BlobNode.cpp
+/// @file BlobNode.cpp
 
 #include "BlobNodeImpl.h"
 #include "StringFunctions.h"
 
 using namespace e57;
 
+// Put this function first so we can reference the code in doxygen using @skip
 /*!
-@class e57::BlobNode
-@brief   An E57 element encoding an fixed-length sequence of bytes with an
-opaque format.
-@details
-A BlobNode is a terminal node (i.e. having no children) that holds an opaque,
-fixed-length sequence of bytes. The number of bytes in the BlobNode is declared
-at creation time. The content of the blob is stored within the E57 file in an
-efficient binary format (but not compressed). The BlobNode cannot grow after it
-is created. There is no ordering constraints on how content of a BlobNode may be
-accessed (i.e. it is random access). BlobNodes in an ImageFile opened for
-reading are read-only.
-
-There are two categories of BlobNodes, distinguished by their usage: private
-BlobNodes and public BlobNodes. In a private BlobNode, the format of its content
-bytes is not published. This is useful for storing proprietary data that a
-writer does not wish to share with all readers. Rather than put this information
-in a separate file, the writer can embed the file inside the E57 file so it
-cannot be lost.
-
-In a public BlobNode, the format is published or follows some industry standard
-format (e.g. JPEG). Rather than reinvent the wheel in applications that are
-already well-served by an existing format standard, an E57 file writer can just
-embed an existing file as an "attachment" in a BlobNode. The internal format of
-a public BlobNode is not enforced by the Foundation API. It is recommended that
-there be some mechanism for a reader to know ahead of time which format the
-BlobNode content adheres to (either specified by a document, or encoded by some
-scheme in the E57 Element tree).
-
-The BlobNode is the one node type where the set-once policy is not strictly
-enforced. It is possible to write the same byte location in a BlobNode several
-times. However it is not recommended.
-
-See Node class discussion for discussion of the common functions that
-StructureNode supports.
-
-@section BlobNode_invariant Class Invariant
-A class invariant is a list of statements about an object that are always true
-before and after any operation on the object. An invariant is useful for testing
-correct operation of an implementation. Statements in an invariant can involve
-only externally visible state, or, can refer to internal implementation-specific
-state that is not visible to the API user. The following C++ code checks
-externally visible state for consistency and throws an exception if the
-invariant is violated:
-@dontinclude BlobNode.cpp
-@skip beginExample BlobNode::checkInvariant
-@until endExample BlobNode::checkInvariant
-
-@see     Node
+@brief Check whether BlobNode class invariant is true
+@copydetails IntegerNode::checkInvariant()
 */
-
-/*!
-@brief   Create an element for storing a sequence of bytes with an opaque
-format.
-@param   [in] destImageFile The ImageFile where the new node will eventually be
-stored.
-@param   [in] byteCount     The number of bytes reserved in the ImageFile for
-holding the blob.
-@details
-The BlobNode class corresponds to the ASTM E57 standard Blob element.
-See the class discussion at bottom of BlobNode page for more details.
-
-The E57 Foundation Implementation may pre-allocate disk space in the ImageFile
-to store the declared length of the blob. The disk must have enough free space
-to store @a byteCount bytes of data. The data of a newly created BlobNode is
-initialized to zero.
-
-The @a destImageFile indicates which ImageFile the BlobNode will eventually be
-attached to. A node is attached to an ImageFile by adding it underneath the
-predefined root of the ImageFile (gotten from ImageFile::root). It is not an
-error to fail to attach the BlobNode to the @a destImageFile. It is an error to
-attempt to attach the BlobNode to a different ImageFile.
-@pre     The @a destImageFile must be open (i.e. destImageFile.isOpen() must be
-true).
-@pre     The @a destImageFile must have been opened in write mode (i.e.
-destImageFile.isWritable() must be true).
-@pre     byteCount >= 0
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorFileReadOnly
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     Node, BlobNode::read, BlobNode::write
-*/
-BlobNode::BlobNode( ImageFile destImageFile, int64_t byteCount ) :
-   impl_( new BlobNodeImpl( destImageFile.impl(), byteCount ) )
-{
-}
-
-//! @brief   Is this a root node.
-//! @copydetails Node::isRoot()
-bool BlobNode::isRoot() const
-{
-   return impl_->isRoot();
-}
-
-//! @brief   Return parent of node, or self if a root node.
-//! @copydetails Node::parent()
-Node BlobNode::parent() const
-{
-   return Node( impl_->parent() );
-}
-
-//! @brief   Get absolute pathname of node.
-//! @copydetails Node::pathName()
-ustring BlobNode::pathName() const
-{
-   return impl_->pathName();
-}
-
-//! @brief   Get elementName string, that identifies the node in its parent..
-//! @copydetails Node::elementName()
-ustring BlobNode::elementName() const
-{
-   return impl_->elementName();
-}
-
-//! @brief   Get the ImageFile that was declared as the destination for the node
-//! when it was created.
-//! @copydetails Node::destImageFile()
-ImageFile BlobNode::destImageFile() const
-{
-   return ImageFile( impl_->destImageFile() );
-}
-
-//! @brief   Has node been attached into the tree of an ImageFile.
-//! @copydetails Node::isAttached()
-bool BlobNode::isAttached() const
-{
-   return impl_->isAttached();
-}
-
-/*!
-@brief   Get size of blob declared when it was created.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The declared size of the blob when it was created.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     BlobNode::read, BlobNode::write
-*/
-int64_t BlobNode::byteCount() const
-{
-   return impl_->byteCount();
-}
-
-/*!
-@brief   Read a buffer of bytes from a blob.
-@param   [in] buf   A memory buffer to store bytes read from the blob.
-@param   [in] start The index of the first byte in blob to read.
-@param   [in] count The number of bytes to read.
-@details
-The memory buffer @a buf must be able to store at least @a count bytes.
-The data is stored in a binary section of the ImageFile with checksum
-protection, so undetected corruption is very unlikely. It is an error to attempt
-to read outside the declared size of the Blob. The format of the data read is
-opaque (unspecified by the ASTM E57 data format standard). Since @a buf is a
-byte buffer, byte ordering is irrelevant (it will come out in the same order
-that it went in). There is no constraint on the ordering of reads. Any part of
-the Blob data can be read zero or more times.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@pre     buf != NULL
-@pre     0 <= @a start < byteCount()
-@pre     0 <= count
-@pre     (@a start + @a count) < byteCount()
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorSeekFailed
-@throw   ::ErrorReadFailed
-@throw   ::ErrorBadChecksum
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     BlobNode::byteCount, BlobNode::write
-*/
-void BlobNode::read( uint8_t *buf, int64_t start, size_t count )
-{
-   impl_->read( buf, start, count );
-}
-
-/*!
-@brief   Write a buffer of bytes to a blob.
-@param   [in] buf   A memory buffer of bytes to write to the blob.
-@param   [in] start The index of the first byte in blob to write to.
-@param   [in] count The number of bytes to write.
-@details
-The memory buffer @a buf must store at least @a count bytes.
-The data is stored in a binary section of the ImageFile with checksum
-protection, so undetected corruption is very unlikely. It is an error to attempt
-to write outside the declared size of the Blob. The format of the data written
-is opaque (unspecified by the ASTM E57 data format standard). Since @a buf is a
-byte buffer, byte ordering is irrelevant (it will come out in the same order
-that it went in). There is no constraint on the ordering of writes. It is not an
-error to write a portion of the BlobNode data more than once, or not at all.
-Initially all the BlobNode data is zero, so if a portion is not written, it will
-remain zero. The BlobNode is one of the two node types that must be attached to
-the root of a write mode ImageFile before write operations can be performed (the
-other type is CompressedVectorNode).
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@pre     The associated destImageFile must have been opened in write mode (i.e.
-destImageFile().isWritable()).
-@pre     The BlobNode must be attached to an ImageFile (i.e. isAttached()).
-@pre     buf != NULL
-@pre     0 <= @a start < byteCount()
-@pre     0 <= count
-@pre     (@a start + @a count) < byteCount()
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorFileReadOnly
-@throw   ::ErrorNodeUnattached
-@throw   ::ErrorSeekFailed
-@throw   ::ErrorReadFailed
-@throw   ::ErrorWriteFailed
-@throw   ::ErrorBadChecksum
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     BlobNode::byteCount, BlobNode::read
-*/
-void BlobNode::write( uint8_t *buf, int64_t start, size_t count )
-{
-   impl_->write( buf, start, count );
-}
-
-//! @brief   Diagnostic function to print internal state of object to output
-//! stream in an indented format.
-//! @copydetails Node::dump()
-#ifdef E57_DEBUG
-void BlobNode::dump( int indent, std::ostream &os ) const
-{
-   impl_->dump( indent, os );
-}
-#else
-void BlobNode::dump( int indent, std::ostream &os ) const
-{
-}
-#endif
-
-//! @brief Check whether BlobNode class invariant is true
-//! @copydetails IntegerNode::checkInvariant()
-// beginExample BlobNode::checkInvariant
 void BlobNode::checkInvariant( bool /*doRecurse*/, bool doUpcast )
 {
-   // If destImageFile not open, can't test invariant (almost every call would
-   // throw)
+   // If destImageFile not open, can't test invariant (almost every call would throw)
    if ( !destImageFile().isOpen() )
    {
       return;
@@ -290,33 +58,289 @@ void BlobNode::checkInvariant( bool /*doRecurse*/, bool doUpcast )
       throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 }
-// endExample BlobNode::checkInvariant
 
 /*!
-@brief   Upcast a BlobNode handle to a generic Node handle.
-@details An upcast is always safe, and the compiler can automatically insert it
-for initializations of Node variables and Node function arguments.
-@return  A smart Node handle referencing the underlying object.
-@throw   No E57Exceptions.
-@see     Explanation in Node, Node::type(), BlobNode(const Node&)
+@class e57::BlobNode
+
+@brief An E57 element encoding an fixed-length sequence of bytes with an opaque format.
+
+@details
+A BlobNode is a terminal node (i.e. having no children) that holds an opaque, fixed-length sequence
+of bytes. The number of bytes in the BlobNode is declared at creation time. The content of the blob
+is stored within the E57 file in an efficient binary format (but not compressed). The BlobNode
+cannot grow after it is created. There is no ordering constraints on how content of a BlobNode may
+be accessed (i.e. it is random access). BlobNodes in an ImageFile opened for reading are read-only.
+
+There are two categories of BlobNodes, distinguished by their usage: private BlobNodes and public
+BlobNodes. In a private BlobNode, the format of its content bytes is not published. This is useful
+for storing proprietary data that a writer does not wish to share with all readers. Rather than put
+this information in a separate file, the writer can embed the file inside the E57 file so it cannot
+be lost.
+
+In a public BlobNode, the format is published or follows some industry standard format (e.g. JPEG).
+Rather than reinvent the wheel in applications that are already well-served by an existing format
+standard, an E57 file writer can just embed an existing file as an "attachment" in a BlobNode. The
+internal format of a public BlobNode is not enforced by the Foundation API. It is recommended that
+there be some mechanism for a reader to know ahead of time which format the BlobNode content adheres
+to (either specified by a document, or encoded by some scheme in the E57 Element tree).
+
+The BlobNode is the one node type where the set-once policy is not strictly enforced. It is possible
+to write the same byte location in a BlobNode several times. However it is not recommended.
+
+See Node class discussion for discussion of the common functions that StructureNode supports.
+
+@section BlobNode_invariant Class Invariant
+A class invariant is a list of statements about an object that are always true before and after any
+operation on the object. An invariant is useful for testing correct operation of an implementation.
+Statements in an invariant can involve only externally visible state, or, can refer to internal
+implementation-specific state that is not visible to the API user. The following C++ code checks
+externally visible state for consistency and throws an exception if the invariant is violated:
+
+@dontinclude BlobNode.cpp
+@skip void BlobNode::checkInvariant
+@until ^}
+
+@see Node
+*/
+
+/*!
+@brief Create an element for storing a sequence of bytes with an opaque format.
+@param [in] destImageFile The ImageFile where the new node will eventually be stored.
+@param [in] byteCount     The number of bytes reserved in the ImageFile for holding the blob.
+@details
+The BlobNode class corresponds to the ASTM E57 standard Blob element.
+
+See the class discussion at bottom of BlobNode page for more details.
+
+The E57 Foundation Implementation may pre-allocate disk space in the ImageFile to store the declared
+length of the blob. The disk must have enough free space to store @a byteCount bytes of data. The
+data of a newly created BlobNode is initialized to zero.
+
+The @a destImageFile indicates which ImageFile the BlobNode will eventually be attached to. A node
+is attached to an ImageFile by adding it underneath the predefined root of the ImageFile (gotten
+from ImageFile::root). It is not an error to fail to attach the BlobNode to the @a destImageFile. It
+is an error to attempt to attach the BlobNode to a different ImageFile.
+
+@pre The @a destImageFile must be open (i.e. destImageFile.isOpen() must be true).
+@pre The @a destImageFile must have been opened in write mode (i.e. destImageFile.isWritable()
+must be true).
+@pre byteCount >= 0
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorFileReadOnly
+@throw ::ErrorInternal All objects in undocumented state
+
+@see Node, BlobNode::read, BlobNode::write
+*/
+BlobNode::BlobNode( ImageFile destImageFile, int64_t byteCount ) :
+   impl_( new BlobNodeImpl( destImageFile.impl(), byteCount ) )
+{
+}
+
+/*!
+@brief Is this a root node.
+@copydetails Node::isRoot()
+*/
+bool BlobNode::isRoot() const
+{
+   return impl_->isRoot();
+}
+
+/*!
+@brief Return parent of node, or self if a root node.
+@copydetails Node::parent()
+*/
+Node BlobNode::parent() const
+{
+   return Node( impl_->parent() );
+}
+
+/*!
+@brief Get absolute pathname of node.
+@copydetails Node::pathName()
+*/
+ustring BlobNode::pathName() const
+{
+   return impl_->pathName();
+}
+
+/*!
+@brief Get elementName string, that identifies the node in its parent.
+@copydetails Node::elementName()
+*/
+ustring BlobNode::elementName() const
+{
+   return impl_->elementName();
+}
+
+/*!
+@brief Get the ImageFile that was declared as the destination for the node when it was created.
+@copydetails Node::destImageFile()
+*/
+ImageFile BlobNode::destImageFile() const
+{
+   return ImageFile( impl_->destImageFile() );
+}
+
+/*!
+@brief Has node been attached into the tree of an ImageFile.
+@copydetails Node::isAttached()
+*/
+bool BlobNode::isAttached() const
+{
+   return impl_->isAttached();
+}
+
+/*!
+@brief Get size of blob declared when it was created.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return The declared size of the blob when it was created.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see BlobNode::read, BlobNode::write
+*/
+int64_t BlobNode::byteCount() const
+{
+   return impl_->byteCount();
+}
+
+/*!
+@brief Read a buffer of bytes from a blob.
+
+@param [in] buf A memory buffer to store bytes read from the blob.
+@param [in] start The index of the first byte in blob to read.
+@param [in] count The number of bytes to read.
+
+@details
+The memory buffer @a buf must be able to store at least @a count bytes.
+
+The data is stored in a binary section of the ImageFile with checksum protection, so undetected
+corruption is very unlikely. It is an error to attempt to read outside the declared size of the
+Blob. The format of the data read is opaque (unspecified by the ASTM E57 data format standard).
+Since @a buf is a byte buffer, byte ordering is irrelevant (it will come out in the same order that
+it went in). There is no constraint on the ordering of reads. Any part of the Blob data can be read
+zero or more times.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@pre buf != NULL
+@pre 0 <= @a start < byteCount()
+@pre 0 <= count
+@pre (@a start + @a count) < byteCount()
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorSeekFailed
+@throw ::ErrorReadFailed
+@throw ::ErrorBadChecksum
+@throw ::ErrorInternal All objects in undocumented state
+
+@see BlobNode::byteCount, BlobNode::write
+*/
+void BlobNode::read( uint8_t *buf, int64_t start, size_t count )
+{
+   impl_->read( buf, start, count );
+}
+
+/*!
+@brief Write a buffer of bytes to a blob.
+
+@param [in] buf A memory buffer of bytes to write to the blob.
+@param [in] start The index of the first byte in blob to write to.
+@param [in] count The number of bytes to write.
+
+@details
+The memory buffer @a buf must store at least @a count bytes.
+
+The data is stored in a binary section of the ImageFile with checksum protection, so undetected
+corruption is very unlikely. It is an error to attempt to write outside the declared size of the
+Blob. The format of the data written is opaque (unspecified by the ASTM E57 data format standard).
+Since @a buf is a byte buffer, byte ordering is irrelevant (it will come out in the same order that
+it went in). There is no constraint on the ordering of writes. It is not an error to write a portion
+of the BlobNode data more than once, or not at all. Initially all the BlobNode data is zero, so if a
+portion is not written, it will remain zero. The BlobNode is one of the two node types that must be
+attached to the root of a write mode ImageFile before write operations can be performed (the other
+type is CompressedVectorNode).
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@pre The associated destImageFile must have been opened in write mode (i.e.
+destImageFile().isWritable()).
+@pre The BlobNode must be attached to an ImageFile (i.e. isAttached()).
+@pre buf != NULL
+@pre 0 <= @a start < byteCount()
+@pre 0 <= count
+@pre (@a start + @a count) < byteCount()
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorFileReadOnly
+@throw ::ErrorNodeUnattached
+@throw ::ErrorSeekFailed
+@throw ::ErrorReadFailed
+@throw ::ErrorWriteFailed
+@throw ::ErrorBadChecksum
+@throw ::ErrorInternal All objects in undocumented state
+
+@see BlobNode::byteCount, BlobNode::read
+*/
+void BlobNode::write( uint8_t *buf, int64_t start, size_t count )
+{
+   impl_->write( buf, start, count );
+}
+
+/*!
+@brief Diagnostic function to print internal state of object to output stream in an indented format.
+@copydetails Node::dump()
+*/
+#ifdef E57_DEBUG
+void BlobNode::dump( int indent, std::ostream &os ) const
+{
+   impl_->dump( indent, os );
+}
+#else
+void BlobNode::dump( int indent, std::ostream &os ) const
+{
+}
+#endif
+
+/*!
+@brief Upcast a BlobNode handle to a generic Node handle.
+
+@details
+An upcast is always safe, and the compiler can automatically insert it for initializations of Node
+variables and Node function arguments.
+
+@return A smart Node handle referencing the underlying object.
+
+@throw No E57Exceptions.
+
+@see Explanation in Node, Node::type(), BlobNode(const Node&)
 */
 BlobNode::operator Node() const
 {
-   /// Upcast from shared_ptr<StringNodeImpl> to SharedNodeImplPtr and construct
-   /// a Node object
+   // Upcast from shared_ptr<StringNodeImpl> to SharedNodeImplPtr and construct
+   // a Node object
    return Node( impl_ );
 }
 
 /*!
-@brief   Downcast a generic Node handle to a BlobNode handle.
-@param   [in] n The generic handle to downcast.
-@details The handle @a n must be for an underlying BlobNode, otherwise an
-exception is thrown. In designs that need to avoid the exception, use
-Node::type() to determine the actual type of the @a n before downcasting. This
-function must be explicitly called (c++ compiler cannot insert it
-automatically).
-@throw   ::ErrorBadNodeDowncast
-@see     Node::type(), BlobNode::operator Node()
+@brief Downcast a generic Node handle to a BlobNode handle.
+
+@param [in] n The generic handle to downcast.
+
+@details
+The handle @a n must be for an underlying BlobNode, otherwise an exception is thrown. In designs
+that need to avoid the exception, use Node::type() to determine the actual type of the @a n before
+downcasting. This function must be explicitly called (c++ compiler cannot insert it automatically).
+
+@throw ::ErrorBadNodeDowncast
+
+@see Node::type(), BlobNode::operator Node()
 */
 BlobNode::BlobNode( const Node &n )
 {
@@ -325,12 +349,11 @@ BlobNode::BlobNode( const Node &n )
       throw E57_EXCEPTION2( ErrorBadNodeDowncast, "nodeType=" + toString( n.type() ) );
    }
 
-   /// Set our shared_ptr to the downcast shared_ptr
+   // Set our shared_ptr to the downcast shared_ptr
    impl_ = std::static_pointer_cast<BlobNodeImpl>( n.impl() );
 }
 
-//! @cond documentNonPublic   The following isn't part of the API, and isn't
-//! documented.
+/// @cond documentNonPublic The following isn't part of the API, and isn't documented.
 BlobNode::BlobNode( ImageFile destImageFile, int64_t fileOffset, int64_t length ) :
    impl_( new BlobNodeImpl( destImageFile.impl(), fileOffset, length ) )
 {
@@ -339,4 +362,4 @@ BlobNode::BlobNode( ImageFile destImageFile, int64_t fileOffset, int64_t length 
 BlobNode::BlobNode( std::shared_ptr<BlobNodeImpl> ni ) : impl_( ni )
 {
 }
-//! @endcond
+/// @endcond

--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -84,10 +84,9 @@ constexpr size_t CheckedFile::physicalPageSize;
 constexpr uint64_t CheckedFile::physicalPageSizeMask;
 constexpr size_t CheckedFile::logicalPageSize;
 
-/// Tool class to read buffer efficiently without
-/// multiplying copy operations.
+/// Tool class to read buffer efficiently without multiplying copy operations.
 ///
-/// WARNING: pointer input is handled by user!
+/// @warning Pointer input is handled by user!
 class e57::BufferView
 {
 public:
@@ -168,7 +167,7 @@ CheckedFile::CheckedFile( const ustring &fileName, Mode mode, ReadChecksumPolicy
 
       case WriteCreate:
       {
-         /// File truncated to zero length if already exists
+         // File truncated to zero length if already exists
 
 #if defined( _MSC_VER )
          constexpr int writeFlags = O_RDWR | O_CREAT | O_TRUNC | O_BINARY;
@@ -224,8 +223,9 @@ int CheckedFile::open64( const ustring &fileName, int flags, int mode )
    errno_t err = _wsopen_s( &handle, widePath.c_str(), flags, _SH_DENYNO, mode );
    if ( err != 0 )
    {
-      throw E57_EXCEPTION2( ErrorOpenFailed, "errno=" + toString( errno ) + " error='" + strerror( errno ) +
-                                                "' fileName=" + fileName + " flags=" + toString( flags ) +
+      throw E57_EXCEPTION2( ErrorOpenFailed, "errno=" + toString( errno ) + " error='" +
+                                                strerror( errno ) + "' fileName=" + fileName +
+                                                " flags=" + toString( flags ) +
                                                 " mode=" + toString( mode ) );
    }
    return handle;
@@ -233,8 +233,9 @@ int CheckedFile::open64( const ustring &fileName, int flags, int mode )
    int fd = ::open( fileName_.c_str(), flags, mode );
    if ( fd < 0 )
    {
-      throw E57_EXCEPTION2( ErrorOpenFailed, "errno=" + toString( errno ) + " error='" + strerror( errno ) +
-                                                "' fileName=" + fileName + " flags=" + toString( flags ) +
+      throw E57_EXCEPTION2( ErrorOpenFailed, "errno=" + toString( errno ) + " error='" +
+                                                strerror( errno ) + "' fileName=" + fileName +
+                                                " flags=" + toString( flags ) +
                                                 " mode=" + toString( mode ) );
    }
    return fd;
@@ -247,7 +248,7 @@ CheckedFile::~CheckedFile()
 {
    try
    {
-      close(); ///??? what if already closed?
+      close(); //??? what if already closed?
    }
    catch ( ... )
    {
@@ -277,7 +278,7 @@ void CheckedFile::read( char *buf, size_t nRead, size_t /*bufSize*/ )
 
    size_t n = std::min( nRead, logicalPageSize - pageOffset );
 
-   /// Allocate temp page buffer
+   // Allocate temp page buffer
    std::vector<char> page_buffer_v( physicalPageSize );
    char *page_buffer = &page_buffer_v[0];
 
@@ -314,7 +315,7 @@ void CheckedFile::read( char *buf, size_t nRead, size_t /*bufSize*/ )
       n = std::min( nRead, logicalPageSize );
    }
 
-   /// When done, leave cursor just past end of last byte read
+   // When done, leave cursor just past end of last byte read
    seek( end, Logical );
 }
 
@@ -338,7 +339,7 @@ void CheckedFile::write( const char *buf, size_t nWrite )
 
    size_t n = std::min( nWrite, logicalPageSize - pageOffset );
 
-   /// Allocate temp page buffer
+   // Allocate temp page buffer
    std::vector<char> page_buffer_v( physicalPageSize );
    char *page_buffer = &page_buffer_v[0];
 
@@ -375,7 +376,7 @@ void CheckedFile::write( const char *buf, size_t nWrite )
       logicalLength_ = end;
    }
 
-   /// When done, leave cursor just past end of buf
+   // When done, leave cursor just past end of buf
    seek( end, Logical );
 }
 
@@ -416,7 +417,8 @@ template <class FTYPE> CheckedFile &CheckedFile::writeFloatingPoint( FTYPE value
    static_assert( std::is_floating_point<FTYPE>::value, "Floating point type required." );
 
 #ifdef E57_MAX_VERBOSE
-   std::cout << "CheckedFile::writeFloatingPoint, value=" << value << " precision=" << precision << std::endl;
+   std::cout << "CheckedFile::writeFloatingPoint, value=" << value << " precision=" << precision
+             << std::endl;
 #endif
 
    return *this << floatingPointToStr( value, precision );
@@ -425,7 +427,8 @@ template <class FTYPE> CheckedFile &CheckedFile::writeFloatingPoint( FTYPE value
 void CheckedFile::seek( uint64_t offset, OffsetMode omode )
 {
    //??? check for seek beyond logicalLength_
-   const auto pos = static_cast<int64_t>( omode == Physical ? offset : logicalToPhysical( offset ) );
+   const auto pos =
+      static_cast<int64_t>( omode == Physical ? offset : logicalToPhysical( offset ) );
 
 #ifdef E57_MAX_VERBOSE
    // cout << "seek offset=" << offset << " omode=" << omode << " pos=" << pos
@@ -445,7 +448,8 @@ uint64_t CheckedFile::lseek64( int64_t offset, int whence )
          return bufView_->pos();
       }
 
-      throw E57_EXCEPTION2( ErrorSeekFailed, "fileName=" + fileName_ + " offset=" + toString( offset ) +
+      throw E57_EXCEPTION2( ErrorSeekFailed, "fileName=" + fileName_ +
+                                                " offset=" + toString( offset ) +
                                                 " whence=" + toString( whence ) );
    }
 
@@ -474,8 +478,9 @@ uint64_t CheckedFile::lseek64( int64_t offset, int whence )
 
    if ( result < 0 )
    {
-      throw E57_EXCEPTION2( ErrorSeekFailed, "fileName=" + fileName_ + " offset=" + toString( offset ) +
-                                                " whence=" + toString( whence ) + " result=" + toString( result ) );
+      throw E57_EXCEPTION2( ErrorSeekFailed,
+                            "fileName=" + fileName_ + " offset=" + toString( offset ) +
+                               " whence=" + toString( whence ) + " result=" + toString( result ) );
    }
 
    return static_cast<uint64_t>( result );
@@ -483,7 +488,7 @@ uint64_t CheckedFile::lseek64( int64_t offset, int whence )
 
 uint64_t CheckedFile::position( OffsetMode omode )
 {
-   /// Get current file cursor position
+   // Get current file cursor position
    const uint64_t pos = lseek64( 0LL, SEEK_CUR );
 
    if ( omode == Physical )
@@ -542,17 +547,18 @@ void CheckedFile::extend( uint64_t newLength, OffsetMode omode )
 
    uint64_t currentLogicalLength = length( Logical );
 
-   /// Make sure we are trying to make file longer
+   // Make sure we are trying to make file longer
    if ( newLogicalLength < currentLogicalLength )
    {
-      throw E57_EXCEPTION2( ErrorInternal, "fileName=" + fileName_ + " newLength=" + toString( newLogicalLength ) +
-                                              " currentLength=" + toString( currentLogicalLength ) );
+      throw E57_EXCEPTION2( ErrorInternal,
+                            "fileName=" + fileName_ + " newLength=" + toString( newLogicalLength ) +
+                               " currentLength=" + toString( currentLogicalLength ) );
    }
 
-   /// Calc how may zero bytes we have to add to end
+   // Calc how may zero bytes we have to add to end
    uint64_t nWrite = newLogicalLength - currentLogicalLength;
 
-   /// Seek to current end of file
+   // Seek to current end of file
    seek( currentLogicalLength, Logical );
 
    uint64_t page = 0;
@@ -560,8 +566,8 @@ void CheckedFile::extend( uint64_t newLength, OffsetMode omode )
 
    getCurrentPageAndOffset( page, pageOffset );
 
-   /// Calc first write size (may be partial page)
-   /// Watch out for different int sizes here.
+   // Calc first write size (may be partial page)
+   // Watch out for different int sizes here.
    size_t n = 0;
 
    if ( nWrite < logicalPageSize - pageOffset )
@@ -573,7 +579,7 @@ void CheckedFile::extend( uint64_t newLength, OffsetMode omode )
       n = logicalPageSize - pageOffset;
    }
 
-   /// Allocate temp page buffer
+   // Allocate temp page buffer
    std::vector<char> page_buffer_v( physicalPageSize );
    char *page_buffer = &page_buffer_v[0];
 
@@ -611,7 +617,7 @@ void CheckedFile::extend( uint64_t newLength, OffsetMode omode )
    //??? what if loop above throws, logicalLength_ may be wrong
    logicalLength_ = newLogicalLength;
 
-   /// When done, leave cursor at end of file
+   // When done, leave cursor at end of file
    seek( newLogicalLength, Logical );
 }
 
@@ -628,7 +634,8 @@ void CheckedFile::close()
 #endif
       if ( result < 0 )
       {
-         throw E57_EXCEPTION2( ErrorCloseFailed, "fileName=" + fileName_ + " result=" + toString( result ) );
+         throw E57_EXCEPTION2( ErrorCloseFailed,
+                               "fileName=" + fileName_ + " result=" + toString( result ) );
       }
 
       fd_ = -1;
@@ -648,7 +655,7 @@ void CheckedFile::unlink()
 {
    close();
 
-   /// Try to remove the file, don't report a failure
+   // Try to remove the file, don't report a failure
    int result = std::remove( fileName_.c_str() ); //??? unicode support here
    (void)result;                                  // this maybe unused
 #ifdef E57_MAX_VERBOSE
@@ -669,7 +676,8 @@ inline uint32_t swap_uint32( uint32_t val )
 /// Calc CRC32C of given data
 uint32_t CheckedFile::checksum( char *buf, size_t size ) const
 {
-   static const CRC::Parameters<crcpp_uint32, 32> sCRCParams{ 0x1EDC6F41, 0xFFFFFFFF, 0xFFFFFFFF, true, true };
+   static const CRC::Parameters<crcpp_uint32, 32> sCRCParams{ 0x1EDC6F41, 0xFFFFFFFF, 0xFFFFFFFF,
+                                                              true, true };
 
    static const CRC::Table<crcpp_uint32, 32> sCRCTable = sCRCParams.MakeTable();
 
@@ -684,15 +692,17 @@ uint32_t CheckedFile::checksum( char *buf, size_t size ) const
 void CheckedFile::verifyChecksum( char *page_buffer, size_t page )
 {
    const uint32_t check_sum = checksum( page_buffer, logicalPageSize );
-   const uint32_t check_sum_in_page = *reinterpret_cast<uint32_t *>( &page_buffer[logicalPageSize] );
+   const uint32_t check_sum_in_page =
+      *reinterpret_cast<uint32_t *>( &page_buffer[logicalPageSize] );
 
    if ( check_sum_in_page != check_sum )
    {
       const uint64_t physicalLength = length( Physical );
 
-      throw E57_EXCEPTION2( ErrorBadChecksum, "fileName=" + fileName_ + " computedChecksum=" + toString( check_sum ) +
-                                                 " storedChecksum=" + toString( check_sum_in_page ) + " page=" +
-                                                 toString( page ) + " length=" + toString( physicalLength ) );
+      throw E57_EXCEPTION2( ErrorBadChecksum,
+                            "fileName=" + fileName_ + " computedChecksum=" + toString( check_sum ) +
+                               " storedChecksum=" + toString( check_sum_in_page ) + " page=" +
+                               toString( page ) + " length=" + toString( physicalLength ) );
    }
 }
 
@@ -724,7 +734,7 @@ void CheckedFile::readPhysicalPage( char *page_buffer, uint64_t page )
    assert( page * physicalPageSize < physicalLength );
 #endif
 
-   /// Seek to start of physical page
+   // Seek to start of physical page
    seek( page * physicalPageSize, Physical );
 
    if ( ( fd_ < 0 ) && ( bufView_ != nullptr ) )
@@ -743,7 +753,8 @@ void CheckedFile::readPhysicalPage( char *page_buffer, uint64_t page )
 
    if ( result < 0 || static_cast<size_t>( result ) != physicalPageSize )
    {
-      throw E57_EXCEPTION2( ErrorReadFailed, "fileName=" + fileName_ + " result=" + toString( result ) );
+      throw E57_EXCEPTION2( ErrorReadFailed,
+                            "fileName=" + fileName_ + " result=" + toString( result ) );
    }
 }
 
@@ -753,11 +764,12 @@ void CheckedFile::writePhysicalPage( char *page_buffer, uint64_t page )
    // cout << "writePhysicalPage, page:" << page << std::endl;
 #endif
 
-   /// Append checksum
+   // Append checksum
    uint32_t check_sum = checksum( page_buffer, logicalPageSize );
-   *reinterpret_cast<uint32_t *>( &page_buffer[logicalPageSize] ) = check_sum; //??? little endian dependency
+   *reinterpret_cast<uint32_t *>( &page_buffer[logicalPageSize] ) =
+      check_sum; //??? little endian dependency
 
-   /// Seek to start of physical page
+   // Seek to start of physical page
    seek( page * physicalPageSize, Physical );
 
 #if defined( _MSC_VER )
@@ -770,6 +782,7 @@ void CheckedFile::writePhysicalPage( char *page_buffer, uint64_t page )
 
    if ( result < 0 )
    {
-      throw E57_EXCEPTION2( ErrorWriteFailed, "fileName=" + fileName_ + " result=" + toString( result ) );
+      throw E57_EXCEPTION2( ErrorWriteFailed,
+                            "fileName=" + fileName_ + " result=" + toString( result ) );
    }
 }

--- a/src/CheckedFile.h
+++ b/src/CheckedFile.h
@@ -33,16 +33,17 @@
 
 namespace e57
 {
-   /// Tool class to read buffer efficiently without
-   /// multiplying copy operations.
-   ///
-   /// WARNING: pointer input is handled by user!
+   // Tool class to read buffer efficiently without
+   // multiplying copy operations.
+   //
+   // WARNING: pointer input is handled by user!
    class BufferView;
 
    class CheckedFile
    {
    public:
-      static constexpr size_t physicalPageSizeLog2 = 10; // physical page size is 2 raised to this power
+      // physical page size is 2 raised to this power
+      static constexpr size_t physicalPageSizeLog2 = 10;
       static constexpr size_t physicalPageSize = 1 << physicalPageSizeLog2;
       static constexpr uint64_t physicalPageSizeMask = physicalPageSize - 1;
       static constexpr size_t logicalPageSize = physicalPageSize - 4;
@@ -94,7 +95,8 @@ namespace e57
 
       template <class FTYPE> CheckedFile &writeFloatingPoint( FTYPE value, int precision );
 
-      void getCurrentPageAndOffset( uint64_t &page, size_t &pageOffset, OffsetMode omode = Logical );
+      void getCurrentPageAndOffset( uint64_t &page, size_t &pageOffset,
+                                    OffsetMode omode = Logical );
       void readPhysicalPage( char *page_buffer, uint64_t page );
       void writePhysicalPage( char *page_buffer, uint64_t page );
       int open64( const e57::ustring &fileName, int flags, int mode );

--- a/src/Common.h
+++ b/src/Common.h
@@ -44,11 +44,12 @@
 
 namespace e57
 {
-//!!! inline these rather than macros?
-#define E57_EXCEPTION1( ecode )                                                                                        \
-   ( E57Exception( ( ecode ), ustring(), __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) ) )
-#define E57_EXCEPTION2( ecode, context )                                                                               \
-   ( E57Exception( ( ecode ), ( context ), __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) ) )
+#define E57_EXCEPTION1( ecode )                                                                    \
+   ( E57Exception( ( ecode ), ustring(), __FILE__, __LINE__,                                       \
+                   static_cast<const char *>( __FUNCTION__ ) ) )
+#define E57_EXCEPTION2( ecode, context )                                                           \
+   ( E57Exception( ( ecode ), ( context ), __FILE__, __LINE__,                                     \
+                   static_cast<const char *>( __FUNCTION__ ) ) )
 
    using ImageFileImplSharedPtr = std::shared_ptr<class ImageFileImpl>;
    using ImageFileImplWeakPtr = std::weak_ptr<class ImageFileImpl>;
@@ -58,6 +59,6 @@ namespace e57
    using StringList = std::vector<std::string>;
    using StringSet = std::set<std::string>;
 
-   //! generates a new random GUID
+   /// generates a new random GUID
    std::string generateRandomGUID();
 }

--- a/src/CompressedVectorNode.cpp
+++ b/src/CompressedVectorNode.cpp
@@ -28,250 +28,22 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-//! @file CompressedVectorNode.cpp
+/// @file CompressedVectorNode.cpp
 
 #include "CompressedVectorNodeImpl.h"
 #include "StringFunctions.h"
 
 using namespace e57;
 
+// Put this function first so we can reference the code in doxygen using @skip
 /*!
-@class e57::CompressedVectorNode
-@brief   An E57 element containing ordered vector of child nodes, stored in an
-efficient binary format.
-@details
-The CompressedVectorNode encodes very long sequences of identically typed
-records. In an E57 file, the per-point information (coordinates, intensity,
-color, time stamp etc.) are stored in a CompressedVectorNode. For time and space
-efficiency, the CompressedVectorNode data is stored in a binary section of the
-E57 file.
-
-Conceptually, the CompressedVectorNode encodes a structure that looks very much
-like a homogeneous VectorNode object. However because of the huge volume of data
-(E57 files can store more than 10 billion points) within a CompressedVectorNode,
-the functions for accessing the data are dramatically different.
-CompressedVectorNode data is accessed in large blocks of records (100s to 1000s
-at a time).
-
-Two attributes are required to create a new CompressedVectorNode.
-The first attribute describes the shape of the record that will be stored.
-This record type description is called the @c prototype of the
-CompressedVectorNode. Often the @c prototype will be a StructNode with a single
-level of named child elements. However, the prototype can be a tree of any depth
-consisting of the following node types: IntegerNode, ScaledIntegerNode,
-FloatNode, StringNode, StructureNode, or VectorNode (i.e. CompressedVectorNode
-and BlobNode are not allowed). Only the node types and attributes are used in
-the prototype, the values stored are ignored. For example, if the prototype
-contains an IntegerNode, with a value=0, minimum=0, maximum=1023, then this
-means that each record will contain an integer that can take any value in the
-interval [0,1023]. As a second example, if the prototype contains an
-ScaledIntegerNode, with a value=0, minimum=0, maximum=1023, scale=.001, offset=0
-then this means that each record will contain an integer that can take any value
-in the interval [0,1023] and if a reader requests the scaledValue of the field,
-the rawValue should be multiplied by 0.001.
-
-The second attribute needed to describe a new CompressedVectorNode is the @c
-codecs description of how the values of the records are to be represented on the
-disk. The codec object is a VectorNode of a particular format that describes the
-encoding for each field in the record, which codec will be used to transfer the
-values to and from the disk. Currently only one codec is defined for E57 files,
-the bitPackCodec, which copies the numbers from memory, removes any unused bit
-positions, and stores the without additional spaces on the disk. The
-bitPackCodec has no configuration options or parameters to tune. In the ASTM
-standard, if no codec is specified, the bitPackCodec is assumed. So specifying
-the @c codecs as an empty VectorNode is equivalent to requesting at all fields
-in the record be encoded with the bitPackCodec.
-
-Other than the @c prototype and @c codecs attributes, the only other state
-directly accessible is the number of children (records) in the
-CompressedVectorNode. The read/write access to the contents of the
-CompressedVectorNode is coordinated by two other Foundation API objects:
-CompressedVectorReader and CompressedVectorWriter.
-
-@section CompressedVectorNode_invariant Class Invariant
-A class invariant is a list of statements about an object that are always true
-before and after any operation on the object. An invariant is useful for testing
-correct operation of an implementation. Statements in an invariant can involve
-only externally visible state, or can refer to internal implementation-specific
-state that is not visible to the API user. The following C++ code checks
-externally visible state for consistency and throws an exception if the
-invariant is violated:
-@dontinclude CompressedVectorNode.cpp
-@skip beginExample CompressedVectorNode::checkInvariant
-@until endExample CompressedVectorNode::checkInvariant
-
-@see     CompressedVectorReader, CompressedVectorWriter, Node
+@brief Check whether CompressedVectorNode class invariant is true
+@copydetails IntegerNode::checkInvariant()
 */
 
-/*!
-@brief   Create an empty CompressedVectorNode, for writing, that will store
-records specified by the prototype.
-@param   [in] destImageFile The ImageFile where the new node will eventually be
-stored.
-@param   [in] prototype     A tree that describes the fields in each record of
-the CompressedVectorNode.
-@param   [in] codecs        A VectorNode describing which codecs should be used
-for each field described in the prototype.
-@details
-The @a destImageFile indicates which ImageFile the CompressedVectorNode will
-eventually be attached to. A node is attached to an ImageFile by adding it
-underneath the predefined root of the ImageFile (gotten from ImageFile::root).
-It is not an error to fail to attach the CompressedVectorNode to the
-@a destImageFile. It is an error to attempt to attach the CompressedVectorNode
-to a different ImageFile. The CompressedVectorNode may not be written to until
-it is attached to the destImageFile tree.
-
-The @a prototype may be any tree consisting of only the following node types:
-IntegerNode, ScaledIntegerNode, FloatNode, StringNode, StructureNode, or
-VectorNode (i.e. CompressedVectorNode and BlobNode are not allowed). See
-CompressedVectorNode for discussion about the @a prototype argument.
-
-The @a codecs must be a heterogeneous VectorNode with children as specified in
-the ASTM E57 data format standard. Since currently only one codec is supported
-(bitPackCodec), and it is the default, passing an empty VectorNode will specify
-that all record fields will be encoded with bitPackCodec.
-
-@pre     The @a destImageFile must be open (i.e. destImageFile.isOpen() must be
-true).
-@pre     The @a destImageFile must have been opened in write mode (i.e.
-destImageFile.isWritable() must be true).
-@pre     @a prototype must be an unattached root node (i.e.
-!prototype.isAttached() && prototype.isRoot())
-@pre     @a prototype cannot contain BlobNodes or CompressedVectorNodes.
-@pre     @a codecs must be an unattached root node (i.e. !codecs.isAttached() &&
-codecs.isRoot())
-@post    prototype.isAttached()
-@post    codecs.isAttached()
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorFileReadOnly
-@throw   ::ErrorBadPrototype
-@throw   ::ErrorBadCodecs
-@throw   ::ErrorAlreadyHasParent
-@throw   ::ErrorDifferentDestImageFile
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     SourceDestBuffer, Node, CompressedVectorNode::reader, CompressedVectorNode::writer
-*/
-CompressedVectorNode::CompressedVectorNode( ImageFile destImageFile, const Node &prototype, const VectorNode &codecs ) :
-   impl_( new CompressedVectorNodeImpl( destImageFile.impl() ) )
-{
-   /// Because of shared_ptr quirks, can't set prototype,codecs in
-   /// CompressedVectorNodeImpl(), so set it afterwards
-   impl_->setPrototype( prototype.impl() );
-   impl_->setCodecs( codecs.impl() );
-}
-
-//! @brief   Is this a root node.
-//! @copydetails Node::isRoot()
-bool CompressedVectorNode::isRoot() const
-{
-   return impl_->isRoot();
-}
-
-//! @brief   Return parent of node, or self if a root node.
-//! @copydetails Node::parent()
-Node CompressedVectorNode::parent() const
-{
-   return Node( impl_->parent() );
-}
-
-//! @brief   Get absolute pathname of node.
-//! @copydetails Node::pathName()
-ustring CompressedVectorNode::pathName() const
-{
-   return impl_->pathName();
-}
-
-//! @brief   Get elementName string, that identifies the node in its parent..
-//! @copydetails Node::elementName()
-ustring CompressedVectorNode::elementName() const
-{
-   return impl_->elementName();
-}
-
-//! @brief   Get the ImageFile that was declared as the destination for the node
-//! when it was created.
-//! @copydetails Node::destImageFile()
-ImageFile CompressedVectorNode::destImageFile() const
-{
-   return ImageFile( impl_->destImageFile() );
-}
-
-//! @brief   Has node been attached into the tree of an ImageFile.
-//! @copydetails Node::isAttached()
-bool CompressedVectorNode::isAttached() const
-{
-   return impl_->isAttached();
-}
-
-/*!
-@brief   Get current number of records in a CompressedVectorNode.
-@details
-For a CompressedVectorNode with an active CompressedVectorWriter, the returned
-number will reflect any writes completed.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  Current number of records in CompressedVectorNode.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorNode::reader, CompressedVectorNode::writer
-*/
-int64_t CompressedVectorNode::childCount() const
-{
-   return impl_->childCount();
-}
-
-/*!
-@brief   Get the prototype tree that describes the types in the record.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  A smart Node handle referencing the root of the prototype tree.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorNode::CompressedVectorNode, SourceDestBuffer,
-CompressedVectorNode::reader, CompressedVectorNode::writer
-*/
-Node CompressedVectorNode::prototype() const
-{
-   return Node( impl_->getPrototype() );
-}
-
-/*!
-@brief   Get the codecs tree that describes the encoder/decoder configuration of
-the CompressedVectorNode.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  A smart VectorNode handle referencing the root of the codecs tree.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorNode::CompressedVectorNode, SourceDestBuffer,
-CompressedVectorNode::reader, CompressedVectorNode::writer
-*/
-VectorNode CompressedVectorNode::codecs() const
-{
-   return VectorNode( impl_->getCodecs() );
-}
-
-//! @brief   Diagnostic function to print internal state of object to output
-//! stream in an indented format.
-//! @copydetails Node::dump()
-#ifdef E57_DEBUG
-void CompressedVectorNode::dump( int indent, std::ostream &os ) const
-{
-   impl_->dump( indent, os );
-}
-#else
-void CompressedVectorNode::dump( int indent, std::ostream &os ) const
-{
-}
-#endif
-
-//! @brief Check whether CompressedVectorNode class invariant is true
-//! @copydetails IntegerNode::checkInvariant()
-// beginExample CompressedVectorNode::checkInvariant
 void CompressedVectorNode::checkInvariant( bool doRecurse, bool doUpcast )
 {
-   // If destImageFile not open, can't test invariant (almost every call would
-   // throw)
+   // If destImageFile not open, can't test invariant (almost every call would throw)
    if ( !destImageFile().isOpen() )
    {
       return;
@@ -325,33 +97,282 @@ void CompressedVectorNode::checkInvariant( bool doRecurse, bool doUpcast )
       throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 }
-// endExample CompressedVectorNode::checkInvariant
 
 /*!
-@brief   Upcast a CompressedVectorNode handle to a generic Node handle.
-@details An upcast is always safe, and the compiler can automatically insert it
-for initializations of Node variables and Node function arguments.
-@return  A smart Node handle referencing the underlying object.
-@throw   No E57Exceptions.
-@see     explanation in Node, Node::type(), CompressedVectorNode(const Node&)
+@class e57::CompressedVectorNode
+
+@brief An E57 element containing ordered vector of child nodes, stored in an efficient binary
+format.
+
+@details
+The CompressedVectorNode encodes very long sequences of identically typed records. In an E57 file,
+the per-point information (coordinates, intensity, color, time stamp etc.) are stored in a
+CompressedVectorNode. For time and space efficiency, the CompressedVectorNode data is stored in a
+binary section of the E57 file.
+
+Conceptually, the CompressedVectorNode encodes a structure that looks very much like a homogeneous
+VectorNode object. However because of the huge volume of data (E57 files can store more than 10
+billion points) within a CompressedVectorNode, the functions for accessing the data are dramatically
+different. CompressedVectorNode data is accessed in large blocks of records (100s to 1000s at a
+time).
+
+Two attributes are required to create a new CompressedVectorNode.
+
+The first attribute describes the shape of the record that will be stored. This record type
+description is called the @c prototype of the CompressedVectorNode. Often the @c prototype will be a
+StructNode with a single level of named child elements. However, the prototype can be a tree of any
+depth consisting of the following node types: IntegerNode, ScaledIntegerNode, FloatNode, StringNode,
+StructureNode, or VectorNode (i.e. CompressedVectorNode and BlobNode are not allowed). Only the node
+types and attributes are used in the prototype, the values stored are ignored. For example, if the
+prototype contains an IntegerNode, with a value=0, minimum=0, maximum=1023, then this means that
+each record will contain an integer that can take any value in the interval [0,1023]. As a second
+example, if the prototype contains an ScaledIntegerNode, with a value=0, minimum=0, maximum=1023,
+scale=.001, offset=0 then this means that each record will contain an integer that can take any
+value in the interval [0,1023] and if a reader requests the scaledValue of the field, the rawValue
+should be multiplied by 0.001.
+
+The second attribute needed to describe a new CompressedVectorNode is the @c codecs description of
+how the values of the records are to be represented on the disk. The codec object is a VectorNode of
+a particular format that describes the encoding for each field in the record, which codec will be
+used to transfer the values to and from the disk. Currently only one codec is defined for E57 files,
+the bitPackCodec, which copies the numbers from memory, removes any unused bit positions, and stores
+the without additional spaces on the disk. The bitPackCodec has no configuration options or
+parameters to tune. In the ASTM standard, if no codec is specified, the bitPackCodec is assumed. So
+specifying the @c codecs as an empty VectorNode is equivalent to requesting at all fields in the
+record be encoded with the bitPackCodec.
+
+Other than the @c prototype and @c codecs attributes, the only other state directly accessible is
+the number of children (records) in the CompressedVectorNode. The read/write access to the contents
+of the CompressedVectorNode is coordinated by two other Foundation API objects:
+CompressedVectorReader and CompressedVectorWriter.
+
+@section CompressedVectorNode_invariant Class Invariant
+
+A class invariant is a list of statements about an object that are always true before and after any
+operation on the object. An invariant is useful for testing correct operation of an implementation.
+Statements in an invariant can involve only externally visible state, or can refer to internal
+implementation-specific state that is not visible to the API user. The following C++ code checks
+externally visible state for consistency and throws an exception if the invariant is violated:
+
+@dontinclude CompressedVectorNode.cpp
+@skip void CompressedVectorNode::checkInvariant
+@until ^}
+
+@see CompressedVectorReader, CompressedVectorWriter, Node
+*/
+
+/*!
+@brief Create an empty CompressedVectorNode, for writing, that will store records specified by the
+prototype.
+
+@param [in] destImageFile The ImageFile where the new node will eventually be stored.
+@param [in] prototype A tree that describes the fields in each record of the CompressedVectorNode.
+@param [in] codecs A VectorNode describing which codecs should be used for each field described in
+the prototype.
+
+@details
+The @a destImageFile indicates which ImageFile the CompressedVectorNode will eventually be attached
+to. A node is attached to an ImageFile by adding it underneath the predefined root of the ImageFile
+(gotten from ImageFile::root). It is not an error to fail to attach the CompressedVectorNode to the
+@a destImageFile. It is an error to attempt to attach the CompressedVectorNode to a different
+ImageFile. The CompressedVectorNode may not be written to until it is attached to the destImageFile
+tree.
+
+The @a prototype may be any tree consisting of only the following node types: IntegerNode,
+ScaledIntegerNode, FloatNode, StringNode, StructureNode, or VectorNode (i.e. CompressedVectorNode
+and BlobNode are not allowed). See CompressedVectorNode for discussion about the @a prototype
+argument.
+
+The @a codecs must be a heterogeneous VectorNode with children as specified in the ASTM E57 data
+format standard. Since currently only one codec is supported (bitPackCodec), and it is the default,
+passing an empty VectorNode will specify that all record fields will be encoded with bitPackCodec.
+
+@pre The @a destImageFile must be open (i.e. destImageFile.isOpen() must be true).
+@pre The @a destImageFile must have been opened in write mode (i.e. destImageFile.isWritable() must
+be true).
+@pre @a prototype must be an unattached root node (i.e. !prototype.isAttached() &&
+prototype.isRoot())
+@pre @a prototype cannot contain BlobNodes or CompressedVectorNodes.
+@pre @a codecs must be an unattached root node (i.e. !codecs.isAttached() && codecs.isRoot())
+@post prototype.isAttached()
+@post codecs.isAttached()
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorFileReadOnly
+@throw ::ErrorBadPrototype
+@throw ::ErrorBadCodecs
+@throw ::ErrorAlreadyHasParent
+@throw ::ErrorDifferentDestImageFile
+@throw ::ErrorInternal All objects in undocumented state
+
+@see SourceDestBuffer, Node, CompressedVectorNode::reader, CompressedVectorNode::writer
+*/
+CompressedVectorNode::CompressedVectorNode( ImageFile destImageFile, const Node &prototype,
+                                            const VectorNode &codecs ) :
+   impl_( new CompressedVectorNodeImpl( destImageFile.impl() ) )
+{
+   // Because of shared_ptr quirks, can't set prototype,codecs in CompressedVectorNodeImpl(), so set
+   // it afterwards
+   impl_->setPrototype( prototype.impl() );
+   impl_->setCodecs( codecs.impl() );
+}
+
+/*!
+@brief Is this a root node.
+@copydetails Node::isRoot()
+*/
+bool CompressedVectorNode::isRoot() const
+{
+   return impl_->isRoot();
+}
+
+/*!
+@brief Return parent of node, or self if a root node.
+@copydetails Node::parent()
+*/
+Node CompressedVectorNode::parent() const
+{
+   return Node( impl_->parent() );
+}
+
+/// @brief Get absolute pathname of node.
+/// @copydetails Node::pathName()
+ustring CompressedVectorNode::pathName() const
+{
+   return impl_->pathName();
+}
+
+/// @brief Get elementName string, that identifies the node in its parent..
+/// @copydetails Node::elementName()
+ustring CompressedVectorNode::elementName() const
+{
+   return impl_->elementName();
+}
+
+/// @brief Get the ImageFile that was declared as the destination for the node  when it was created.
+/// @copydetails Node::destImageFile()
+ImageFile CompressedVectorNode::destImageFile() const
+{
+   return ImageFile( impl_->destImageFile() );
+}
+
+/// @brief Has node been attached into the tree of an ImageFile.
+/// @copydetails Node::isAttached()
+bool CompressedVectorNode::isAttached() const
+{
+   return impl_->isAttached();
+}
+
+/*!
+@brief Get current number of records in a CompressedVectorNode.
+
+@details
+For a CompressedVectorNode with an active CompressedVectorWriter, the returned number will reflect
+any writes completed.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return Current number of records in CompressedVectorNode.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see CompressedVectorNode::reader, CompressedVectorNode::writer
+*/
+int64_t CompressedVectorNode::childCount() const
+{
+   return impl_->childCount();
+}
+
+/*!
+@brief Get the prototype tree that describes the types in the record.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return A smart Node handle referencing the root of the prototype tree.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see CompressedVectorNode::CompressedVectorNode, SourceDestBuffer, CompressedVectorNode::reader,
+CompressedVectorNode::writer
+*/
+Node CompressedVectorNode::prototype() const
+{
+   return Node( impl_->getPrototype() );
+}
+
+/*!
+@brief Get the codecs tree that describes the encoder/decoder configuration of the
+CompressedVectorNode.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return A smart VectorNode handle referencing the root of the codecs tree.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see CompressedVectorNode::CompressedVectorNode, SourceDestBuffer, CompressedVectorNode::reader,
+CompressedVectorNode::writer
+*/
+VectorNode CompressedVectorNode::codecs() const
+{
+   return VectorNode( impl_->getCodecs() );
+}
+
+/*!
+@brief Diagnostic function to print internal state of object to output stream in an indented format.
+@copydetails Node::dump()
+*/
+#ifdef E57_DEBUG
+void CompressedVectorNode::dump( int indent, std::ostream &os ) const
+{
+   impl_->dump( indent, os );
+}
+#else
+void CompressedVectorNode::dump( int indent, std::ostream &os ) const
+{
+}
+#endif
+
+/*!
+@brief Upcast a CompressedVectorNode handle to a generic Node handle.
+
+@details
+An upcast is always safe, and the compiler can automatically insert it for initializations of Node
+variables and Node function arguments.
+
+@return A smart Node handle referencing the underlying object.
+
+@throw No E57Exceptions.
+
+@see explanation in Node, Node::type(), CompressedVectorNode(const Node&)
 */
 CompressedVectorNode::operator Node() const
 {
-   /// Implicitly upcast from shared_ptr<CompressedVectorNodeImpl> to
-   /// SharedNodeImplPtr and construct a Node object
+   // Implicitly upcast from shared_ptr<CompressedVectorNodeImpl> to SharedNodeImplPtr and
+   // construct a Node object
    return Node( impl_ );
 }
 
 /*!
-@brief   Downcast a generic Node handle to a CompressedVectorNode handle.
-@param   [in] n The generic handle to downcast.
-@details The handle @a n must be for an underlying CompressedVectorNode,
-otherwise an exception is thrown. In designs that need to avoid the exception,
-use Node::type() to determine the actual type of the @a n before downcasting.
-This function must be explicitly called (c++ compiler cannot insert it
+@brief Downcast a generic Node handle to a CompressedVectorNode handle.
+
+@param [in] n The generic handle to downcast.
+
+@details
+The handle @a n must be for an underlying CompressedVectorNode, otherwise an exception is thrown. In
+designs that need to avoid the exception, use Node::type() to determine the actual type of the @a n
+before downcasting. This function must be explicitly called (c++ compiler cannot insert it
 automatically).
-@throw   ::ErrorBadNodeDowncast
-@see     Node::type(), CompressedVectorNode::operator, Node()
+
+@throw ::ErrorBadNodeDowncast
+
+@see Node::type(), CompressedVectorNode::operator, Node()
 */
 CompressedVectorNode::CompressedVectorNode( const Node &n )
 {
@@ -360,60 +381,59 @@ CompressedVectorNode::CompressedVectorNode( const Node &n )
       throw E57_EXCEPTION2( ErrorBadNodeDowncast, "nodeType=" + toString( n.type() ) );
    }
 
-   /// Set our shared_ptr to the downcast shared_ptr
+   // Set our shared_ptr to the downcast shared_ptr
    impl_ = std::static_pointer_cast<CompressedVectorNodeImpl>( n.impl() );
 }
 
-//! @cond documentNonPublic   The following isn't part of the API, and isn't
-//! documented.
-CompressedVectorNode::CompressedVectorNode( std::shared_ptr<CompressedVectorNodeImpl> ni ) : impl_( ni )
+/// @cond documentNonPublic The following isn't part of the API, and isn't documented.
+CompressedVectorNode::CompressedVectorNode( std::shared_ptr<CompressedVectorNodeImpl> ni ) :
+   impl_( ni )
 {
 }
-//! @endcond
+/// @endcond
 
 /*!
-@brief   Create an iterator object for writing a series of blocks of data to a
+@brief Create an iterator object for writing a series of blocks of data to a CompressedVectorNode.
+
+@param [in] sbufs Vector of memory buffers that will hold data to be written to a
 CompressedVectorNode.
-@param   [in] sbufs         Vector of memory buffers that will hold data to be
-written to a CompressedVectorNode.
+
 @details
-See CompressedVectorWriter::write(std::vector<SourceDestBuffer>&, unsigned) for
-discussion about restrictions on @a sbufs.
+See CompressedVectorWriter::write(std::vector<SourceDestBuffer>&, unsigned) for discussion about
+restrictions on @a sbufs.
 
-The pathNames in the @a sbufs must match one-to-one with the terminal nodes
-(i.e. nodes that can have no children: IntegerNode, ScaledIntegerNode,
-FloatNode, StringNode) in this CompressedVectorNode's prototype. It is an error
-for two SourceDestBuffers in @a dbufs to identify the same terminal node in the
-prototype.
+The pathNames in the @a sbufs must match one-to-one with the terminal nodes (i.e. nodes that can
+have no children: IntegerNode, ScaledIntegerNode, FloatNode, StringNode) in this
+CompressedVectorNode's prototype. It is an error for two SourceDestBuffers in @a dbufs to identify
+the same terminal node in the prototype.
 
+It is an error to call this function if the CompressedVectorNode already has any records (i.e. a
+CompressedVectorNode cannot be set twice).
 
-It is an error to call this function if the CompressedVectorNode already has any
-records (i.e. a CompressedVectorNode cannot be set twice).
-
-@pre     @a sbufs can't be empty (i.e. sbufs.length() > 0).
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@pre     The @a destImageFile must have been opened in write mode (i.e.
-destImageFile.isWritable()).
-@pre     The destination ImageFile can't have any readers or writers open
+@pre @a sbufs can't be empty (i.e. sbufs.length() > 0).
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@pre The @a destImageFile must have been opened in write mode (i.e. destImageFile.isWritable()).
+@pre The destination ImageFile can't have any readers or writers open
 (destImageFile().readerCount()==0 && destImageFile().writerCount()==0)
-@pre     This CompressedVectorNode must be attached (i.e. isAttached()).
-@pre     This CompressedVectorNode must have no records (i.e. childCount() ==
-0).
-@return  A smart CompressedVectorWriter handle referencing the underlying
-iterator object.
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorFileReadOnly
-@throw   ::ErrorSetTwice
-@throw   ::ErrorTooManyWriters
-@throw   ::ErrorTooManyReaders
-@throw   ::ErrorNodeUnattached
-@throw   ::ErrorPathUndefined
-@throw   ::ErrorBufferSizeMismatch
-@throw   ::ErrorBufferDuplicatePathName
-@throw   ::ErrorNoBufferForElement
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorWriter, SourceDestBuffer, CompressedVectorNode::CompressedVectorNode,
+@pre This CompressedVectorNode must be attached (i.e. isAttached()).
+@pre This CompressedVectorNode must have no records (i.e. childCount() == 0).
+
+@return A smart CompressedVectorWriter handle referencing the underlying iterator object.
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorFileReadOnly
+@throw ::ErrorSetTwice
+@throw ::ErrorTooManyWriters
+@throw ::ErrorTooManyReaders
+@throw ::ErrorNodeUnattached
+@throw ::ErrorPathUndefined
+@throw ::ErrorBufferSizeMismatch
+@throw ::ErrorBufferDuplicatePathName
+@throw ::ErrorNoBufferForElement
+@throw ::ErrorInternal All objects in undocumented state
+
+@see CompressedVectorWriter, SourceDestBuffer, CompressedVectorNode::CompressedVectorNode,
 CompressedVectorNode::prototype
 */
 CompressedVectorWriter CompressedVectorNode::writer( std::vector<SourceDestBuffer> &sbufs )
@@ -422,34 +442,34 @@ CompressedVectorWriter CompressedVectorNode::writer( std::vector<SourceDestBuffe
 }
 
 /*!
-@brief   Create an iterator object for reading a series of blocks of data from a
-CompressedVectorNode.
-@param   [in] dbufs     Vector of memory buffers that will receive data read
-from a CompressedVectorNode.
-@details
-The pathNames in the @a dbufs must identify terminal nodes (i.e. node that can
-have no children: IntegerNode, ScaledIntegerNode, FloatNode, StringNode) in this
-CompressedVectorNode's prototype. It is an error for two SourceDestBuffers in @a
-dbufs to identify the same terminal node in the prototype. It is not an error to
-create a CompressedVectorReader for an empty CompressedVectorNode.
+@brief Create an iterator object for reading a series of blocks of data from a CompressedVectorNode.
 
-@pre     @a dbufs can't be empty
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@pre     The destination ImageFile can't have any writers open
-(destImageFile().writerCount()==0)
-@pre     This CompressedVectorNode must be attached (i.e. isAttached()).
-@return  A smart CompressedVectorReader handle referencing the underlying
-iterator object.
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorTooManyWriters
-@throw   ::ErrorNodeUnattached
-@throw   ::ErrorPathUndefined
-@throw   ::ErrorBufferSizeMismatch
-@throw   ::ErrorBufferDuplicatePathName
-@throw   ::ErrorBadCVHeader
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorReader, SourceDestBuffer, CompressedVectorNode::CompressedVectorNode,
+@param [in] dbufs Vector of memory buffers that will receive data read from a CompressedVectorNode.
+
+@details
+The pathNames in the @a dbufs must identify terminal nodes (i.e. node that can have no children:
+IntegerNode, ScaledIntegerNode, FloatNode, StringNode) in this CompressedVectorNode's prototype. It
+is an error for two SourceDestBuffers in @a dbufs to identify the same terminal node in the
+prototype. It is not an error to create a CompressedVectorReader for an empty CompressedVectorNode.
+
+@pre @a dbufs can't be empty
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@pre The destination ImageFile can't have any writers open (destImageFile().writerCount()==0)
+@pre This CompressedVectorNode must be attached (i.e. isAttached()).
+
+@return A smart CompressedVectorReader handle referencing the underlying iterator object.
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorTooManyWriters
+@throw ::ErrorNodeUnattached
+@throw ::ErrorPathUndefined
+@throw ::ErrorBufferSizeMismatch
+@throw ::ErrorBufferDuplicatePathName
+@throw ::ErrorBadCVHeader
+@throw ::ErrorInternal All objects in undocumented state
+
+@see CompressedVectorReader, SourceDestBuffer, CompressedVectorNode::CompressedVectorNode,
 CompressedVectorNode::prototype
 */
 CompressedVectorReader CompressedVectorNode::reader( const std::vector<SourceDestBuffer> &dbufs )

--- a/src/CompressedVectorNodeImpl.cpp
+++ b/src/CompressedVectorNodeImpl.cpp
@@ -35,7 +35,8 @@
 
 namespace e57
 {
-   CompressedVectorNodeImpl::CompressedVectorNodeImpl( ImageFileImplWeakPtr destImageFile ) : NodeImpl( destImageFile )
+   CompressedVectorNodeImpl::CompressedVectorNodeImpl( ImageFileImplWeakPtr destImageFile ) :
+      NodeImpl( destImageFile )
    {
       // don't checkImageFileOpen, NodeImpl() will do it
    }
@@ -47,34 +48,35 @@ namespace e57
       //??? check ok for proto, no Blob CompressedVector, empty?
       //??? throw E57_EXCEPTION2(ErrorBadPrototype)
 
-      /// Can't set prototype twice.
+      // Can't set prototype twice.
       if ( prototype_ )
       {
          throw E57_EXCEPTION2( ErrorSetTwice, "this->pathName=" + this->pathName() );
       }
 
-      /// prototype can't have a parent (must be a root node)
+      // prototype can't have a parent (must be a root node)
       if ( !prototype->isRoot() )
       {
          throw E57_EXCEPTION2( ErrorAlreadyHasParent,
-                               "this->pathName=" + this->pathName() + " prototype->pathName=" + prototype->pathName() );
+                               "this->pathName=" + this->pathName() +
+                                  " prototype->pathName=" + prototype->pathName() );
       }
 
-      /// Verify that prototype is destined for same ImageFile as this is
+      // Verify that prototype is destined for same ImageFile as this is
       ImageFileImplSharedPtr thisDest( destImageFile() );
       ImageFileImplSharedPtr prototypeDest( prototype->destImageFile() );
       if ( thisDest != prototypeDest )
       {
-         throw E57_EXCEPTION2( ErrorDifferentDestImageFile, "this->destImageFile" + thisDest->fileName() +
-                                                               " prototype->destImageFile" +
-                                                               prototypeDest->fileName() );
+         throw E57_EXCEPTION2( ErrorDifferentDestImageFile,
+                               "this->destImageFile" + thisDest->fileName() +
+                                  " prototype->destImageFile" + prototypeDest->fileName() );
       }
 
-      //!!! check for incomplete CompressedVectors when closing file
+      // !!! check for incomplete CompressedVectors when closing file
       prototype_ = prototype;
 
-      /// Note that prototype is not attached to CompressedVector in a parent/child
-      /// relationship. This means that prototype is a root node (has no parent).
+      // Note that prototype is not attached to CompressedVector in a parent/child
+      // relationship. This means that prototype is a root node (has no parent).
    }
 
    NodeImplSharedPtr CompressedVectorNodeImpl::getPrototype() const
@@ -91,32 +93,34 @@ namespace e57
       // of strings, codec
       // substruct
 
-      /// Can't set codecs twice.
+      // Can't set codecs twice.
       if ( codecs_ )
       {
          throw E57_EXCEPTION2( ErrorSetTwice, "this->pathName=" + this->pathName() );
       }
 
-      /// codecs can't have a parent (must be a root node)
+      // codecs can't have a parent (must be a root node)
       if ( !codecs->isRoot() )
       {
          throw E57_EXCEPTION2( ErrorAlreadyHasParent,
-                               "this->pathName=" + this->pathName() + " codecs->pathName=" + codecs->pathName() );
+                               "this->pathName=" + this->pathName() +
+                                  " codecs->pathName=" + codecs->pathName() );
       }
 
-      /// Verify that codecs is destined for same ImageFile as this is
+      // Verify that codecs is destined for same ImageFile as this is
       ImageFileImplSharedPtr thisDest( destImageFile() );
       ImageFileImplSharedPtr codecsDest( codecs->destImageFile() );
       if ( thisDest != codecsDest )
       {
-         throw E57_EXCEPTION2( ErrorDifferentDestImageFile, "this->destImageFile" + thisDest->fileName() +
-                                                               " codecs->destImageFile" + codecsDest->fileName() );
+         throw E57_EXCEPTION2( ErrorDifferentDestImageFile,
+                               "this->destImageFile" + thisDest->fileName() +
+                                  " codecs->destImageFile" + codecsDest->fileName() );
       }
 
       codecs_ = codecs;
 
-      /// Note that codecs is not attached to CompressedVector in a parent/child
-      /// relationship. This means that codecs is a root node (has no parent).
+      // Note that codecs is not attached to CompressedVector in a parent/child
+      // relationship. This means that codecs is a root node (has no parent).
    }
 
    std::shared_ptr<VectorNodeImpl> CompressedVectorNodeImpl::getCodecs() const
@@ -131,21 +135,22 @@ namespace e57
 
       //??? is this test a good idea?
 
-      /// Same node type?
+      // Same node type?
       if ( ni->type() != TypeCompressedVector )
       {
          return ( false );
       }
 
-      std::shared_ptr<CompressedVectorNodeImpl> cvi( std::static_pointer_cast<CompressedVectorNodeImpl>( ni ) );
+      std::shared_ptr<CompressedVectorNodeImpl> cvi(
+         std::static_pointer_cast<CompressedVectorNodeImpl>( ni ) );
 
-      /// recordCount must match
+      // recordCount must match
       if ( recordCount_ != cvi->recordCount_ )
       {
          return ( false );
       }
 
-      /// Prototypes and codecs must match ???
+      // Prototypes and codecs must match ???
       if ( !prototype_->isTypeEquivalent( cvi->prototype_ ) )
       {
          return ( false );
@@ -160,21 +165,22 @@ namespace e57
 
    bool CompressedVectorNodeImpl::isDefined( const ustring &pathName )
    {
-      throw E57_EXCEPTION2( ErrorNotImplemented, "this->pathName=" + this->pathName() + " pathName=" + pathName );
+      throw E57_EXCEPTION2( ErrorNotImplemented,
+                            "this->pathName=" + this->pathName() + " pathName=" + pathName );
    }
 
    void CompressedVectorNodeImpl::setAttachedRecursive()
    {
-      /// Mark this node as attached to an ImageFile
+      // Mark this node as attached to an ImageFile
       isAttached_ = true;
 
-      /// Mark nodes in prototype tree, if defined
+      // Mark nodes in prototype tree, if defined
       if ( prototype_ )
       {
          prototype_->setAttachedRecursive();
       }
 
-      /// Mark nodes in codecs tree if defined
+      // Mark nodes in codecs tree if defined
       if ( codecs_ )
       {
          codecs_->setAttachedRecursive();
@@ -187,12 +193,13 @@ namespace e57
       return ( recordCount_ );
    }
 
-   void CompressedVectorNodeImpl::checkLeavesInSet( const StringSet & /*pathNames*/, NodeImplSharedPtr /*origin*/ )
+   void CompressedVectorNodeImpl::checkLeavesInSet( const StringSet & /*pathNames*/,
+                                                    NodeImplSharedPtr /*origin*/ )
    {
       // don't checkImageFileOpen
 
-      /// Since only called for prototype nodes, shouldn't be able to get here since
-      /// CompressedVectors can't be in prototypes
+      // Since only called for prototype nodes, shouldn't be able to get here since
+      // CompressedVectors can't be in prototypes
       throw E57_EXCEPTION2( ErrorInternal, "this->pathName=" + this->pathName() );
    }
 
@@ -253,31 +260,35 @@ namespace e57
          os << space( indent ) << "codecs: <empty>" << std::endl;
       }
       os << space( indent ) << "recordCount:                " << recordCount_ << std::endl;
-      os << space( indent ) << "binarySectionLogicalStart:  " << binarySectionLogicalStart_ << std::endl;
+      os << space( indent ) << "binarySectionLogicalStart:  " << binarySectionLogicalStart_
+         << std::endl;
    }
 #endif
 
-   std::shared_ptr<CompressedVectorWriterImpl> CompressedVectorNodeImpl::writer( std::vector<SourceDestBuffer> sbufs )
+   std::shared_ptr<CompressedVectorWriterImpl> CompressedVectorNodeImpl::writer(
+      std::vector<SourceDestBuffer> sbufs )
    {
       checkImageFileOpen( __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) );
 
       ImageFileImplSharedPtr destImageFile( destImageFile_ );
 
-      /// Check don't have any writers/readers open for this ImageFile
+      // Check don't have any writers/readers open for this ImageFile
       if ( destImageFile->writerCount() > 0 )
       {
-         throw E57_EXCEPTION2( ErrorTooManyWriters, "fileName=" + destImageFile->fileName() +
-                                                       " writerCount=" + toString( destImageFile->writerCount() ) +
-                                                       " readerCount=" + toString( destImageFile->readerCount() ) );
+         throw E57_EXCEPTION2( ErrorTooManyWriters,
+                               "fileName=" + destImageFile->fileName() +
+                                  " writerCount=" + toString( destImageFile->writerCount() ) +
+                                  " readerCount=" + toString( destImageFile->readerCount() ) );
       }
       if ( destImageFile->readerCount() > 0 )
       {
-         throw E57_EXCEPTION2( ErrorTooManyReaders, "fileName=" + destImageFile->fileName() +
-                                                       " writerCount=" + toString( destImageFile->writerCount() ) +
-                                                       " readerCount=" + toString( destImageFile->readerCount() ) );
+         throw E57_EXCEPTION2( ErrorTooManyReaders,
+                               "fileName=" + destImageFile->fileName() +
+                                  " writerCount=" + toString( destImageFile->writerCount() ) +
+                                  " readerCount=" + toString( destImageFile->readerCount() ) );
       }
 
-      /// sbufs can't be empty
+      // sbufs can't be empty
       if ( sbufs.empty() )
       {
          throw E57_EXCEPTION2( ErrorBadAPIArgument, "fileName=" + destImageFile->fileName() );
@@ -293,64 +304,71 @@ namespace e57
          throw E57_EXCEPTION2( ErrorNodeUnattached, "fileName=" + destImageFile->fileName() );
       }
 
-      /// Get pointer to me (really shared_ptr<CompressedVectorNodeImpl>)
+      // Get pointer to me (really shared_ptr<CompressedVectorNodeImpl>)
       NodeImplSharedPtr ni( shared_from_this() );
 
-      /// Downcast pointer to right type
-      std::shared_ptr<CompressedVectorNodeImpl> cai( std::static_pointer_cast<CompressedVectorNodeImpl>( ni ) );
+      // Downcast pointer to right type
+      std::shared_ptr<CompressedVectorNodeImpl> cai(
+         std::static_pointer_cast<CompressedVectorNodeImpl>( ni ) );
 
-      /// Return a shared_ptr to new object
-      std::shared_ptr<CompressedVectorWriterImpl> cvwi( new CompressedVectorWriterImpl( cai, sbufs ) );
+      // Return a shared_ptr to new object
+      std::shared_ptr<CompressedVectorWriterImpl> cvwi(
+         new CompressedVectorWriterImpl( cai, sbufs ) );
       return ( cvwi );
    }
 
-   std::shared_ptr<CompressedVectorReaderImpl> CompressedVectorNodeImpl::reader( std::vector<SourceDestBuffer> dbufs )
+   std::shared_ptr<CompressedVectorReaderImpl> CompressedVectorNodeImpl::reader(
+      std::vector<SourceDestBuffer> dbufs )
    {
       checkImageFileOpen( __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) );
 
       ImageFileImplSharedPtr destImageFile( destImageFile_ );
 
-      /// Check don't have any writers/readers open for this ImageFile
+      // Check don't have any writers/readers open for this ImageFile
       if ( destImageFile->writerCount() > 0 )
       {
-         throw E57_EXCEPTION2( ErrorTooManyWriters, "fileName=" + destImageFile->fileName() +
-                                                       " writerCount=" + toString( destImageFile->writerCount() ) +
-                                                       " readerCount=" + toString( destImageFile->readerCount() ) );
+         throw E57_EXCEPTION2( ErrorTooManyWriters,
+                               "fileName=" + destImageFile->fileName() +
+                                  " writerCount=" + toString( destImageFile->writerCount() ) +
+                                  " readerCount=" + toString( destImageFile->readerCount() ) );
       }
       if ( destImageFile->readerCount() > 0 )
       {
-         throw E57_EXCEPTION2( ErrorTooManyReaders, "fileName=" + destImageFile->fileName() +
-                                                       " writerCount=" + toString( destImageFile->writerCount() ) +
-                                                       " readerCount=" + toString( destImageFile->readerCount() ) );
+         throw E57_EXCEPTION2( ErrorTooManyReaders,
+                               "fileName=" + destImageFile->fileName() +
+                                  " writerCount=" + toString( destImageFile->writerCount() ) +
+                                  " readerCount=" + toString( destImageFile->readerCount() ) );
       }
 
-      /// dbufs can't be empty
+      // dbufs can't be empty
       if ( dbufs.empty() )
       {
          throw E57_EXCEPTION2( ErrorBadAPIArgument, "fileName=" + destImageFile->fileName() );
       }
 
-      /// Can be read or write mode, but must be attached
+      // Can be read or write mode, but must be attached
       if ( !isAttached() )
       {
          throw E57_EXCEPTION2( ErrorNodeUnattached, "fileName=" + destImageFile->fileName() );
       }
 
-      /// Get pointer to me (really shared_ptr<CompressedVectorNodeImpl>)
+      // Get pointer to me (really shared_ptr<CompressedVectorNodeImpl>)
       NodeImplSharedPtr ni( shared_from_this() );
 #ifdef E57_MAX_VERBOSE
       // cout << "constructing CAReader, ni:" << std::endl;
       // ni->dump(4);
 #endif
 
-      /// Downcast pointer to right type
-      std::shared_ptr<CompressedVectorNodeImpl> cai( std::static_pointer_cast<CompressedVectorNodeImpl>( ni ) );
+      // Downcast pointer to right type
+      std::shared_ptr<CompressedVectorNodeImpl> cai(
+         std::static_pointer_cast<CompressedVectorNodeImpl>( ni ) );
 #ifdef E57_MAX_VERBOSE
       // cout<<"constructing CAReader, cai:"<<endl;
       // cai->dump(4);
 #endif
-      /// Return a shared_ptr to new object
-      std::shared_ptr<CompressedVectorReaderImpl> cvri( new CompressedVectorReaderImpl( cai, dbufs ) );
+      // Return a shared_ptr to new object
+      std::shared_ptr<CompressedVectorReaderImpl> cvri(
+         new CompressedVectorReaderImpl( cai, dbufs ) );
       return ( cvri );
    }
 }

--- a/src/CompressedVectorReader.cpp
+++ b/src/CompressedVectorReader.cpp
@@ -28,292 +28,26 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-//! @file CompressedVectorReader.cpp
+/// @file CompressedVectorReader.cpp
 
 #include "CompressedVectorReaderImpl.h"
 
 using namespace e57;
 
-/*!
-@class e57::CompressedVectorReader
-@brief   An iterator object keeping track of a read in progress from a
-CompressedVectorNode.
-@details
-A CompressedVectorReader object is a block iterator that reads blocks of records
-from a CompressedVectorNode and stores them in memory buffers
-(SourceDestBuffers). Blocks of records are processed rather than a single
-record-at-a-time for efficiency reasons. The CompressedVectorReader class
-encapsulates all the state that must be saved in between the processing of one
-record block and the next (e.g. partially read disk pages, or data decompression
-state). New memory buffers can be used for each record block read, or the
-previous buffers can be reused.
-
-CompressedVectorReader objects have an open/closed state.
-Initially a newly created CompressedVectorReader is in the open state.
-After the API user calls CompressedVectorReader::close, the object will be in
-the closed state and no more data transfers will be possible.
-
-There is no CompressedVectorReader constructor in the API.
-The function CompressedVectorNode::reader returns an already constructed
-CompressedVectorReader object with given memory buffers (SourceDestBuffers)
-already associated.
-
-It is recommended to call CompressedVectorReader::close to gracefully end the
-transfer. Unlike the CompressedVectorWriter, not all fields in the record of the
-CompressedVectorNode are required to be read at one time.
-
-@section CompressedVectorReader_invariant Class Invariant
-A class invariant is a list of statements about an object that are always true
-before and after any operation on the object. An invariant is useful for testing
-correct operation of an implementation. Statements in an invariant can involve
-only externally visible state, or can refer to internal implementation-specific
-state that is not visible to the API user. The following C++ code checks
-externally visible state for consistency and throws an exception if the
-invariant is violated:
-@dontinclude CompressedVectorReader.cpp
-@skip beginExample CompressedVectorReader::checkInvariant
-@until endExample CompressedVectorReader::checkInvariant
-
-@see     CompressedVectorNode, CompressedVectorWriter
-*/
-
-//! @cond documentNonPublic   The following isn't part of the API, and isn't
-//! documented.
-CompressedVectorReader::CompressedVectorReader( std::shared_ptr<CompressedVectorReaderImpl> ni ) : impl_( ni )
-{
-}
-//! @endcond
-
-/*!
-@brief   Request transfer of blocks of data from CompressedVectorNode into
-previously designated destination buffers.
-@details
-The SourceDestBuffers used are previously designated either in
-CompressedVectorNode::reader where this object was created, or in the last call
-to CompressedVectorReader::read(std::vector<SourceDestBuffer>&) where new
-buffers were designated. The function will always return the full number of
-records requested (the capacity of the SourceDestBuffers) unless it has reached
-the end of the CompressedVectorNode, in which case it will return less than the
-capacity of the SourceDestBuffers. Partial reads will store the records at the
-beginning of the SourceDestBuffers. It is not an error to call this function
-after all records in the CompressedVectorNode have been read (the function
-returns 0).
-
-If a conversion or bounds error occurs during the transfer, the
-CompressedVectorReader is left in an undocumented state (it can't be used any
-further). If a file I/O or checksum error occurs during the transfer, both the
-CompressedVectorReader and the associated ImageFile are left in an undocumented
-state (they can't be used any further).
-
-The API user is responsible for ensuring that the underlying memory buffers
-represented in the SourceDestBuffers still exist when this function is called.
-The E57 Foundation Implementation cannot detect that a memory buffer been
-destroyed.
-
-@pre     The associated ImageFile must be open.
-@pre     This CompressedVectorReader must be open (i.e isOpen())
-@return  The number of records read.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorReaderNotOpen
-@throw   ::ErrorConversionRequired            This CompressedVectorReader
-in undocumented state
-@throw   ::ErrorValueNotRepresentable        This CompressedVectorReader
-in undocumented state
-@throw   ::ErrorScaledValueNotRepresentable This CompressedVectorReader
-in undocumented state
-@throw   ::ErrorReal64TooLarge               This CompressedVectorReader
-in undocumented state
-@throw   ::ErrorExpectingNumeric              This CompressedVectorReader
-in undocumented state
-@throw   ::ErrorExpectingUString              This CompressedVectorReader
-in undocumented state
-@throw   ::ErrorBadCVPacket      This CompressedVectorReader, associated
-ImageFile in undocumented state
-@throw   ::ErrorSeekFailed       This CompressedVectorReader, associated
-ImageFile in undocumented state
-@throw   ::ErrorReadFailed        This CompressedVectorReader, associated
-ImageFile in undocumented state
-@throw   ::ErrorBadChecksum       This CompressedVectorReader, associated
-ImageFile in undocumented state
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorReader::read(std::vector<SourceDestBuffer>&),
-CompressedVectorNode::reader, SourceDestBuffer,
-CompressedVectorReader::read(std::vector<SourceDestBuffer>&)
-*/
-unsigned CompressedVectorReader::read()
-{
-   return impl_->read();
-}
-
-/*!
-@brief   Request transfer of block of data from CompressedVectorNode into given
-destination buffers.
-@param   [in] dbufs     Vector of memory buffers that will receive data read
-from a CompressedVectorNode.
-@details
-The @a dbufs must all have the same capacity.
-The specified @a dbufs must have same number of elements as previously
-designated SourceDestBuffer vector. The each SourceDestBuffer within @a dbufs
-must be identical to the previously designated SourceDestBuffer except for
-capacity and buffer address.
-
-The @a dbufs locations are saved so that a later call to
-CompressedVectorReader::read() can be used without having to re-specify the
-SourceDestBuffers.
-
-The function will always return the full number of records requested (the
-capacity of the SourceDestBuffers) unless it has reached the end of the
-CompressedVectorNode, in which case it will return less than the capacity of the
-SourceDestBuffers. Partial reads will store the records at the beginning of the
-SourceDestBuffers. It is not an error to call this function after all records in
-the CompressedVectorNode have been read (the function returns 0).
-
-If a conversion or bounds error occurs during the transfer, the
-CompressedVectorReader is left in an undocumented state (it can't be used any
-further). If a file I/O or checksum error occurs during the transfer, both the
-CompressedVectorReader and the associated ImageFile are left in an undocumented
-state (they can't be used any further).
-
-The API user is responsible for ensuring that the underlying memory buffers
-represented in the SourceDestBuffers still exist when this function is called.
-The E57 Foundation Implementation cannot detect that a memory buffer been
-destroyed.
-
-@pre     The associated ImageFile must be open.
-@pre     This CompressedVectorReader must be open (i.e isOpen())
-@return  The number of records read.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorReaderNotOpen
-@throw   ::ErrorPathUndefined
-@throw   ::ErrorBufferSizeMismatch
-@throw   ::ErrorBufferDuplicatePathName
-@throw   ::ErrorConversionRequired            This CompressedVectorReader
-in undocumented state
-@throw   ::ErrorValueNotRepresentable        This CompressedVectorReader
-in undocumented state
-@throw   ::ErrorScaledValueNotRepresentable This CompressedVectorReader
-in undocumented state
-@throw   ::ErrorReal64TooLarge               This CompressedVectorReader
-in undocumented state
-@throw   ::ErrorExpectingNumeric              This CompressedVectorReader
-in undocumented state
-@throw   ::ErrorExpectingUString              This CompressedVectorReader
-in undocumented state
-@throw   ::ErrorBadCVPacket      This CompressedVectorReader, associated
-ImageFile in undocumented state
-@throw   ::ErrorSeekFailed       This CompressedVectorReader, associated
-ImageFile in undocumented state
-@throw   ::ErrorReadFailed        This CompressedVectorReader, associated
-ImageFile in undocumented state
-@throw   ::ErrorBadChecksum       This CompressedVectorReader, associated
-ImageFile in undocumented state
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorReader::read(), CompressedVectorNode::reader, SourceDestBuffer
-*/
-unsigned CompressedVectorReader::read( std::vector<SourceDestBuffer> &dbufs )
-{
-   return impl_->read( dbufs );
-}
-
-/*!
-@brief   Set record number of CompressedVectorNode where next read will start.
-@param   [in] recordNumber   The index of record in CompressedVectorNode where
-next read using this CompressedVectorReader will start.
-@details
-This function may be called at any time (as long as ImageFile and
-CompressedVectorReader are open). The next read will start at the given
-recordNumber. It is not an error to seek to recordNumber = childCount() (i.e. to
-one record past end of CompressedVectorNode).
-
-@pre     @a recordNumber <= childCount() of CompressedVectorNode.
-@pre     The associated ImageFile must be open.
-@pre     This CompressedVectorReader must be open (i.e isOpen())
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorReaderNotOpen
-@throw   ::ErrorBadCVPacket
-@throw   ::ErrorSeekFailed
-@throw   ::ErrorReadFailed
-@throw   ::ErrorBadChecksum
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorNode::reader
-*/
-void CompressedVectorReader::seek( int64_t recordNumber )
-{
-   impl_->seek( recordNumber );
-}
-
-/*!
-@brief   End the read operation.
-@details
-It is recommended that this function be called to gracefully end a transfer to a
-CompressedVectorNode. It is not an error to call this function if the
-CompressedVectorReader is already closed. This function will cause the
-CompressedVectorReader to enter the closed state, and any further transfers
-requests will fail.
-
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorReader::isOpen, CompressedVectorNode::reader
-*/
-void CompressedVectorReader::close()
-{
-   impl_->close();
-}
-
-/*!
-@brief   Test whether CompressedVectorReader is still open for reading.
-@pre     The associated ImageFile must be open.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorReader::close, CompressedVectorNode::reader
-*/
-bool CompressedVectorReader::isOpen()
-{
-   return impl_->isOpen();
-}
-
-/*!
-@brief   Return the CompressedVectorNode being read.
-@details
-It is not an error if this CompressedVectorReader is closed.
-@pre     The associated ImageFile must be open.
-@return  A smart CompressedVectorNode handle referencing the underlying object
-being read from.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorReader::close, CompressedVectorNode::reader
-*/
-CompressedVectorNode CompressedVectorReader::compressedVectorNode() const
-{
-   return impl_->compressedVectorNode();
-}
-
-//! @brief   Diagnostic function to print internal state of object to output
-//! stream in an indented format.
-//! @copydetails Node::dump()
-#ifdef E57_DEBUG
-void CompressedVectorReader::dump( int indent, std::ostream &os ) const
-{
-   impl_->dump( indent, os );
-}
-#else
-void CompressedVectorReader::dump( int indent, std::ostream &os ) const
-{
-}
-#endif
-
+// Put this function first so we can reference the code in doxygen using @skip
 /*!
 @brief Check whether CompressedVectorReader class invariant is true
-@param   [in] doRecurse   If true, also check invariants of all children or
-sub-objects recursively.
+
+@param [in] doRecurse If true, also check invariants of all children or sub-objects recursively.
+
 @details
-This function checks at least the assertions in the documented class invariant
-description (see class reference page for this object). Other internal
-invariants that are implementation-dependent may also be checked. If any
-invariant clause is violated, an ::ErrorInvarianceViolation E57Exception is thrown.
-@post    No visible state is modified.
+This function checks at least the assertions in the documented class invariant description (see
+class reference page for this object). Other internal invariants that are implementation-dependent
+may also be checked. If any invariant clause is violated, an ::ErrorInvarianceViolation E57Exception
+is thrown.
+
+@post No visible state is modified.
 */
-// beginExample CompressedVectorReader::checkInvariant
 void CompressedVectorReader::checkInvariant( bool /*doRecurse*/ )
 {
    // If this CompressedVectorReader is not open, can't test invariant (almost
@@ -351,4 +85,272 @@ void CompressedVectorReader::checkInvariant( bool /*doRecurse*/ )
       throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 }
-// endExample CompressedVectorReader::checkInvariant
+
+/*!
+@class e57::CompressedVectorReader
+
+@brief An iterator object keeping track of a read in progress from a CompressedVectorNode.
+
+@details
+A CompressedVectorReader object is a block iterator that reads blocks of records from a
+CompressedVectorNode and stores them in memory buffers (SourceDestBuffers). Blocks of records are
+processed rather than a single record-at-a-time for efficiency reasons. The CompressedVectorReader
+class encapsulates all the state that must be saved in between the processing of one record block
+and the next (e.g. partially read disk pages, or data decompression state). New memory buffers can
+be used for each record block read, or the previous buffers can be reused.
+
+CompressedVectorReader objects have an open/closed state. Initially a newly created
+CompressedVectorReader is in the open state. After the API user calls CompressedVectorReader::close,
+the object will be in the closed state and no more data transfers will be possible.
+
+There is no CompressedVectorReader constructor in the API. The function CompressedVectorNode::reader
+returns an already constructed CompressedVectorReader object with given memory buffers
+(SourceDestBuffers) already associated.
+
+It is recommended to call CompressedVectorReader::close to gracefully end the transfer. Unlike the
+CompressedVectorWriter, not all fields in the record of the CompressedVectorNode are required to be
+read at one time.
+
+@section CompressedVectorReader_invariant Class Invariant
+A class invariant is a list of statements about an object that are always true before and after any
+operation on the object. An invariant is useful for testing correct operation of an implementation.
+Statements in an invariant can involve only externally visible state, or can refer to internal
+implementation-specific state that is not visible to the API user. The following C++ code checks
+externally visible state for consistency and throws an exception if the invariant is violated:
+
+@dontinclude CompressedVectorReader.cpp
+@skip void CompressedVectorReader::checkInvariant
+@until ^}
+
+@see CompressedVectorNode, CompressedVectorWriter
+*/
+
+/// @cond documentNonPublic The following isn't part of the API, and isn't documented.
+CompressedVectorReader::CompressedVectorReader( std::shared_ptr<CompressedVectorReaderImpl> ni ) :
+   impl_( ni )
+{
+}
+/// @endcond
+
+/*!
+@brief Request transfer of blocks of data from CompressedVectorNode into
+previously designated destination buffers.
+
+@details
+The SourceDestBuffers used are previously designated either in
+CompressedVectorNode::reader where this object was created, or in the last call
+to CompressedVectorReader::read(std::vector<SourceDestBuffer>&) where new
+buffers were designated. The function will always return the full number of
+records requested (the capacity of the SourceDestBuffers) unless it has reached
+the end of the CompressedVectorNode, in which case it will return less than the
+capacity of the SourceDestBuffers. Partial reads will store the records at the
+beginning of the SourceDestBuffers. It is not an error to call this function
+after all records in the CompressedVectorNode have been read (the function
+returns 0).
+
+If a conversion or bounds error occurs during the transfer, the
+CompressedVectorReader is left in an undocumented state (it can't be used any
+further). If a file I/O or checksum error occurs during the transfer, both the
+CompressedVectorReader and the associated ImageFile are left in an undocumented
+state (they can't be used any further).
+
+The API user is responsible for ensuring that the underlying memory buffers
+represented in the SourceDestBuffers still exist when this function is called.
+The E57 Foundation Implementation cannot detect that a memory buffer been
+destroyed.
+
+@pre The associated ImageFile must be open.
+@pre This CompressedVectorReader must be open (i.e isOpen())
+
+@return The number of records read.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorReaderNotOpen
+@throw ::ErrorConversionRequired            This CompressedVectorReader
+in undocumented state
+@throw ::ErrorValueNotRepresentable        This CompressedVectorReader
+in undocumented state
+@throw ::ErrorScaledValueNotRepresentable This CompressedVectorReader
+in undocumented state
+@throw ::ErrorReal64TooLarge               This CompressedVectorReader
+in undocumented state
+@throw ::ErrorExpectingNumeric              This CompressedVectorReader
+in undocumented state
+@throw ::ErrorExpectingUString              This CompressedVectorReader
+in undocumented state
+@throw ::ErrorBadCVPacket      This CompressedVectorReader, associated
+ImageFile in undocumented state
+@throw ::ErrorSeekFailed       This CompressedVectorReader, associated
+ImageFile in undocumented state
+@throw ::ErrorReadFailed        This CompressedVectorReader, associated
+ImageFile in undocumented state
+@throw ::ErrorBadChecksum       This CompressedVectorReader, associated
+ImageFile in undocumented state
+@throw ::ErrorInternal           All objects in undocumented state
+
+@see CompressedVectorReader::read(std::vector<SourceDestBuffer>&),
+CompressedVectorNode::reader, SourceDestBuffer,
+CompressedVectorReader::read(std::vector<SourceDestBuffer>&)
+*/
+unsigned CompressedVectorReader::read()
+{
+   return impl_->read();
+}
+
+/*!
+@brief Request transfer of block of data from CompressedVectorNode into given destination buffers.
+
+@param [in] dbufs Vector of memory buffers that will receive data read from a CompressedVectorNode.
+
+@details
+The @a dbufs must all have the same capacity.
+
+The specified @a dbufs must have same number of elements as previously designated SourceDestBuffer
+vector. The each SourceDestBuffer within @a dbufs must be identical to the previously designated
+SourceDestBuffer except for capacity and buffer address.
+
+The @a dbufs locations are saved so that a later call to CompressedVectorReader::read() can be used
+without having to re-specify the SourceDestBuffers.
+
+The function will always return the full number of records requested (the capacity of the
+SourceDestBuffers) unless it has reached the end of the CompressedVectorNode, in which case it will
+return less than the capacity of the SourceDestBuffers. Partial reads will store the records at the
+beginning of the SourceDestBuffers. It is not an error to call this function after all records in
+the CompressedVectorNode have been read (the function returns 0).
+
+If a conversion or bounds error occurs during the transfer, the CompressedVectorReader is left in an
+undocumented state (it can't be used any further). If a file I/O or checksum error occurs during the
+transfer, both the CompressedVectorReader and the associated ImageFile are left in an undocumented
+state (they can't be used any further).
+
+The API user is responsible for ensuring that the underlying memory buffers represented in the
+SourceDestBuffers still exist when this function is called. The E57 Foundation Implementation cannot
+detect that a memory buffer been destroyed.
+
+@pre The associated ImageFile must be open.
+@pre This CompressedVectorReader must be open (i.e isOpen())
+
+@return The number of records read.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorReaderNotOpen
+@throw ::ErrorPathUndefined
+@throw ::ErrorBufferSizeMismatch
+@throw ::ErrorBufferDuplicatePathName
+@throw ::ErrorConversionRequired This CompressedVectorReader in undocumented state
+@throw ::ErrorValueNotRepresentable This CompressedVectorReader in undocumented state
+@throw ::ErrorScaledValueNotRepresentable This CompressedVectorReader in undocumented state
+@throw ::ErrorReal64TooLarge This CompressedVectorReader in undocumented state
+@throw ::ErrorExpectingNumeric This CompressedVectorReader in undocumented state
+@throw ::ErrorExpectingUString  This CompressedVectorReader in undocumented state
+@throw ::ErrorBadCVPacket This CompressedVectorReader, associated ImageFile in undocumented state
+@throw ::ErrorSeekFailed This CompressedVectorReader, associated ImageFile in undocumented state
+@throw ::ErrorReadFailed This CompressedVectorReader, associated ImageFile in undocumented state
+@throw ::ErrorBadChecksum This CompressedVectorReader, associated ImageFile in undocumented state
+@throw ::ErrorInternal All objects in undocumented state
+
+@see CompressedVectorReader::read(), CompressedVectorNode::reader, SourceDestBuffer
+*/
+unsigned CompressedVectorReader::read( std::vector<SourceDestBuffer> &dbufs )
+{
+   return impl_->read( dbufs );
+}
+
+/*!
+@brief Set record number of CompressedVectorNode where next read will start.
+
+@param [in] recordNumber The index of record in CompressedVectorNode where next read using this
+CompressedVectorReader will start.
+
+@details
+This function may be called at any time (as long as ImageFile and CompressedVectorReader are open).
+The next read will start at the given recordNumber. It is not an error to seek to recordNumber =
+childCount() (i.e. to one record past end of CompressedVectorNode).
+
+@pre @a recordNumber <= childCount() of CompressedVectorNode.
+@pre The associated ImageFile must be open.
+@pre This CompressedVectorReader must be open (i.e isOpen())
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorReaderNotOpen
+@throw ::ErrorBadCVPacket
+@throw ::ErrorSeekFailed
+@throw ::ErrorReadFailed
+@throw ::ErrorBadChecksum
+@throw ::ErrorInternal All objects in undocumented state
+
+@see CompressedVectorNode::reader
+*/
+void CompressedVectorReader::seek( int64_t recordNumber )
+{
+   impl_->seek( recordNumber );
+}
+
+/*!
+@brief End the read operation.
+
+@details
+It is recommended that this function be called to gracefully end a transfer to a
+CompressedVectorNode. It is not an error to call this function if the CompressedVectorReader is
+already closed. This function will cause the CompressedVectorReader to enter the closed state, and
+any further transfers requests will fail.
+
+@throw ::ErrorInternal All objects in undocumented state
+
+@see CompressedVectorReader::isOpen, CompressedVectorNode::reader
+*/
+void CompressedVectorReader::close()
+{
+   impl_->close();
+}
+
+/*!
+@brief Test whether CompressedVectorReader is still open for reading.
+
+@pre The associated ImageFile must be open.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal           All objects in undocumented state
+
+@see CompressedVectorReader::close, CompressedVectorNode::reader
+*/
+bool CompressedVectorReader::isOpen()
+{
+   return impl_->isOpen();
+}
+
+/*!
+@brief Return the CompressedVectorNode being read.
+
+@details
+It is not an error if this CompressedVectorReader is closed.
+
+@pre The associated ImageFile must be open.
+
+@return A smart CompressedVectorNode handle referencing the underlying object being read from.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal           All objects in undocumented state
+
+@see CompressedVectorReader::close, CompressedVectorNode::reader
+*/
+CompressedVectorNode CompressedVectorReader::compressedVectorNode() const
+{
+   return impl_->compressedVectorNode();
+}
+
+/*!
+@brief Diagnostic function to print internal state of object to output stream in an indented format.
+@copydetails Node::dump()
+*/
+#ifdef E57_DEBUG
+void CompressedVectorReader::dump( int indent, std::ostream &os ) const
+{
+   impl_->dump( indent, os );
+}
+#else
+void CompressedVectorReader::dump( int indent, std::ostream &os ) const
+{
+}
+#endif

--- a/src/CompressedVectorReaderImpl.h
+++ b/src/CompressedVectorReaderImpl.h
@@ -36,8 +36,10 @@ namespace e57
    class CompressedVectorReaderImpl
    {
    public:
-      CompressedVectorReaderImpl( std::shared_ptr<CompressedVectorNodeImpl> cvi, std::vector<SourceDestBuffer> &dbufs );
+      CompressedVectorReaderImpl( std::shared_ptr<CompressedVectorNodeImpl> cvi,
+                                  std::vector<SourceDestBuffer> &dbufs );
       ~CompressedVectorReaderImpl();
+
       unsigned read();
       unsigned read( std::vector<SourceDestBuffer> &dbufs );
       void seek( uint64_t recordNumber );
@@ -50,8 +52,10 @@ namespace e57
 #endif
 
    private:
-      void checkImageFileOpen( const char *srcFileName, int srcLineNumber, const char *srcFunctionName ) const;
-      void checkReaderOpen( const char *srcFileName, int srcLineNumber, const char *srcFunctionName ) const;
+      void checkImageFileOpen( const char *srcFileName, int srcLineNumber,
+                               const char *srcFunctionName ) const;
+      void checkReaderOpen( const char *srcFileName, int srcLineNumber,
+                            const char *srcFunctionName ) const;
       void setBuffers( std::vector<SourceDestBuffer> &dbufs ); //???needed?
       uint64_t earliestPacketNeededForInput() const;
 

--- a/src/CompressedVectorWriter.cpp
+++ b/src/CompressedVectorWriter.cpp
@@ -28,277 +28,17 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-//! @file CompressedVectorWriter.cpp
+/// @file CompressedVectorWriter.cpp
 
 #include "CompressedVectorWriterImpl.h"
 
 using namespace e57;
 
+// Put this function first so we can reference the code in doxygen using @skip
 /*!
-@class e57::CompressedVectorWriter
-@brief   An iterator object keeping track of a write in progress to a
-CompressedVectorNode.
-@details
-A CompressedVectorWriter object is a block iterator that reads blocks of records
-from memory and stores them in a CompressedVectorNode. Blocks of records are
-processed rather than a single record-at-a-time for efficiency reasons. The
-CompressedVectorWriter class encapsulates all the state that must be saved in
-between the processing of one record block and the next (e.g. partially written
-disk pages, partially filled bytes in a bytestream, or data compression state).
-New memory buffers can be used for each record block write, or the previous
-buffers can be reused.
-
-CompressedVectorWriter objects have an open/closed state.
-Initially a newly created CompressedVectorWriter is in the open state.
-After the API user calls CompressedVectorWriter::close, the object will be in
-the closed state and no more data transfers will be possible.
-
-There is no CompressedVectorWriter constructor in the API.
-The function CompressedVectorNode::writer returns an already constructed
-CompressedVectorWriter object with given memory buffers (SourceDestBuffers)
-already associated. CompressedVectorWriter::close must explicitly be called to
-safely and gracefully end the transfer.
-
-@b Warning: If CompressedVectorWriter::close is not called before the
-CompressedVectorWriter destructor is invoked, all writes to the
-CompressedVectorNode will be lost (it will have zero children).
-
-@section CompressedVectorWriter_invariant Class Invariant
-A class invariant is a list of statements about an object that are always true
-before and after any operation on the object. An invariant is useful for testing
-correct operation of an implementation. Statements in an invariant can involve
-only externally visible state, or can refer to internal implementation-specific
-state that is not visible to the API user. The following C++ code checks
-externally visible state for consistency and throws an exception if the
-invariant is violated:
-@dontinclude CompressedVectorWriter.cpp
-@skip beginExample CompressedVectorWriter::checkInvariant
-@until endExample CompressedVectorWriter::checkInvariant
-
-@see     CompressedVectorNode, CompressedVectorReader
+@brief Check whether CompressedVectorWriter class invariant is true
+@copydetails CompressedVectorReader::checkInvariant
 */
-
-//! @cond documentNonPublic   The following isn't part of the API, and isn't
-//! documented.
-CompressedVectorWriter::CompressedVectorWriter( std::shared_ptr<CompressedVectorWriterImpl> ni ) : impl_( ni )
-{
-}
-//! @endcond
-
-/*!
-@brief   Request transfer of blocks of data to CompressedVectorNode from
-previously designated source buffers.
-@param   [in] recordCount   Number of records to write.
-@details
-The SourceDestBuffers used are previously designated either in
-CompressedVectorNode::writer where this object was created, or in the last call
-to CompressedVectorWriter::write(std::vector<SourceDestBuffer>&, unsigned) where
-new buffers were designated.
-
-If a conversion or bounds error occurs during the transfer, the
-CompressedVectorWriter is left in an undocumented state (it can't be used any
-further), and all previously written records are deleted from the associated
-CompressedVectorNode which will then have zero children. If a file I/O or
-checksum error occurs during the transfer, both this CompressedVectorWriter and
-the associated ImageFile are left in an undocumented state (they can't be used
-any further). If CompressedVectorWriter::close is not called before the
-CompressedVectorWriter destructor is invoked, all writes to the
-CompressedVectorNode will be lost (it will have zero children).
-
-@pre     The associated ImageFile must be open.
-@pre     This CompressedVectorWriter must be open (i.e isOpen())
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorWriterNotOpen
-@throw   ::ErrorPathUndefined
-@throw   ::ErrorNoBufferForElement
-@throw   ::ErrorBufferSizeMismatch
-@throw   ::ErrorBufferDuplicatePathName
-@throw   ::ErrorConversionRequired     This CompressedVectorWriter in
-undocumented state, associated CompressedVectorNode modified but consistent,
-associated ImageFile modified but consistent.
-@throw   ::ErrorValueOutOfBounds     This CompressedVectorWriter in
-undocumented state, associated CompressedVectorNode modified but consistent,
-associated ImageFile modified but consistent.
-@throw   ::ErrorValueNotRepresentable This CompressedVectorWriter in
-undocumented state, associated CompressedVectorNode modified but consistent,
-associated ImageFile modified but consistent.
-@throw   ::ErrorScaledValueNotRepresentable This CompressedVectorWriter
-in undocumented state, associated CompressedVectorNode modified but consistent,
-associated ImageFile modified but consistent.
-@throw   ::ErrorReal64TooLarge   This CompressedVectorWriter in
-undocumented state, associated CompressedVectorNode modified but consistent,
-associated ImageFile modified but consistent.
-@throw   ::ErrorExpectingNumeric  This CompressedVectorWriter in
-undocumented state, associated CompressedVectorNode modified but consistent,
-associated ImageFile modified but consistent.
-@throw   ::ErrorExpectingUString  This CompressedVectorWriter in
-undocumented state, associated CompressedVectorNode modified but consistent,
-associated ImageFile modified but consistent.
-@throw   ::ErrorSeekFailed       This CompressedVectorWriter, associated
-ImageFile in undocumented state
-@throw   ::ErrorReadFailed        This CompressedVectorWriter, associated
-ImageFile in undocumented state
-@throw   ::ErrorWriteFailed       This CompressedVectorWriter, associated
-ImageFile in undocumented state
-@throw   ::ErrorBadChecksum       This CompressedVectorWriter, associated
-ImageFile in undocumented state
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorWriter::write(std::vector<SourceDestBuffer>&,unsigned),
-CompressedVectorNode::writer, CompressedVectorWriter::close, SourceDestBuffer,
-E57Exception
-*/
-void CompressedVectorWriter::write( const size_t recordCount )
-{
-   impl_->write( recordCount );
-}
-
-/*!
-@brief   Request transfer of block of data to CompressedVectorNode from given
-source buffers.
-@param   [in] sbufs         Vector of memory buffers that hold data to be
-written to a CompressedVectorNode.
-@param   [in] recordCount   Number of records to write.
-@details
-The @a sbufs must all have the same capacity.
-The @a sbufs capacity must be >= @a recordCount.
-The specified @a sbufs must have same number of elements as previously
-designated SourceDestBuffer vector. The each SourceDestBuffer within @a sbufs
-must be identical to the previously designated SourceDestBuffer except for
-capacity and buffer address.
-
-The @a sbufs locations are saved so that a later call to
-CompressedVectorWriter::write(unsigned) can be used without having to re-specify
-the SourceDestBuffers.
-
-If a conversion or bounds error occurs during the transfer, the
-CompressedVectorWriter is left in an undocumented state (it can't be used any
-further), and all previously written records are deleted from the the associated
-CompressedVectorNode which will then have zero children. If a file I/O or
-checksum error occurs during the transfer, both this CompressedVectorWriter and
-the associated ImageFile are left in an undocumented state (they can't be used
-any further).
-
-@b Warning: If CompressedVectorWriter::close is not called before the
-CompressedVectorWriter destructor is invoked, all writes to the
-CompressedVectorNode will be lost (it will have zero children).
-
-@pre     The associated ImageFile must be open.
-@pre     This CompressedVectorWriter must be open (i.e isOpen())
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorWriterNotOpen
-@throw   ::ErrorPathUndefined
-@throw   ::ErrorNoBufferForElement
-@throw   ::ErrorBufferSizeMismatch
-@throw   ::ErrorBufferDuplicatePathName
-@throw   ::ErrorConversionRequired     This CompressedVectorWriter in
-undocumented state, associated ImageFile modified but consistent.
-@throw   ::ErrorValueOutOfBounds     This CompressedVectorWriter in
-undocumented state, associated ImageFile modified but consistent.
-@throw   ::ErrorValueNotRepresentable This CompressedVectorWriter in
-undocumented state, associated ImageFile modified but consistent.
-@throw   ::ErrorScaledValueNotRepresentable This CompressedVectorWriter
-in undocumented state, associated ImageFile modified but consistent.
-@throw   ::ErrorReal64TooLarge   This CompressedVectorWriter in
-undocumented state, associated ImageFile modified but consistent.
-@throw   ::ErrorExpectingNumeric  This CompressedVectorWriter in
-undocumented state, associated ImageFile modified but consistent.
-@throw   ::ErrorExpectingUString  This CompressedVectorWriter in
-undocumented state, associated ImageFile modified but consistent.
-@throw   ::ErrorSeekFailed       This CompressedVectorWriter, associated
-ImageFile in undocumented state
-@throw   ::ErrorReadFailed        This CompressedVectorWriter, associated
-ImageFile in undocumented state
-@throw   ::ErrorWriteFailed       This CompressedVectorWriter, associated
-ImageFile in undocumented state
-@throw   ::ErrorBadChecksum       This CompressedVectorWriter, associated
-ImageFile in undocumented state
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorWriter::write(unsigned), CompressedVectorNode::writer,
-CompressedVectorWriter::close, SourceDestBuffer, E57Exception
-*/
-void CompressedVectorWriter::write( std::vector<SourceDestBuffer> &sbufs, const size_t recordCount )
-{
-   impl_->write( sbufs, recordCount );
-}
-
-/*!
-@brief   End the write operation.
-@details
-This function must be called to safely and gracefully end a transfer to a
-CompressedVectorNode. This is required because errors cannot be communicated
-from the CompressedVectorNode destructor (in C++ destructors can't throw
-exceptions). It is not an error to call this function if the
-CompressedVectorWriter is already closed. This function will cause the
-CompressedVectorWriter to enter the closed state, and any further transfers
-requests will fail.
-
-@b Warning: If this function is not called before the CompressedVectorWriter
-destructor is invoked, all writes to the CompressedVectorNode will be lost (it
-will have zero children).
-@pre     The associated ImageFile must be open.
-@post    This CompressedVectorWriter is closed (i.e !isOpen())
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorSeekFailed       This CompressedVectorWriter, associated
-ImageFile in undocumented state
-@throw   ::ErrorReadFailed        This CompressedVectorWriter, associated
-ImageFile in undocumented state
-@throw   ::ErrorWriteFailed       This CompressedVectorWriter, associated
-ImageFile in undocumented state
-@throw   ::ErrorBadChecksum       This CompressedVectorWriter, associated
-ImageFile in undocumented state
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorWriter::isOpen
-*/
-void CompressedVectorWriter::close()
-{
-   impl_->close();
-}
-
-/*!
-@brief   Test whether CompressedVectorWriter is still open for writing.
-@pre     The associated ImageFile must be open.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorWriter::close, CompressedVectorNode::writer
-*/
-bool CompressedVectorWriter::isOpen()
-{
-   return impl_->isOpen();
-}
-
-/*!
-@brief   Return the CompressedVectorNode being written to.
-@pre     The associated ImageFile must be open.
-@return  A smart CompressedVectorNode handle referencing the underlying object
-being written to.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorNode::writer
-*/
-CompressedVectorNode CompressedVectorWriter::compressedVectorNode() const
-{
-   return impl_->compressedVectorNode();
-}
-
-//! @brief   Diagnostic function to print internal state of object to output
-//! stream in an indented format.
-//! @copydetails Node::dump()
-#ifdef E57_DEBUG
-void CompressedVectorWriter::dump( int indent, std::ostream &os ) const
-{
-   impl_->dump( indent, os );
-}
-#else
-void CompressedVectorWriter::dump( int indent, std::ostream &os ) const
-{
-}
-#endif
-
-//! @brief Check whether CompressedVectorWriter class invariant is true
-//! @copydetails CompressedVectorReader::checkInvariant
-// beginExample CompressedVectorWriter::checkInvariant
 void CompressedVectorWriter::checkInvariant( bool /*doRecurse*/ )
 {
    // If this CompressedVectorWriter is not open, can't test invariant (almost
@@ -342,4 +82,250 @@ void CompressedVectorWriter::checkInvariant( bool /*doRecurse*/ )
       throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 }
-// endExample CompressedVectorWriter::checkInvariant
+
+/*!
+@class e57::CompressedVectorWriter
+
+@brief An iterator object keeping track of a write in progress to a CompressedVectorNode.
+
+@details
+A CompressedVectorWriter object is a block iterator that reads blocks of records from memory and
+stores them in a CompressedVectorNode. Blocks of records are processed rather than a single
+record-at-a-time for efficiency reasons. The CompressedVectorWriter class encapsulates all the state
+that must be saved in between the processing of one record block and the next (e.g. partially
+written disk pages, partially filled bytes in a bytestream, or data compression state). New memory
+buffers can be used for each record block write, or the previous buffers can be reused.
+
+CompressedVectorWriter objects have an open/closed state. Initially a newly created
+CompressedVectorWriter is in the open state. After the API user calls CompressedVectorWriter::close,
+the object will be in the closed state and no more data transfers will be possible.
+
+There is no CompressedVectorWriter constructor in the API. The function CompressedVectorNode::writer
+returns an already constructed CompressedVectorWriter object with given memory buffers
+(SourceDestBuffers) already associated. CompressedVectorWriter::close must explicitly be called to
+safely and gracefully end the transfer.
+
+@warning If CompressedVectorWriter::close is not called before the CompressedVectorWriter destructor
+is invoked, all writes to the CompressedVectorNode will be lost (it will have zero children).
+
+@section CompressedVectorWriter_invariant Class Invariant A class invariant is a list of statements
+about an object that are always true before and after any operation on the object. An invariant is
+useful for testing correct operation of an implementation. Statements in an invariant can involve
+only externally visible state, or can refer to internal implementation-specific state that is not
+visible to the API user. The following C++ code checks externally visible state for consistency and
+throws an exception if the invariant is violated:
+
+@dontinclude CompressedVectorWriter.cpp
+@skip void CompressedVectorWriter::checkInvariant
+@until ^}
+
+@see CompressedVectorNode, CompressedVectorReader
+*/
+
+/// @cond documentNonPublic The following isn't part of the API, and isn't documented.
+CompressedVectorWriter::CompressedVectorWriter( std::shared_ptr<CompressedVectorWriterImpl> ni ) :
+   impl_( ni )
+{
+}
+/// @endcond
+
+/*!
+@brief Request transfer of blocks of data to CompressedVectorNode from previously designated source
+buffers.
+
+@param [in] recordCount Number of records to write.
+
+@details
+The SourceDestBuffers used are previously designated either in CompressedVectorNode::writer where
+this object was created, or in the last call to
+CompressedVectorWriter::write(std::vector<SourceDestBuffer>&, unsigned) where new buffers were
+designated.
+
+If a conversion or bounds error occurs during the transfer, the CompressedVectorWriter is left in an
+undocumented state (it can't be used any further), and all previously written records are deleted
+from the associated CompressedVectorNode which will then have zero children. If a file I/O or
+checksum error occurs during the transfer, both this CompressedVectorWriter and the associated
+ImageFile are left in an undocumented state (they can't be used any further). If
+CompressedVectorWriter::close is not called before the CompressedVectorWriter destructor is invoked,
+all writes to the CompressedVectorNode will be lost (it will have zero children).
+
+@pre The associated ImageFile must be open.
+@pre This CompressedVectorWriter must be open (i.e isOpen())
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorWriterNotOpen
+@throw ::ErrorPathUndefined
+@throw ::ErrorNoBufferForElement
+@throw ::ErrorBufferSizeMismatch
+@throw ::ErrorBufferDuplicatePathName
+@throw ::ErrorConversionRequired This CompressedVectorWriter in undocumented state, associated
+CompressedVectorNode modified but consistent, associated ImageFile modified but consistent.
+@throw ::ErrorValueOutOfBounds This CompressedVectorWriter in undocumented state, associated
+CompressedVectorNode modified but consistent, associated ImageFile modified but consistent.
+@throw ::ErrorValueNotRepresentable This CompressedVectorWriter in undocumented state, associated
+CompressedVectorNode modified but consistent, associated ImageFile modified but consistent.
+@throw ::ErrorScaledValueNotRepresentable This CompressedVectorWriter in undocumented state,
+associated CompressedVectorNode modified but consistent, associated ImageFile modified but
+consistent.
+@throw ::ErrorReal64TooLarge This CompressedVectorWriter in undocumented state, associated
+CompressedVectorNode modified but consistent, associated ImageFile modified but consistent.
+@throw ::ErrorExpectingNumeric This CompressedVectorWriter in undocumented state, associated
+CompressedVectorNode modified but consistent, associated ImageFile modified but consistent.
+@throw ::ErrorExpectingUString This CompressedVectorWriter in undocumented state, associated
+CompressedVectorNode modified but consistent, associated ImageFile modified but consistent.
+@throw ::ErrorSeekFailed This CompressedVectorWriter, associated ImageFile in undocumented state
+@throw ::ErrorReadFailed This CompressedVectorWriter, associated ImageFile in undocumented state
+@throw ::ErrorWriteFailed This CompressedVectorWriter, associated ImageFile in undocumented state
+@throw ::ErrorBadChecksum This CompressedVectorWriter, associated ImageFile in undocumented state
+@throw ::ErrorInternal All objects in undocumented state
+
+@see CompressedVectorWriter::write(std::vector<SourceDestBuffer>&,unsigned),
+CompressedVectorNode::writer, CompressedVectorWriter::close, SourceDestBuffer, E57Exception
+*/
+void CompressedVectorWriter::write( const size_t recordCount )
+{
+   impl_->write( recordCount );
+}
+
+/*!
+@brief Request transfer of block of data to CompressedVectorNode from given source buffers.
+
+@param [in] sbufs Vector of memory buffers that hold data to be written to a CompressedVectorNode.
+@param [in] recordCount Number of records to write.
+
+@details
+The @a sbufs must all have the same capacity.
+
+The @a sbufs capacity must be >= @a recordCount.
+
+The specified @a sbufs must have same number of elements as previously designated SourceDestBuffer
+vector. The each SourceDestBuffer within @a sbufs must be identical to the previously designated
+SourceDestBuffer except for capacity and buffer address.
+
+The @a sbufs locations are saved so that a later call to CompressedVectorWriter::write(unsigned) can
+be used without having to re-specify the SourceDestBuffers.
+
+If a conversion or bounds error occurs during the transfer, the CompressedVectorWriter is left in an
+undocumented state (it can't be used any further), and all previously written records are deleted
+from the the associated CompressedVectorNode which will then have zero children. If a file I/O or
+checksum error occurs during the transfer, both this CompressedVectorWriter and the associated
+ImageFile are left in an undocumented state (they can't be used any further).
+
+@warning If CompressedVectorWriter::close is not called before the CompressedVectorWriter destructor
+is invoked, all writes to the CompressedVectorNode will be lost (it will have zero children).
+
+@pre The associated ImageFile must be open.
+@pre This CompressedVectorWriter must be open (i.e isOpen())
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorWriterNotOpen
+@throw ::ErrorPathUndefined
+@throw ::ErrorNoBufferForElement
+@throw ::ErrorBufferSizeMismatch
+@throw ::ErrorBufferDuplicatePathName
+@throw ::ErrorConversionRequired This CompressedVectorWriter in undocumented state, associated
+ImageFile modified but consistent.
+@throw ::ErrorValueOutOfBounds This CompressedVectorWriter in undocumented state, associated
+ImageFile modified but consistent.
+@throw ::ErrorValueNotRepresentable This CompressedVectorWriter in undocumented state, associated
+ImageFile modified but consistent.
+@throw ::ErrorScaledValueNotRepresentable This CompressedVectorWriter in undocumented state,
+associated ImageFile modified but consistent.
+@throw ::ErrorReal64TooLarge This CompressedVectorWriter in undocumented state, associated ImageFile
+modified but consistent.
+@throw ::ErrorExpectingNumeric This CompressedVectorWriter in undocumented state, associated
+ImageFile modified but consistent.
+@throw ::ErrorExpectingUString This CompressedVectorWriter in undocumented state, associated
+ImageFile modified but consistent.
+@throw ::ErrorSeekFailed This CompressedVectorWriter, associated ImageFile in undocumented state
+@throw ::ErrorReadFailed This CompressedVectorWriter, associated ImageFile in undocumented state
+@throw ::ErrorWriteFailed This CompressedVectorWriter, associated ImageFile in undocumented state
+@throw ::ErrorBadChecksum This CompressedVectorWriter, associated ImageFile in undocumented state
+@throw ::ErrorInternal All objects in undocumented state
+
+@see CompressedVectorWriter::write(unsigned), CompressedVectorNode::writer,
+CompressedVectorWriter::close, SourceDestBuffer, E57Exception
+*/
+void CompressedVectorWriter::write( std::vector<SourceDestBuffer> &sbufs, const size_t recordCount )
+{
+   impl_->write( sbufs, recordCount );
+}
+
+/*!
+@brief End the write operation.
+
+@details
+This function must be called to safely and gracefully end a transfer to a CompressedVectorNode. This
+is required because errors cannot be communicated from the CompressedVectorNode destructor (in C++
+destructors can't throw exceptions). It is not an error to call this function if the
+CompressedVectorWriter is already closed. This function will cause the CompressedVectorWriter to
+enter the closed state, and any further transfers requests will fail.
+
+@warning If this function is not called before the CompressedVectorWriter destructor is invoked, all
+writes to the CompressedVectorNode will be lost (it will have zero children).
+
+@pre The associated ImageFile must be open.
+@post This CompressedVectorWriter is closed (i.e !isOpen())
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorSeekFailed This CompressedVectorWriter, associated ImageFile in undocumented state
+@throw ::ErrorReadFailed  This CompressedVectorWriter, associated ImageFile in undocumented state
+@throw ::ErrorWriteFailed This CompressedVectorWriter, associated ImageFile in undocumented state
+@throw ::ErrorBadChecksum This CompressedVectorWriter, associated ImageFile in undocumented state
+@throw ::ErrorInternal All objects in undocumented state
+
+@see CompressedVectorWriter::isOpen
+*/
+void CompressedVectorWriter::close()
+{
+   impl_->close();
+}
+
+/*!
+@brief Test whether CompressedVectorWriter is still open for writing.
+
+@pre The associated ImageFile must be open.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see CompressedVectorWriter::close, CompressedVectorNode::writer
+*/
+bool CompressedVectorWriter::isOpen()
+{
+   return impl_->isOpen();
+}
+
+/*!
+@brief Return the CompressedVectorNode being written to.
+
+@pre The associated ImageFile must be open.
+
+@return A smart CompressedVectorNode handle referencing the underlying object being written to.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see CompressedVectorNode::writer
+*/
+CompressedVectorNode CompressedVectorWriter::compressedVectorNode() const
+{
+   return impl_->compressedVectorNode();
+}
+
+/*!
+@brief Diagnostic function to print internal state of object to output stream in an indented format.
+@copydetails Node::dump()
+*/
+#ifdef E57_DEBUG
+void CompressedVectorWriter::dump( int indent, std::ostream &os ) const
+{
+   impl_->dump( indent, os );
+}
+#else
+void CompressedVectorWriter::dump( int indent, std::ostream &os ) const
+{
+}
+#endif

--- a/src/CompressedVectorWriterImpl.h
+++ b/src/CompressedVectorWriterImpl.h
@@ -34,8 +34,10 @@ namespace e57
    class CompressedVectorWriterImpl
    {
    public:
-      CompressedVectorWriterImpl( std::shared_ptr<CompressedVectorNodeImpl> ni, std::vector<SourceDestBuffer> &sbufs );
+      CompressedVectorWriterImpl( std::shared_ptr<CompressedVectorNodeImpl> ni,
+                                  std::vector<SourceDestBuffer> &sbufs );
       ~CompressedVectorWriterImpl();
+
       void write( size_t requestedRecordCount );
       void write( std::vector<SourceDestBuffer> &sbufs, size_t requestedRecordCount );
       bool isOpen() const;
@@ -47,15 +49,15 @@ namespace e57
 #endif
 
    private:
-      void checkImageFileOpen( const char *srcFileName, int srcLineNumber, const char *srcFunctionName ) const;
-      void checkWriterOpen( const char *srcFileName, int srcLineNumber, const char *srcFunctionName ) const;
+      void checkImageFileOpen( const char *srcFileName, int srcLineNumber,
+                               const char *srcFunctionName ) const;
+      void checkWriterOpen( const char *srcFileName, int srcLineNumber,
+                            const char *srcFunctionName ) const;
       void setBuffers( std::vector<SourceDestBuffer> &sbufs ); //???needed?
       size_t totalOutputAvailable() const;
       size_t currentPacketSize() const;
       uint64_t packetWrite();
       void flush();
-
-      //??? no default ctor, copy, assignment?
 
       std::vector<SourceDestBuffer> sbufs_;
       std::shared_ptr<CompressedVectorNodeImpl> cVector_;

--- a/src/DecodeChannel.cpp
+++ b/src/DecodeChannel.cpp
@@ -45,25 +45,25 @@ namespace e57
 
    bool DecodeChannel::isOutputBlocked() const
    {
-      /// If we have completed the entire vector, we are done
+      // If we have completed the entire vector, we are done
       if ( decoder->totalRecordsCompleted() >= maxRecordCount )
       {
          return ( true );
       }
 
-      /// If we have filled the dest buffer, we are blocked
+      // If we have filled the dest buffer, we are blocked
       return ( dbuf.impl()->nextIndex() == dbuf.impl()->capacity() );
    }
 
    bool DecodeChannel::isInputBlocked() const
    {
-      /// If have read until the section end, we are done
+      // If have read until the section end, we are done
       if ( inputFinished )
       {
          return ( true );
       }
 
-      /// If have eaten all the input in the current packet, we are blocked.
+      // If have eaten all the input in the current packet, we are blocked.
       return ( currentBytestreamBufferIndex == currentBytestreamBufferLength );
    }
 
@@ -78,9 +78,12 @@ namespace e57
 
       os << space( indent ) << "bytestreamNumber:              " << bytestreamNumber << std::endl;
       os << space( indent ) << "maxRecordCount:                " << maxRecordCount << std::endl;
-      os << space( indent ) << "currentPacketLogicalOffset:    " << currentPacketLogicalOffset << std::endl;
-      os << space( indent ) << "currentBytestreamBufferIndex:  " << currentBytestreamBufferIndex << std::endl;
-      os << space( indent ) << "currentBytestreamBufferLength: " << currentBytestreamBufferLength << std::endl;
+      os << space( indent ) << "currentPacketLogicalOffset:    " << currentPacketLogicalOffset
+         << std::endl;
+      os << space( indent ) << "currentBytestreamBufferIndex:  " << currentBytestreamBufferIndex
+         << std::endl;
+      os << space( indent ) << "currentBytestreamBufferLength: " << currentBytestreamBufferLength
+         << std::endl;
       os << space( indent ) << "inputFinished:                 " << inputFinished << std::endl;
       os << space( indent ) << "isInputBlocked():              " << isInputBlocked() << std::endl;
       os << space( indent ) << "isOutputBlocked():             " << isOutputBlocked() << std::endl;

--- a/src/DecodeChannel.h
+++ b/src/DecodeChannel.h
@@ -34,7 +34,7 @@ namespace e57
 
    struct DecodeChannel
    {
-      SourceDestBuffer dbuf; //??? for now, one input per channel
+      SourceDestBuffer dbuf;
       std::shared_ptr<Decoder> decoder;
       unsigned bytestreamNumber;
       uint64_t maxRecordCount;
@@ -43,8 +43,8 @@ namespace e57
       size_t currentBytestreamBufferLength;
       bool inputFinished;
 
-      DecodeChannel( SourceDestBuffer dbuf_arg, std::shared_ptr<Decoder> decoder_arg, unsigned bytestreamNumber_arg,
-                     uint64_t maxRecordCount_arg );
+      DecodeChannel( SourceDestBuffer dbuf_arg, std::shared_ptr<Decoder> decoder_arg,
+                     unsigned bytestreamNumber_arg, uint64_t maxRecordCount_arg );
 
       bool isOutputBlocked() const;
       bool isInputBlocked() const; /// has exhausted data in the current packet

--- a/src/Decoder.cpp
+++ b/src/Decoder.cpp
@@ -41,11 +41,12 @@ using namespace e57;
 
 std::shared_ptr<Decoder> Decoder::DecoderFactory( unsigned bytestreamNumber, //!!! name ok?
                                                   const CompressedVectorNodeImpl *cVector,
-                                                  std::vector<SourceDestBuffer> &dbufs, const ustring & /*codecPath*/ )
+                                                  std::vector<SourceDestBuffer> &dbufs,
+                                                  const ustring & /*codecPath*/ )
 {
-   //!!! verify single dbuf
+   // !!! verify single dbuf
 
-   /// Get node we are going to decode from the CompressedVector's prototype
+   // Get node we are going to decode from the CompressedVector's prototype
    NodeImplSharedPtr prototype = cVector->getPrototype();
    ustring path = dbufs.at( 0 ).pathName();
    NodeImplSharedPtr decodeNode = prototype->get( path );
@@ -64,99 +65,106 @@ std::shared_ptr<Decoder> Decoder::DecoderFactory( unsigned bytestreamNumber, //!
          std::shared_ptr<IntegerNodeImpl> ini =
             std::static_pointer_cast<IntegerNodeImpl>( decodeNode ); // downcast to correct type
 
-         /// Get pointer to parent ImageFileImpl, to call bitsNeeded()
-         ImageFileImplSharedPtr imf( decodeNode->destImageFile_ ); //??? should be function for this,
-                                                                   // imf->parentFile()
-                                                                   //--> ImageFile?
+         // Get pointer to parent ImageFileImpl, to call bitsNeeded()
+         ImageFileImplSharedPtr imf(
+            decodeNode->destImageFile_ ); //??? should be function for this,
+                                          // imf->parentFile()
+                                          //--> ImageFile?
 
          unsigned bitsPerRecord = imf->bitsNeeded( ini->minimum(), ini->maximum() );
 
-         //!!! need to pick smarter channel buffer sizes, here and elsewhere
-         /// Construct Integer decoder with appropriate register size, based on
-         /// number of bits stored.
+         // !!! need to pick smarter channel buffer sizes, here and elsewhere
+         // Construct Integer decoder with appropriate register size, based on
+         // number of bits stored.
          if ( bitsPerRecord == 0 )
          {
-            std::shared_ptr<Decoder> decoder( new ConstantIntegerDecoder( false, bytestreamNumber, dbufs.at( 0 ),
-                                                                          ini->minimum(), 1.0, 0.0, maxRecordCount ) );
+            std::shared_ptr<Decoder> decoder( new ConstantIntegerDecoder(
+               false, bytestreamNumber, dbufs.at( 0 ), ini->minimum(), 1.0, 0.0, maxRecordCount ) );
             return decoder;
          }
 
          if ( bitsPerRecord <= 8 )
          {
             std::shared_ptr<Decoder> decoder( new BitpackIntegerDecoder<uint8_t>(
-               false, bytestreamNumber, dbufs.at( 0 ), ini->minimum(), ini->maximum(), 1.0, 0.0, maxRecordCount ) );
+               false, bytestreamNumber, dbufs.at( 0 ), ini->minimum(), ini->maximum(), 1.0, 0.0,
+               maxRecordCount ) );
             return decoder;
          }
 
          if ( bitsPerRecord <= 16 )
          {
             std::shared_ptr<Decoder> decoder( new BitpackIntegerDecoder<uint16_t>(
-               false, bytestreamNumber, dbufs.at( 0 ), ini->minimum(), ini->maximum(), 1.0, 0.0, maxRecordCount ) );
+               false, bytestreamNumber, dbufs.at( 0 ), ini->minimum(), ini->maximum(), 1.0, 0.0,
+               maxRecordCount ) );
             return decoder;
          }
 
          if ( bitsPerRecord <= 32 )
          {
             std::shared_ptr<Decoder> decoder( new BitpackIntegerDecoder<uint32_t>(
-               false, bytestreamNumber, dbufs.at( 0 ), ini->minimum(), ini->maximum(), 1.0, 0.0, maxRecordCount ) );
+               false, bytestreamNumber, dbufs.at( 0 ), ini->minimum(), ini->maximum(), 1.0, 0.0,
+               maxRecordCount ) );
             return decoder;
          }
 
          std::shared_ptr<Decoder> decoder( new BitpackIntegerDecoder<uint64_t>(
-            false, bytestreamNumber, dbufs.at( 0 ), ini->minimum(), ini->maximum(), 1.0, 0.0, maxRecordCount ) );
+            false, bytestreamNumber, dbufs.at( 0 ), ini->minimum(), ini->maximum(), 1.0, 0.0,
+            maxRecordCount ) );
          return decoder;
       }
 
       case TypeScaledInteger:
       {
          std::shared_ptr<ScaledIntegerNodeImpl> sini =
-            std::static_pointer_cast<ScaledIntegerNodeImpl>( decodeNode ); // downcast to correct type
+            std::static_pointer_cast<ScaledIntegerNodeImpl>(
+               decodeNode ); // downcast to correct type
 
-         /// Get pointer to parent ImageFileImpl, to call bitsNeeded()
-         ImageFileImplSharedPtr imf( decodeNode->destImageFile_ ); //??? should be function for this,
-                                                                   // imf->parentFile()
-                                                                   //--> ImageFile?
+         // Get pointer to parent ImageFileImpl, to call bitsNeeded()
+         ImageFileImplSharedPtr imf(
+            decodeNode->destImageFile_ ); //??? should be function for this,
+                                          // imf->parentFile()
+                                          //--> ImageFile?
 
          unsigned bitsPerRecord = imf->bitsNeeded( sini->minimum(), sini->maximum() );
 
-         //!!! need to pick smarter channel buffer sizes, here and elsewhere
-         /// Construct ScaledInteger dencoder with appropriate register size,
-         /// based on number of bits stored.
+         // !!! need to pick smarter channel buffer sizes, here and elsewhere
+         // Construct ScaledInteger dencoder with appropriate register size,
+         // based on number of bits stored.
          if ( bitsPerRecord == 0 )
          {
-            std::shared_ptr<Decoder> decoder( new ConstantIntegerDecoder( true, bytestreamNumber, dbufs.at( 0 ),
-                                                                          sini->minimum(), sini->scale(),
-                                                                          sini->offset(), maxRecordCount ) );
+            std::shared_ptr<Decoder> decoder(
+               new ConstantIntegerDecoder( true, bytestreamNumber, dbufs.at( 0 ), sini->minimum(),
+                                           sini->scale(), sini->offset(), maxRecordCount ) );
             return decoder;
          }
 
          if ( bitsPerRecord <= 8 )
          {
-            std::shared_ptr<Decoder> decoder(
-               new BitpackIntegerDecoder<uint8_t>( true, bytestreamNumber, dbufs.at( 0 ), sini->minimum(),
-                                                   sini->maximum(), sini->scale(), sini->offset(), maxRecordCount ) );
+            std::shared_ptr<Decoder> decoder( new BitpackIntegerDecoder<uint8_t>(
+               true, bytestreamNumber, dbufs.at( 0 ), sini->minimum(), sini->maximum(),
+               sini->scale(), sini->offset(), maxRecordCount ) );
             return decoder;
          }
 
          if ( bitsPerRecord <= 16 )
          {
-            std::shared_ptr<Decoder> decoder(
-               new BitpackIntegerDecoder<uint16_t>( true, bytestreamNumber, dbufs.at( 0 ), sini->minimum(),
-                                                    sini->maximum(), sini->scale(), sini->offset(), maxRecordCount ) );
+            std::shared_ptr<Decoder> decoder( new BitpackIntegerDecoder<uint16_t>(
+               true, bytestreamNumber, dbufs.at( 0 ), sini->minimum(), sini->maximum(),
+               sini->scale(), sini->offset(), maxRecordCount ) );
             return decoder;
          }
 
          if ( bitsPerRecord <= 32 )
          {
-            std::shared_ptr<Decoder> decoder(
-               new BitpackIntegerDecoder<uint32_t>( true, bytestreamNumber, dbufs.at( 0 ), sini->minimum(),
-                                                    sini->maximum(), sini->scale(), sini->offset(), maxRecordCount ) );
+            std::shared_ptr<Decoder> decoder( new BitpackIntegerDecoder<uint32_t>(
+               true, bytestreamNumber, dbufs.at( 0 ), sini->minimum(), sini->maximum(),
+               sini->scale(), sini->offset(), maxRecordCount ) );
             return decoder;
          }
 
-         std::shared_ptr<Decoder> decoder(
-            new BitpackIntegerDecoder<uint64_t>( true, bytestreamNumber, dbufs.at( 0 ), sini->minimum(),
-                                                 sini->maximum(), sini->scale(), sini->offset(), maxRecordCount ) );
+         std::shared_ptr<Decoder> decoder( new BitpackIntegerDecoder<uint64_t>(
+            true, bytestreamNumber, dbufs.at( 0 ), sini->minimum(), sini->maximum(), sini->scale(),
+            sini->offset(), maxRecordCount ) );
          return decoder;
       }
 
@@ -165,8 +173,8 @@ std::shared_ptr<Decoder> Decoder::DecoderFactory( unsigned bytestreamNumber, //!
          std::shared_ptr<FloatNodeImpl> fni =
             std::static_pointer_cast<FloatNodeImpl>( decodeNode ); // downcast to correct type
 
-         std::shared_ptr<Decoder> decoder(
-            new BitpackFloatDecoder( bytestreamNumber, dbufs.at( 0 ), fni->precision(), maxRecordCount ) );
+         std::shared_ptr<Decoder> decoder( new BitpackFloatDecoder(
+            bytestreamNumber, dbufs.at( 0 ), fni->precision(), maxRecordCount ) );
          return decoder;
       }
 
@@ -189,12 +197,13 @@ Decoder::Decoder( unsigned bytestreamNumber ) : bytestreamNumber_( bytestreamNum
 {
 }
 
-BitpackDecoder::BitpackDecoder( unsigned bytestreamNumber, SourceDestBuffer &dbuf, unsigned alignmentSize,
-                                uint64_t maxRecordCount ) :
+BitpackDecoder::BitpackDecoder( unsigned bytestreamNumber, SourceDestBuffer &dbuf,
+                                unsigned alignmentSize, uint64_t maxRecordCount ) :
    Decoder( bytestreamNumber ),
    maxRecordCount_( maxRecordCount ), destBuffer_( dbuf.impl() ),
-   inBuffer_( 1024 ), //!!! need to pick smarter channel buffer sizes
-   inBufferAlignmentSize_( alignmentSize ), bitsPerWord_( 8 * alignmentSize ), bytesPerWord_( alignmentSize )
+   inBuffer_( 1024 ), // !!! need to pick smarter channel buffer sizes
+   inBufferAlignmentSize_( alignmentSize ), bitsPerWord_( 8 * alignmentSize ),
+   bytesPerWord_( alignmentSize )
 {
 }
 
@@ -218,17 +227,18 @@ size_t BitpackDecoder::inputProcess( const char *source, const size_t availableB
    size_t bitsEaten = 0;
    do
    {
-      size_t byteCount = std::min( bytesUnsaved, inBuffer_.size() - static_cast<size_t>( inBufferEndByte_ ) );
+      size_t byteCount =
+         std::min( bytesUnsaved, inBuffer_.size() - static_cast<size_t>( inBufferEndByte_ ) );
 
-      /// Copy input bytes from caller, if any
+      // Copy input bytes from caller, if any
       if ( ( byteCount > 0 ) && ( source != nullptr ) )
       {
          memcpy( &inBuffer_[inBufferEndByte_], source, byteCount );
 
-         /// Advance tail pointer.
+         // Advance tail pointer.
          inBufferEndByte_ += byteCount;
 
-         /// Update amount available from caller
+         // Update amount available from caller
          bytesUnsaved -= byteCount;
          source += byteCount;
       }
@@ -238,8 +248,8 @@ size_t BitpackDecoder::inputProcess( const char *source, const size_t availableB
          unsigned firstByte = inBufferFirstBit_ / 8;
          for ( i = 0; i < byteCount && i < 20; i++ )
          {
-            std::cout << "  inBuffer[" << firstByte + i << "]=" << (unsigned)(unsigned char)( inBuffer_[firstByte + i] )
-                      << std::endl;
+            std::cout << "  inBuffer[" << firstByte + i
+                      << "]=" << (unsigned)(unsigned char)( inBuffer_[firstByte + i] ) << std::endl;
          }
          if ( i < byteCount )
          {
@@ -248,44 +258,47 @@ size_t BitpackDecoder::inputProcess( const char *source, const size_t availableB
       }
 #endif
 
-      /// ??? fix doc for new bit interface
-      /// Now that we have input stored in an aligned buffer, call derived class
-      /// to try to eat some Note that end of filled buffer may not be at a
-      /// natural boundary. The subclass may transfer this partial word in a
-      /// full word transfer, but it must be careful to only use the defined
-      /// bits. inBuffer_ is a multiple of largest word size, so this full word
-      /// transfer off the end will always be in defined memory.
+      // ??? fix doc for new bit interface
+      // Now that we have input stored in an aligned buffer, call derived class
+      // to try to eat some Note that end of filled buffer may not be at a
+      // natural boundary. The subclass may transfer this partial word in a
+      // full word transfer, but it must be careful to only use the defined
+      // bits. inBuffer_ is a multiple of largest word size, so this full word
+      // transfer off the end will always be in defined memory.
 
       size_t firstWord = inBufferFirstBit_ / bitsPerWord_;
       size_t firstNaturalBit = firstWord * bitsPerWord_;
       size_t endBit = inBufferEndByte_ * 8;
 #ifdef E57_MAX_VERBOSE
-      std::cout << "  feeding aligned decoder " << endBit - inBufferFirstBit_ << " bits." << std::endl;
+      std::cout << "  feeding aligned decoder " << endBit - inBufferFirstBit_ << " bits."
+                << std::endl;
 #endif
-      bitsEaten = inputProcessAligned( &inBuffer_[firstWord * bytesPerWord_], inBufferFirstBit_ - firstNaturalBit,
-                                       endBit - firstNaturalBit );
+      bitsEaten =
+         inputProcessAligned( &inBuffer_[firstWord * bytesPerWord_],
+                              inBufferFirstBit_ - firstNaturalBit, endBit - firstNaturalBit );
 #ifdef E57_MAX_VERBOSE
-      std::cout << "  bitsEaten=" << bitsEaten << " firstWord=" << firstWord << " firstNaturalBit=" << firstNaturalBit
-                << " endBit=" << endBit << std::endl;
+      std::cout << "  bitsEaten=" << bitsEaten << " firstWord=" << firstWord
+                << " firstNaturalBit=" << firstNaturalBit << " endBit=" << endBit << std::endl;
 #endif
 #ifdef E57_DEBUG
       if ( bitsEaten > endBit - inBufferFirstBit_ )
       {
-         throw E57_EXCEPTION2( ErrorInternal, "bitsEaten=" + toString( bitsEaten ) + " endBit=" + toString( endBit ) +
-                                                 " inBufferFirstBit=" + toString( inBufferFirstBit_ ) );
+         throw E57_EXCEPTION2(
+            ErrorInternal, "bitsEaten=" + toString( bitsEaten ) + " endBit=" + toString( endBit ) +
+                              " inBufferFirstBit=" + toString( inBufferFirstBit_ ) );
       }
 #endif
       inBufferFirstBit_ += bitsEaten;
 
-      /// Shift uneaten data to beginning of inBuffer_, keep on natural word
-      /// boundaries.
+      // Shift uneaten data to beginning of inBuffer_, keep on natural word
+      // boundaries.
       inBufferShiftDown();
 
-      /// If the lower level processing didn't eat anything on this iteration,
-      /// stop looping and tell caller how much we ate or stored.
+      // If the lower level processing didn't eat anything on this iteration,
+      // stop looping and tell caller how much we ate or stored.
    } while ( bytesUnsaved > 0 && bitsEaten > 0 );
 
-   /// Return the number of bytes we ate/saved.
+   // Return the number of bytes we ate/saved.
    return ( availableByteCount - bytesUnsaved );
 }
 
@@ -297,9 +310,9 @@ void BitpackDecoder::stateReset()
 
 void BitpackDecoder::inBufferShiftDown()
 {
-   /// Move uneaten data down to beginning of inBuffer_.
-   /// Keep on natural boundaries.
-   /// Moves all of word that contains inBufferFirstBit.
+   // Move uneaten data down to beginning of inBuffer_.
+   // Keep on natural boundaries.
+   // Moves all of word that contains inBufferFirstBit.
    size_t firstWord = inBufferFirstBit_ / bitsPerWord_;
    size_t firstNaturalByte = firstWord * bytesPerWord_;
 #ifdef E57_DEBUG
@@ -313,10 +326,10 @@ void BitpackDecoder::inBufferShiftDown()
    if ( byteCount > 0 )
    {
       memmove( &inBuffer_[0], &inBuffer_[firstNaturalByte],
-               byteCount ); /// Overlapping regions ok with memmove().
+               byteCount ); // Overlapping regions ok with memmove().
    }
 
-   /// Update indexes
+   // Update indexes
    inBufferEndByte_ = byteCount;
    inBufferFirstBit_ = inBufferFirstBit_ % bitsPerWord_;
 }
@@ -339,7 +352,8 @@ void BitpackDecoder::dump( int indent, std::ostream &os )
    for ( i = 0; i < inBuffer_.size() && i < 20; i++ )
    {
       os << space( indent + 4 ) << "inBuffer[" << i
-         << "]: " << static_cast<unsigned>( static_cast<unsigned char>( inBuffer_.at( i ) ) ) << std::endl;
+         << "]: " << static_cast<unsigned>( static_cast<unsigned char>( inBuffer_.at( i ) ) )
+         << std::endl;
    }
    if ( i < inBuffer_.size() )
    {
@@ -350,22 +364,25 @@ void BitpackDecoder::dump( int indent, std::ostream &os )
 
 //================================================================
 
-BitpackFloatDecoder::BitpackFloatDecoder( unsigned bytestreamNumber, SourceDestBuffer &dbuf, FloatPrecision precision,
-                                          uint64_t maxRecordCount ) :
-   BitpackDecoder( bytestreamNumber, dbuf, ( precision == PrecisionSingle ) ? sizeof( float ) : sizeof( double ),
+BitpackFloatDecoder::BitpackFloatDecoder( unsigned bytestreamNumber, SourceDestBuffer &dbuf,
+                                          FloatPrecision precision, uint64_t maxRecordCount ) :
+   BitpackDecoder( bytestreamNumber, dbuf,
+                   ( precision == PrecisionSingle ) ? sizeof( float ) : sizeof( double ),
                    maxRecordCount ),
    precision_( precision )
 {
 }
 
-size_t BitpackFloatDecoder::inputProcessAligned( const char *inbuf, const size_t firstBit, const size_t endBit )
+size_t BitpackFloatDecoder::inputProcessAligned( const char *inbuf, const size_t firstBit,
+                                                 const size_t endBit )
 {
 #ifdef E57_MAX_VERBOSE
-   std::cout << "BitpackFloatDecoder::inputProcessAligned() called, inbuf=" << reinterpret_cast<const void *>( inbuf )
-             << " firstBit=" << firstBit << " endBit=" << endBit << std::endl;
+   std::cout << "BitpackFloatDecoder::inputProcessAligned() called, inbuf="
+             << reinterpret_cast<const void *>( inbuf ) << " firstBit=" << firstBit
+             << " endBit=" << endBit << std::endl;
 #endif
-   /// Read from inbuf, decode, store in destBuffer
-   /// Repeat until have filled destBuffer, or completed all records
+   // Read from inbuf, decode, store in destBuffer
+   // Repeat until have filled destBuffer, or completed all records
 
    size_t n = destBuffer_->capacity() - destBuffer_->nextIndex();
 
@@ -374,24 +391,24 @@ size_t BitpackFloatDecoder::inputProcessAligned( const char *inbuf, const size_t
 #ifdef E57_DEBUG
 #if 0 // I know no way to do this portably <rs>
    // Deactivate for now until a better solution is found.
-   /// Verify that inbuf is naturally aligned to correct boundary (4 or 8 bytes).  Base class should be doing this for us.
+   // Verify that inbuf is naturally aligned to correct boundary (4 or 8 bytes).  Base class should be doing this for us.
    if (reinterpret_cast<unsigned>(inbuf) % typeSize) {
       throw E57_EXCEPTION2(ErrorInternal,
                            "inbuf=" + toString(reinterpret_cast<unsigned>(inbuf))
                            + " typeSize=" + toString(typeSize));
    }
 #endif
-   /// Verify first bit is zero
+   // Verify first bit is zero
    if ( firstBit != 0 )
    {
       throw E57_EXCEPTION2( ErrorInternal, "firstBit=" + toString( firstBit ) );
    }
 #endif
 
-   /// Calc how many whole records worth of data we have in inbuf
+   // Calc how many whole records worth of data we have in inbuf
    size_t maxInputRecords = ( endBit - firstBit ) / ( 8 * typeSize );
 
-   /// Can't process more records than we have input data for.
+   // Can't process more records than we have input data for.
    if ( n > maxInputRecords )
    {
       n = maxInputRecords;
@@ -409,10 +426,10 @@ size_t BitpackFloatDecoder::inputProcessAligned( const char *inbuf, const size_t
 
    if ( precision_ == PrecisionSingle )
    {
-      /// Form the starting address for first data location in inBuffer
+      // Form the starting address for first data location in inBuffer
       auto inp = reinterpret_cast<const float *>( inbuf );
 
-      /// Copy floats from inbuf to destBuffer_
+      // Copy floats from inbuf to destBuffer_
       for ( unsigned i = 0; i < n; i++ )
       {
          float value = *inp;
@@ -425,11 +442,11 @@ size_t BitpackFloatDecoder::inputProcessAligned( const char *inbuf, const size_t
       }
    }
    else
-   { /// Double precision
-      /// Form the starting address for first data location in inBuffer
+   { // Double precision
+      // Form the starting address for first data location in inBuffer
       auto inp = reinterpret_cast<const double *>( inbuf );
 
-      /// Copy doubles from inbuf to destBuffer_
+      // Copy doubles from inbuf to destBuffer_
       for ( unsigned i = 0; i < n; i++ )
       {
          double value = *inp;
@@ -442,10 +459,10 @@ size_t BitpackFloatDecoder::inputProcessAligned( const char *inbuf, const size_t
       }
    }
 
-   /// Update counts of records processed
+   // Update counts of records processed
    currentRecordIndex_ += n;
 
-   /// Returned number of bits processed  (always a multiple of alignment size).
+   // Returned number of bits processed  (always a multiple of alignment size).
    return ( n * 8 * typeSize );
 }
 
@@ -472,42 +489,45 @@ BitpackStringDecoder::BitpackStringDecoder( unsigned bytestreamNumber, SourceDes
 {
 }
 
-size_t BitpackStringDecoder::inputProcessAligned( const char *inbuf, const size_t firstBit, const size_t endBit )
+size_t BitpackStringDecoder::inputProcessAligned( const char *inbuf, const size_t firstBit,
+                                                  const size_t endBit )
 {
 #ifdef E57_MAX_VERBOSE
-   std::cout << "BitpackStringDecoder::inputProcessAligned() called, inbuf=" << inbuf << " firstBit=" << firstBit
-             << " endBit=" << endBit << std::endl;
+   std::cout << "BitpackStringDecoder::inputProcessAligned() called, inbuf=" << inbuf
+             << " firstBit=" << firstBit << " endBit=" << endBit << std::endl;
 #endif
-   /// Read from inbuf, decode, store in destBuffer
-   /// Repeat until have filled destBuffer, or completed all records
+   // Read from inbuf, decode, store in destBuffer
+   // Repeat until have filled destBuffer, or completed all records
 
 #ifdef E57_DEBUG
-   /// Verify first bit is zero (always byte-aligned)
+   // Verify first bit is zero (always byte-aligned)
    if ( firstBit != 0 )
    {
       throw E57_EXCEPTION2( ErrorInternal, "firstBit=" + toString( firstBit ) );
    }
 #endif
 
-   /// Converts start/end bits to whole bytes
+   // Converts start/end bits to whole bytes
    size_t nBytesAvailable = ( endBit - firstBit ) >> 3;
    size_t nBytesRead = 0;
 
-   /// Loop until we've finished all the records, or ran out of input currently
-   /// available
+   // Loop until we've finished all the records, or ran out of input currently
+   // available
    while ( currentRecordIndex_ < maxRecordCount_ && nBytesRead < nBytesAvailable )
    {
 #ifdef E57_MAX_VERBOSE
-      std::cout << "read string loop1: readingPrefix=" << readingPrefix_ << " prefixLength=" << prefixLength_
-                << " nBytesPrefixRead=" << nBytesPrefixRead_ << " nBytesStringRead=" << nBytesStringRead_ << std::endl;
+      std::cout << "read string loop1: readingPrefix=" << readingPrefix_
+                << " prefixLength=" << prefixLength_ << " nBytesPrefixRead=" << nBytesPrefixRead_
+                << " nBytesStringRead=" << nBytesStringRead_ << std::endl;
 #endif
       if ( readingPrefix_ )
       {
-         /// Try to read more prefix bytes
-         while ( nBytesRead < nBytesAvailable && ( nBytesPrefixRead_ == 0 || nBytesPrefixRead_ < prefixLength_ ) )
+         // Try to read more prefix bytes
+         while ( nBytesRead < nBytesAvailable &&
+                 ( nBytesPrefixRead_ == 0 || nBytesPrefixRead_ < prefixLength_ ) )
          {
-            /// If first byte of prefix, test the least significant bit to see
-            /// how long prefix is
+            // If first byte of prefix, test the least significant bit to see
+            // how long prefix is
             if ( nBytesPrefixRead_ == 0 )
             {
                if ( *inbuf & 0x01 )
@@ -520,33 +540,33 @@ size_t BitpackStringDecoder::inputProcessAligned( const char *inbuf, const size_
                }
             }
 
-            /// Accumulate prefix bytes
+            // Accumulate prefix bytes
             prefixBytes_[nBytesPrefixRead_] = *inbuf++;
             nBytesPrefixRead_++;
             nBytesRead++;
          }
 
 #ifdef E57_MAX_VERBOSE
-         std::cout << "read string loop2: readingPrefix=" << readingPrefix_ << " prefixLength=" << prefixLength_
-                   << " nBytesPrefixRead=" << nBytesPrefixRead_ << " nBytesStringRead=" << nBytesStringRead_
-                   << std::endl;
+         std::cout << "read string loop2: readingPrefix=" << readingPrefix_
+                   << " prefixLength=" << prefixLength_ << " nBytesPrefixRead=" << nBytesPrefixRead_
+                   << " nBytesStringRead=" << nBytesStringRead_ << std::endl;
 #endif
-         /// If got all of prefix, convert to length and get ready to read
-         /// string
+         // If got all of prefix, convert to length and get ready to read
+         // string
          if ( nBytesPrefixRead_ > 0 && nBytesPrefixRead_ == prefixLength_ )
          {
             if ( prefixLength_ == 1 )
             {
-               /// Single byte prefix, extract length from b7-b1.
-               /// Removing the least significant bit (which says this is a
-               /// short prefix).
+               // Single byte prefix, extract length from b7-b1.
+               // Removing the least significant bit (which says this is a
+               // short prefix).
                stringLength_ = static_cast<uint64_t>( prefixBytes_[0] >> 1 );
             }
             else
             {
-               /// Eight byte prefix, extract length from b63-b1. Little endian
-               /// ordering. Removing the least significant bit (which says this
-               /// is a long prefix).
+               // Eight byte prefix, extract length from b63-b1. Little endian
+               // ordering. Removing the least significant bit (which says this
+               // is a long prefix).
                stringLength_ = ( static_cast<uint64_t>( prefixBytes_[0] ) >> 1 ) +
                                ( static_cast<uint64_t>( prefixBytes_[1] ) << ( 1 * 8 - 1 ) ) +
                                ( static_cast<uint64_t>( prefixBytes_[2] ) << ( 2 * 8 - 1 ) ) +
@@ -556,7 +576,7 @@ size_t BitpackStringDecoder::inputProcessAligned( const char *inbuf, const size_
                                ( static_cast<uint64_t>( prefixBytes_[6] ) << ( 6 * 8 - 1 ) ) +
                                ( static_cast<uint64_t>( prefixBytes_[7] ) << ( 7 * 8 - 1 ) );
             }
-            /// Get ready to read string contents
+            // Get ready to read string contents
             readingPrefix_ = false;
             prefixLength_ = 1;
             memset( prefixBytes_, 0, sizeof( prefixBytes_ ) );
@@ -565,40 +585,40 @@ size_t BitpackStringDecoder::inputProcessAligned( const char *inbuf, const size_
             nBytesStringRead_ = 0;
          }
 #ifdef E57_MAX_VERBOSE
-         std::cout << "read string loop3: readingPrefix=" << readingPrefix_ << " prefixLength=" << prefixLength_
-                   << " nBytesPrefixRead=" << nBytesPrefixRead_ << " nBytesStringRead=" << nBytesStringRead_
-                   << std::endl;
+         std::cout << "read string loop3: readingPrefix=" << readingPrefix_
+                   << " prefixLength=" << prefixLength_ << " nBytesPrefixRead=" << nBytesPrefixRead_
+                   << " nBytesStringRead=" << nBytesStringRead_ << std::endl;
 #endif
       }
 
-      /// If currently reading string contents, keep doing it until have
-      /// complete string
+      // If currently reading string contents, keep doing it until have
+      // complete string
       if ( !readingPrefix_ )
       {
-         /// Calc how many bytes we need to complete current string
+         // Calc how many bytes we need to complete current string
          uint64_t nBytesNeeded = stringLength_ - nBytesStringRead_;
 
-         /// Can process the smaller of unread or needed bytes
+         // Can process the smaller of unread or needed bytes
          size_t nBytesProcess = nBytesAvailable - nBytesRead;
          if ( nBytesNeeded < static_cast<uint64_t>( nBytesProcess ) )
          {
             nBytesProcess = static_cast<unsigned>( nBytesNeeded );
          }
 
-         /// Append to current string and update counts
+         // Append to current string and update counts
          currentString_ += ustring( inbuf, nBytesProcess );
          inbuf += nBytesProcess;
          nBytesRead += nBytesProcess;
          nBytesStringRead_ += nBytesProcess;
 
-         /// Check if completed reading the string contents
+         // Check if completed reading the string contents
          if ( nBytesStringRead_ == stringLength_ )
          {
-            /// Save accumulated string to dest buffer
+            // Save accumulated string to dest buffer
             destBuffer_->setNextString( currentString_ );
             currentRecordIndex_++;
 
-            /// Get ready to read next prefix
+            // Get ready to read next prefix
             readingPrefix_ = true;
             prefixLength_ = 1;
             memset( prefixBytes_, 0, sizeof( prefixBytes_ ) );
@@ -610,7 +630,7 @@ size_t BitpackStringDecoder::inputProcessAligned( const char *inbuf, const size_
       }
    }
 
-   /// Returned number of bits processed  (always a multiple of alignment size).
+   // Returned number of bits processed  (always a multiple of alignment size).
    return ( nBytesRead * 8 );
 }
 
@@ -620,11 +640,12 @@ void BitpackStringDecoder::dump( int indent, std::ostream &os )
    BitpackDecoder::dump( indent, os );
    os << space( indent ) << "readingPrefix:      " << readingPrefix_ << std::endl;
    os << space( indent ) << "prefixLength:       " << prefixLength_ << std::endl;
-   os << space( indent ) << "prefixBytes[8]:     " << static_cast<unsigned>( prefixBytes_[0] ) << " "
-      << static_cast<unsigned>( prefixBytes_[1] ) << " " << static_cast<unsigned>( prefixBytes_[2] ) << " "
-      << static_cast<unsigned>( prefixBytes_[3] ) << " " << static_cast<unsigned>( prefixBytes_[4] ) << " "
-      << static_cast<unsigned>( prefixBytes_[5] ) << " " << static_cast<unsigned>( prefixBytes_[6] ) << " "
-      << static_cast<unsigned>( prefixBytes_[7] ) << std::endl;
+   os << space( indent ) << "prefixBytes[8]:     " << static_cast<unsigned>( prefixBytes_[0] )
+      << " " << static_cast<unsigned>( prefixBytes_[1] ) << " "
+      << static_cast<unsigned>( prefixBytes_[2] ) << " " << static_cast<unsigned>( prefixBytes_[3] )
+      << " " << static_cast<unsigned>( prefixBytes_[4] ) << " "
+      << static_cast<unsigned>( prefixBytes_[5] ) << " " << static_cast<unsigned>( prefixBytes_[6] )
+      << " " << static_cast<unsigned>( prefixBytes_[7] ) << std::endl;
    os << space( indent ) << "nBytesPrefixRead:   " << nBytesPrefixRead_ << std::endl;
    os << space( indent ) << "stringLength:       " << stringLength_ << std::endl;
    os << space( indent )
@@ -641,22 +662,27 @@ void BitpackStringDecoder::dump( int indent, std::ostream &os )
 //================================================================
 
 template <typename RegisterT>
-BitpackIntegerDecoder<RegisterT>::BitpackIntegerDecoder( bool isScaledInteger, unsigned bytestreamNumber,
-                                                         SourceDestBuffer &dbuf, int64_t minimum, int64_t maximum,
-                                                         double scale, double offset, uint64_t maxRecordCount ) :
+BitpackIntegerDecoder<RegisterT>::BitpackIntegerDecoder( bool isScaledInteger,
+                                                         unsigned bytestreamNumber,
+                                                         SourceDestBuffer &dbuf, int64_t minimum,
+                                                         int64_t maximum, double scale,
+                                                         double offset, uint64_t maxRecordCount ) :
    BitpackDecoder( bytestreamNumber, dbuf, sizeof( RegisterT ), maxRecordCount ),
-   isScaledInteger_( isScaledInteger ), minimum_( minimum ), maximum_( maximum ), scale_( scale ), offset_( offset )
+   isScaledInteger_( isScaledInteger ), minimum_( minimum ), maximum_( maximum ), scale_( scale ),
+   offset_( offset )
 {
-   /// Get pointer to parent ImageFileImpl
+   // Get pointer to parent ImageFileImpl
    ImageFileImplSharedPtr imf( dbuf.impl()->destImageFile() ); //??? should be function for this,
                                                                // imf->parentFile()  --> ImageFile?
 
    bitsPerRecord_ = imf->bitsNeeded( minimum_, maximum_ );
-   destBitMask_ = ( bitsPerRecord_ == 64 ) ? ~0 : static_cast<RegisterT>( 1ULL << bitsPerRecord_ ) - 1;
+   destBitMask_ =
+      ( bitsPerRecord_ == 64 ) ? ~0 : static_cast<RegisterT>( 1ULL << bitsPerRecord_ ) - 1;
 }
 
 template <typename RegisterT>
-size_t BitpackIntegerDecoder<RegisterT>::inputProcessAligned( const char *inbuf, const size_t firstBit,
+size_t BitpackIntegerDecoder<RegisterT>::inputProcessAligned( const char *inbuf,
+                                                              const size_t firstBit,
                                                               const size_t endBit )
 {
 #ifdef E57_MAX_VERBOSE
@@ -664,17 +690,17 @@ size_t BitpackIntegerDecoder<RegisterT>::inputProcessAligned( const char *inbuf,
              << " firstBit=" << firstBit << " endBit=" << endBit << std::endl;
 #endif
 
-   /// Read from inbuf, decode, store in destBuffer
-   /// Repeat until have filled destBuffer, or completed all records
+   // Read from inbuf, decode, store in destBuffer
+   // Repeat until have filled destBuffer, or completed all records
 
 #ifdef E57_DEBUG
 #if 0 // I know now way to do this portably
    // Deactivate for now until a better solution is found.
-   /// Verify that inbuf is naturally aligned to RegisterT boundary (1, 2, 4,or 8 bytes).  Base class is doing this for us.
+   // Verify that inbuf is naturally aligned to RegisterT boundary (1, 2, 4,or 8 bytes).  Base class is doing this for us.
    if ((reinterpret_cast<unsigned>(inbuf)) % sizeof(RegisterT))
       throw E57_EXCEPTION2(ErrorInternal, "inbuf=" + toString(reinterpret_cast<unsigned>(inbuf)));
 #endif
-   /// Verify first bit is in first word
+   // Verify first bit is in first word
    if ( firstBit >= 8 * sizeof( RegisterT ) )
    {
       throw E57_EXCEPTION2( ErrorInternal, "firstBit=" + toString( firstBit ) );
@@ -683,14 +709,14 @@ size_t BitpackIntegerDecoder<RegisterT>::inputProcessAligned( const char *inbuf,
 
    size_t destRecords = destBuffer_->capacity() - destBuffer_->nextIndex();
 
-   /// Precalculate exact number of full records that are in inbuf
-   /// We can handle the case where don't have a full word at end of inbuf, but
-   /// all the bits of the record are there;
+   // Precalculate exact number of full records that are in inbuf
+   // We can handle the case where don't have a full word at end of inbuf, but
+   // all the bits of the record are there;
    size_t bitCount = endBit - firstBit;
    size_t maxInputRecords = bitCount / bitsPerRecord_;
 
-   /// Number of transfers is the smaller of what was requested and what is
-   /// available in input.
+   // Number of transfers is the smaller of what was requested and what is
+   // available in input.
    size_t recordCount = std::min( destRecords, maxInputRecords );
 
    // Can't process more than defined in input file
@@ -704,25 +730,25 @@ size_t BitpackIntegerDecoder<RegisterT>::inputProcessAligned( const char *inbuf,
 #endif
 
    auto inp = reinterpret_cast<const RegisterT *>( inbuf );
-   unsigned wordPosition = 0; /// The index in inbuf of the word we are currently working on.
+   unsigned wordPosition = 0; // The index in inbuf of the word we are currently working on.
 
    // clang-format off
-   /// For example on little endian machine:
-   /// Assume: registerT=uint32_t, bitOffset=20, destBitMask=0x00007fff (for a 15 bit value).
-   /// inp[wordPosition]                    LLLLLLLL LLLLXXXX XXXXXXXX XXXXXXXX   Note LSB of value is at bit20
-   /// inp(wordPosition+1]                  XXXXXXXX XXXXXXXX XXXXXXXX XXXXXHHH   H=high bits of value, X=uninteresting bits
-   /// low = inp[i] >> bitOffset            00000000 00000000 0000LLLL LLLLLLLL   L=low bits of value, X=uninteresting bits
-   /// high = inp[i+1] << (32-bitOffset)    XXXXXXXX XXXXXXXX XHHH0000 00000000
-   /// w = high | low                       XXXXXXXX XXXXXXXX XHHHLLLL LLLLLLLL
-   /// destBitmask                          00000000 00000000 01111111 11111111
-   /// w & mask                             00000000 00000000 0HHHLLLL LLLLLLLL
+   // For example on little endian machine:
+   // Assume: registerT=uint32_t, bitOffset=20, destBitMask=0x00007fff (for a 15 bit value).
+   // inp[wordPosition]                    LLLLLLLL LLLLXXXX XXXXXXXX XXXXXXXX   Note LSB of value is at bit20
+   // inp(wordPosition+1]                  XXXXXXXX XXXXXXXX XXXXXXXX XXXXXHHH   H=high bits of value, X=uninteresting bits
+   // low = inp[i] >> bitOffset            00000000 00000000 0000LLLL LLLLLLLL   L=low bits of value, X=uninteresting bits
+   // high = inp[i+1] << (32-bitOffset)    XXXXXXXX XXXXXXXX XHHH0000 00000000
+   // w = high | low                       XXXXXXXX XXXXXXXX XHHHLLLL LLLLLLLL
+   // destBitmask                          00000000 00000000 01111111 11111111
+   // w & mask                             00000000 00000000 0HHHLLLL LLLLLLLL
    // clang-format on
 
    size_t bitOffset = firstBit;
 
    for ( size_t i = 0; i < recordCount; i++ )
    {
-      /// Get lower word (contains at least the LSbit of the value),
+      // Get lower word (contains at least the LSbit of the value),
       RegisterT low = inp[wordPosition];
 
 #ifdef E57_MAX_VERBOSE
@@ -733,8 +759,8 @@ size_t BitpackIntegerDecoder<RegisterT>::inputProcessAligned( const char *inbuf,
       RegisterT w;
       if ( bitOffset == 0 )
       {
-         /// The left shift (used below) is not defined if shift is >= size of
-         /// word
+         // The left shift (used below) is not defined if shift is >= size of
+         // word
          w = low;
       }
       // Avoid reading the next word, unless it is needed
@@ -745,16 +771,16 @@ size_t BitpackIntegerDecoder<RegisterT>::inputProcessAligned( const char *inbuf,
       }
       else
       {
-         /// Get upper word (may or may not contain interesting bits),
+         // Get upper word (may or may not contain interesting bits),
          RegisterT high = inp[wordPosition + 1];
 
 #ifdef E57_MAX_VERBOSE
          std::cout << "  high:" << binaryString( high ) << std::endl;
 #endif
 
-         /// Shift high to just above the lower bits, shift low LSBit to bit0,
-         /// OR together. Note shifts are logical (not arithmetic) because using
-         /// unsigned variables.
+         // Shift high to just above the lower bits, shift low LSBit to bit0,
+         // OR together. Note shifts are logical (not arithmetic) because using
+         // unsigned variables.
          w = ( high << ( RegisterBits - bitOffset ) ) | ( low >> bitOffset );
       }
 
@@ -762,18 +788,18 @@ size_t BitpackIntegerDecoder<RegisterT>::inputProcessAligned( const char *inbuf,
       std::cout << "  w:   " << binaryString( w ) << std::endl;
 #endif
 
-      /// Mask off uninteresting bits
+      // Mask off uninteresting bits
       w &= destBitMask_;
 
-      /// Add minimum_ to value to get back what writer originally sent
+      // Add minimum_ to value to get back what writer originally sent
       int64_t value = minimum_ + static_cast<uint64_t>( w );
 
 #ifdef E57_MAX_VERBOSE
       std::cout << "  Storing value=" << value << std::endl;
 #endif
 
-      /// The parameter isScaledInteger_ determines which version of
-      /// setNextInt64 gets called
+      // The parameter isScaledInteger_ determines which version of
+      // setNextInt64 gets called
       if ( isScaledInteger_ )
       {
          destBuffer_->setNextInt64( value, scale_, offset_ );
@@ -783,9 +809,9 @@ size_t BitpackIntegerDecoder<RegisterT>::inputProcessAligned( const char *inbuf,
          destBuffer_->setNextInt64( value );
       }
 
-      /// Store the result in next available position in the user's dest buffer
+      // Store the result in next available position in the user's dest buffer
 
-      /// Calc next bit alignment and which word it starts in
+      // Calc next bit alignment and which word it starts in
       bitOffset += bitsPerRecord_;
       if ( bitOffset >= 8 * sizeof( RegisterT ) )
       {
@@ -793,20 +819,22 @@ size_t BitpackIntegerDecoder<RegisterT>::inputProcessAligned( const char *inbuf,
          wordPosition++;
       }
 #ifdef E57_MAX_VERBOSE
-      std::cout << "  Processed " << i + 1 << " records, wordPosition=" << wordPosition << " decoder:" << std::endl;
+      std::cout << "  Processed " << i + 1 << " records, wordPosition=" << wordPosition
+                << " decoder:" << std::endl;
       dump( 4 );
 #endif
    }
 
-   /// Update counts of records processed
+   // Update counts of records processed
    currentRecordIndex_ += recordCount;
 
-   /// Return number of bits processed.
+   // Return number of bits processed.
    return ( recordCount * bitsPerRecord_ );
 }
 
 #ifdef E57_DEBUG
-template <typename RegisterT> void BitpackIntegerDecoder<RegisterT>::dump( int indent, std::ostream &os )
+template <typename RegisterT>
+void BitpackIntegerDecoder<RegisterT>::dump( int indent, std::ostream &os )
 {
    BitpackDecoder::dump( indent, os );
    os << space( indent ) << "isScaledInteger:  " << isScaledInteger_ << std::endl;
@@ -815,19 +843,20 @@ template <typename RegisterT> void BitpackIntegerDecoder<RegisterT>::dump( int i
    os << space( indent ) << "scale:            " << scale_ << std::endl;
    os << space( indent ) << "offset:           " << offset_ << std::endl;
    os << space( indent ) << "bitsPerRecord:    " << bitsPerRecord_ << std::endl;
-   os << space( indent ) << "destBitMask:      " << binaryString( destBitMask_ ) << " = " << hexString( destBitMask_ )
-      << std::endl;
+   os << space( indent ) << "destBitMask:      " << binaryString( destBitMask_ ) << " = "
+      << hexString( destBitMask_ ) << std::endl;
 }
 #endif
 
 //================================================================
 
-ConstantIntegerDecoder::ConstantIntegerDecoder( bool isScaledInteger, unsigned bytestreamNumber, SourceDestBuffer &dbuf,
-                                                int64_t minimum, double scale, double offset,
+ConstantIntegerDecoder::ConstantIntegerDecoder( bool isScaledInteger, unsigned bytestreamNumber,
+                                                SourceDestBuffer &dbuf, int64_t minimum,
+                                                double scale, double offset,
                                                 uint64_t maxRecordCount ) :
    Decoder( bytestreamNumber ),
-   maxRecordCount_( maxRecordCount ), destBuffer_( dbuf.impl() ), isScaledInteger_( isScaledInteger ),
-   minimum_( minimum ), scale_( scale ), offset_( offset )
+   maxRecordCount_( maxRecordCount ), destBuffer_( dbuf.impl() ),
+   isScaledInteger_( isScaledInteger ), minimum_( minimum ), scale_( scale ), offset_( offset )
 {
 }
 
@@ -848,10 +877,10 @@ size_t ConstantIntegerDecoder::inputProcess( const char *source, const size_t av
              << " availableByteCount=" << availableByteCount << std::endl;
 #endif
 
-   /// We don't need any input bytes to produce output, so ignore source and
-   /// availableByteCount.
+   // We don't need any input bytes to produce output, so ignore source and
+   // availableByteCount.
 
-   /// Fill dest buffer unless get to maxRecordCount
+   // Fill dest buffer unless get to maxRecordCount
    size_t count = destBuffer_->capacity() - destBuffer_->nextIndex();
    uint64_t remainingRecordCount = maxRecordCount_ - currentRecordIndex_;
    if ( static_cast<uint64_t>( count ) > remainingRecordCount )

--- a/src/Decoder.h
+++ b/src/Decoder.h
@@ -36,7 +36,8 @@ namespace e57
    public:
       static std::shared_ptr<Decoder> DecoderFactory( unsigned bytestreamNumber,
                                                       const CompressedVectorNodeImpl *cVector,
-                                                      std::vector<SourceDestBuffer> &dbufs, const ustring &codecPath );
+                                                      std::vector<SourceDestBuffer> &dbufs,
+                                                      const ustring &codecPath );
       Decoder() = delete;
       virtual ~Decoder() = default;
 
@@ -49,6 +50,7 @@ namespace e57
       {
          return bytestreamNumber_;
       }
+
 #ifdef E57_DEBUG
       virtual void dump( int indent = 0, std::ostream &os = std::cout ) = 0;
 #endif
@@ -77,6 +79,7 @@ namespace e57
 #ifdef E57_DEBUG
       void dump( int indent = 0, std::ostream &os = std::cout ) override;
 #endif
+
    protected:
       BitpackDecoder( unsigned bytestreamNumber, SourceDestBuffer &dbuf, unsigned alignmentSize,
                       uint64_t maxRecordCount );
@@ -99,14 +102,15 @@ namespace e57
    class BitpackFloatDecoder : public BitpackDecoder
    {
    public:
-      BitpackFloatDecoder( unsigned bytestreamNumber, SourceDestBuffer &dbuf, FloatPrecision precision,
-                           uint64_t maxRecordCount );
+      BitpackFloatDecoder( unsigned bytestreamNumber, SourceDestBuffer &dbuf,
+                           FloatPrecision precision, uint64_t maxRecordCount );
 
       size_t inputProcessAligned( const char *inbuf, size_t firstBit, size_t endBit ) override;
 
 #ifdef E57_DEBUG
       void dump( int indent = 0, std::ostream &os = std::cout ) override;
 #endif
+
    protected:
       FloatPrecision precision_ = PrecisionSingle;
    };
@@ -114,13 +118,15 @@ namespace e57
    class BitpackStringDecoder : public BitpackDecoder
    {
    public:
-      BitpackStringDecoder( unsigned bytestreamNumber, SourceDestBuffer &dbuf, uint64_t maxRecordCount );
+      BitpackStringDecoder( unsigned bytestreamNumber, SourceDestBuffer &dbuf,
+                            uint64_t maxRecordCount );
 
       size_t inputProcessAligned( const char *inbuf, size_t firstBit, size_t endBit ) override;
 
 #ifdef E57_DEBUG
       void dump( int indent = 0, std::ostream &os = std::cout ) override;
 #endif
+
    protected:
       bool readingPrefix_ = true;
       int prefixLength_ = 1;
@@ -134,14 +140,16 @@ namespace e57
    template <typename RegisterT> class BitpackIntegerDecoder : public BitpackDecoder
    {
    public:
-      BitpackIntegerDecoder( bool isScaledInteger, unsigned bytestreamNumber, SourceDestBuffer &dbuf, int64_t minimum,
-                             int64_t maximum, double scale, double offset, uint64_t maxRecordCount );
+      BitpackIntegerDecoder( bool isScaledInteger, unsigned bytestreamNumber,
+                             SourceDestBuffer &dbuf, int64_t minimum, int64_t maximum, double scale,
+                             double offset, uint64_t maxRecordCount );
 
       size_t inputProcessAligned( const char *inbuf, size_t firstBit, size_t endBit ) override;
 
 #ifdef E57_DEBUG
       void dump( int indent = 0, std::ostream &os = std::cout ) override;
 #endif
+
    protected:
       bool isScaledInteger_;
       int64_t minimum_;
@@ -156,8 +164,9 @@ namespace e57
    class ConstantIntegerDecoder : public Decoder
    {
    public:
-      ConstantIntegerDecoder( bool isScaledInteger, unsigned bytestreamNumber, SourceDestBuffer &dbuf, int64_t minimum,
-                              double scale, double offset, uint64_t maxRecordCount );
+      ConstantIntegerDecoder( bool isScaledInteger, unsigned bytestreamNumber,
+                              SourceDestBuffer &dbuf, int64_t minimum, double scale, double offset,
+                              uint64_t maxRecordCount );
       void destBufferSetNew( std::vector<SourceDestBuffer> &dbufs ) override;
 
       uint64_t totalRecordsCompleted() override
@@ -167,9 +176,11 @@ namespace e57
 
       size_t inputProcess( const char *source, size_t availableByteCount ) override;
       void stateReset() override;
+
 #ifdef E57_DEBUG
       void dump( int indent = 0, std::ostream &os = std::cout ) override;
 #endif
+
    protected:
       uint64_t currentRecordIndex_ = 0;
       uint64_t maxRecordCount_;

--- a/src/E57Exception.cpp
+++ b/src/E57Exception.cpp
@@ -32,95 +32,90 @@ namespace e57
 {
    /*!
    @class E57Exception
-   @brief   Object thrown by E57 API functions to communicate the conditions of an
-   error.
+
+   @brief Object thrown by E57 API functions to communicate the conditions of an error.
+
    @details
-   The E57Exception object communicates information about errors occurring in calls
-   to the E57 API functions. The error information is communicated from the
-   location in the E57 implementation where the error was detected to the @c catch
-   statement in the code of the API user. The state of E57Exception object has one
-   mandatory field, the errorCode, and several optional fields that can be set
-   depending on the debug level of the E57 implementation. There are three optional
-   fields that encode the location in the source code of the E57 implementation
-   where the error was detected: @c sourceFileName, @c sourceFunctionName, and @c
-   sourceLineNumber. Another optional field is the @c context string that is human
-   (or at least programmer) readable, which can capture some variable values that
-   might be useful in debugging. The E57Exception class is derived from
-   std::exception. So applications that only catch std::exceptions will detect
-   E57Exceptions (but with no information about the origin of the error).
+   The E57Exception object communicates information about errors occurring in calls to the E57 API
+   functions. The error information is communicated from the location in the E57 implementation
+   where the error was detected to the @c catch statement in the code of the API user. The state of
+   E57Exception object has one mandatory field, the errorCode, and several optional fields that can
+   be set depending on the debug level of the E57 implementation. There are three optional fields
+   that encode the location in the source code of the E57 implementation where the error was
+   detected: @c sourceFileName, @c sourceFunctionName, and @c sourceLineNumber. Another optional
+   field is the @c context string that is human (or at least programmer) readable, which can capture
+   some variable values that might be useful in debugging. The E57Exception class is derived from
+   std::exception. So applications that only catch std::exceptions will detect E57Exceptions (but
+   with no information about the origin of the error).
 
-   Many other APIs use error codes (defined integer constants) returned from the
-   API functions to communicate success or failure of the requested command. In
-   contrast, the E57 API uses the C++ exception mechanism to communicate failure
-   (success is communicated by the return of the function without exception).
-   ::Success is never thrown. The API ErrorCode is packaged inside
-   the E57Exception. The documentation for each function in the API declares which
-   ErrorCode values (inside an E57Exception) can possibly be thrown by the
-   function. Some API functions do not throw any E57Exceptions, and this is
-   documented by the designation "No E57Exceptions." in the "Exceptions:" section
-   of the function documentation page.
+   Many other APIs use error codes (defined integer constants) returned from the API functions to
+   communicate success or failure of the requested command. In contrast, the E57 API uses the C++
+   exception mechanism to communicate failure (success is communicated by the return of the function
+   without exception). ::Success is never thrown. The API ErrorCode is packaged inside the
+   E57Exception. The documentation for each function in the API declares which ErrorCode values
+   (inside an E57Exception) can possibly be thrown by the function. Some API functions do not throw
+   any E57Exceptions, and this is documented by the designation "No E57Exceptions." in the
+   "Exceptions:" section of the function documentation page.
 
-   If an API function does throw an E57Exception, the API user will rightfully be
-   concerned about the state of all of the API objects. There are four categories
-   of guarantee about the state of all objects that the API specifies.
+   If an API function does throw an E57Exception, the API user will rightfully be concerned about
+   the state of all of the API objects. There are four categories of guarantee about the state of
+   all objects that the API specifies.
 
-   1) <b>All objects unchanged</b> - all API objects are left in their original
-   state before the API function was called. This is the default guarantee, so if
-   there is no notation next to the ErrorCode in the "Exceptions:" section of the
-   function documentation page, the this category is implied.
+   1) <b>All objects unchanged</b> - all API objects are left in their original state before the API
+   function was called. This is the default guarantee, so if there is no notation next to the
+   ErrorCode in the "Exceptions:" section of the function documentation page, the this category is
+   implied.
 
-   2) <b>XXX object modified, but consistent</b> - The given object (or objects)
-   have been modified, but are left in a consistent state.
+   2) <b>XXX object modified, but consistent</b> - The given object (or objects) have been modified,
+   but are left in a consistent state.
 
-   3) <b>XXX object in undocumented state</b> - The given object (or objects) may
-   have been left in an inconsistent state, and the only safe thing to do with them
-   is to call their destructor.
+   3) <b>XXX object in undocumented state</b> - The given object (or objects) may have been left in
+   an inconsistent state, and the only safe thing to do with them is to call their destructor.
 
-   4) <b>All objects in undocumented state</b> - A very serious consistency error
-   has been detected, and the state of all API objects is suspect.  The only safe
-   thing to do is to call their destructors.
+   4) <b>All objects in undocumented state</b> - A very serious consistency error has been detected,
+   and the state of all API objects is suspect.  The only safe thing to do is to call their
+   destructors.
 
-   Almost all of the API functions can throw the following two ErrorCodes:
-   ::ErrorImageFileNotOpen and ::ErrorInternal. In some E57
-   implementations, the tree information may be stored on disk rather than in
-   memory. If the disk file is closed, even the most basic information may not be
-   available about nodes in the tree. So if the ImageFile is closed (by calling
-   ImageFile::close), the API user must be ready for many of the API functions to
-   throw ::ErrorImageFileNotOpen. Secondly, regarding the
-   ErrorInternal error, there is a lot of consistency checking in the
-   Reference Implementation, and there may be much more added. Even if some API
-   routines do not now throw ::ErrorInternal, they could some time in the
-   future, or in different implementations. So the right to throw
-   ::ErrorInternal is reserved for every API function (except those that by
+   Almost all of the API functions can throw the following two ErrorCodes: ::ErrorImageFileNotOpen
+   and ::ErrorInternal. In some E57 implementations, the tree information may be stored on disk
+   rather than in memory. If the disk file is closed, even the most basic information may not be
+   available about nodes in the tree. So if the ImageFile is closed (by calling ImageFile::close),
+   the API user must be ready for many of the API functions to throw ::ErrorImageFileNotOpen.
+   Secondly, regarding the ErrorInternal error, there is a lot of consistency checking in the
+   Reference Implementation, and there may be much more added. Even if some API routines do not now
+   throw ::ErrorInternal, they could some time in the future, or in different implementations. So
+   the right to throw ::ErrorInternal is reserved for every API function (except those that by
    design can't throw E57Exceptions).
 
-   It is strongly recommended that catch statements in user code that call API
-   functions catch E57Exception by reference (i.e. <tt>catch (E57Exception&
-   ex)</tt> and, if necessary, rethrow using the syntax that throws the currently
-   active exception (i.e. <tt>throw;</tt>).
+   It is strongly recommended that catch statements in user code that call API functions catch
+   E57Exception by reference (i.e. <tt>catch (E57Exception& ex)</tt> and, if necessary, rethrow
+   using the syntax that throws the currently active exception (i.e. <tt>throw;</tt>).
 
-   Exceptions other that E57Exception may be thrown by calls to API functions (e.g.
-   std::bad_alloc). Production code will likely have catch handlers for these
-   exceptions as well.
+   Exceptions other that E57Exception may be thrown by calls to API functions (e.g. std::bad_alloc).
+   Production code will likely have catch handlers for these exceptions as well.
    */
 
-   //! @cond documentNonPublic   The following isn't part of the API, and isn't
-   //! documented.
-   E57Exception::E57Exception( ErrorCode ecode, std::string context, const char *srcFileName, int srcLineNumber,
-                               const char *srcFunctionName ) :
+   /// @cond documentNonPublic   The following isn't part of the API, and isn't documented.
+   E57Exception::E57Exception( ErrorCode ecode, std::string context, const char *srcFileName,
+                               int srcLineNumber, const char *srcFunctionName ) :
       errorCode_( ecode ),
-      context_( std::move( context ) ), sourceFileName_( srcFileName ), sourceFunctionName_( srcFunctionName ),
-      sourceLineNumber_( srcLineNumber )
+      context_( std::move( context ) ), sourceFileName_( srcFileName ),
+      sourceFunctionName_( srcFunctionName ), sourceLineNumber_( srcLineNumber )
    {
    }
-   //! @endcond
+   /// @endcond
 
    /*!
-   @brief   Get string description of exception category.
-   @details Returns "E57 Exception" for all E57Exceptions, no matter what the errorCode.
-   @post    No visible state is modified.
-   @return  The string description of exception category.
-   @throw   No E57Exceptions.
+   @brief Get string description of exception category.
+
+   @details
+   Returns "E57 Exception" for all E57Exceptions, no matter what the errorCode.
+
+   @post No visible state is modified.
+
+   @return The string description of exception category.
+
+   @throw No E57Exceptions.
    */
    const char *E57Exception::what() const noexcept
    {
@@ -128,24 +123,29 @@ namespace e57
    }
 
    /*!
-   @brief   Print error information on a given output stream.
-   @param   [in] reportingFileName     Name of file where catch statement caught
+   @brief Print error information on a given output stream.
+
+   @param [in] reportingFileName Name of file where catch statement caught the exception. NULL if
+   unknown.
+   @param [in] reportingLineNumber Number of source code line where catch statement caught the
+   exception. 0 if unknown.
+   @param [in] reportingFunctionName String name of function containing catch statement that caught
    the exception. NULL if unknown.
-   @param   [in] reportingLineNumber   Number of source code line where catch
-   statement caught the exception.  0 if unknown.
-   @param   [in] reportingFunctionName String name of function containing catch
-   statement that caught the exception.  NULL if unknown.
-   @param   [in] os Output string to print a summary of exception information and
-   location of catch statement.
+   @param [in] os Output string to print a summary of exception information and location of catch
+   statement.
+
    @details
-   The amount of information printed to output stream may depend on whether the E57
-   implementation was built with debugging enabled.
-   @post    No visible state is modified.
-   @throw   No E57Exceptions.
-   @see     ErrorCode
+   The amount of information printed to output stream may depend on whether the E57 implementation
+   was built with debugging enabled.
+
+   @post No visible state is modified.
+
+   @throw No E57Exceptions.
+
+   @see ErrorCode
    */
-   void E57Exception::report( const char *reportingFileName, int reportingLineNumber, const char *reportingFunctionName,
-                              std::ostream &os ) const noexcept
+   void E57Exception::report( const char *reportingFileName, int reportingLineNumber,
+                              const char *reportingFunctionName, std::ostream &os ) const noexcept
    {
       os << "**** Got an e57 exception: " << errorStr() << std::endl;
 
@@ -160,21 +160,26 @@ namespace e57
 
       /*** Add a line in error message that a smart editor (gnu emacs) can
        * interpret as a link to the source code: */
-      os << sourceFileName_ << "(" << sourceLineNumber_ << ") : error C" << errorCode_ << ":  <--- occurred on"
-         << std::endl;
+      os << sourceFileName_ << "(" << sourceLineNumber_ << ") : error C" << errorCode_
+         << ":  <--- occurred on" << std::endl;
       if ( reportingFileName != nullptr )
       {
-         os << reportingFileName << "(" << reportingLineNumber << ") : error C0:  <--- reported on" << std::endl;
+         os << reportingFileName << "(" << reportingLineNumber << ") : error C0:  <--- reported on"
+            << std::endl;
       }
 #endif
    }
 
    /*!
-   @brief   Get numeric ::ErrorCode associated with the exception.
-   @post    No visible state is modified.
-   @return  The numeric ::ErrorCode associated with the exception.
-   @throw   No E57Exceptions.
-   @see     E57Exception::errorStr, Utilities::errorCodeToString, ErrorCode
+   @brief Get numeric ::ErrorCode associated with the exception.
+
+   @post No visible state is modified.
+
+   @return The numeric ::ErrorCode associated with the exception.
+
+   @throw No E57Exceptions.
+
+   @see E57Exception::errorStr, Utilities::errorCodeToString, ErrorCode
    */
    ErrorCode E57Exception::errorCode() const noexcept
    {
@@ -182,10 +187,13 @@ namespace e57
    }
 
    /*!
-   @brief   Get error string associated with the exception.
-   @post    No visible state is modified.
-   @return  The error string associated with the exception.
-   @throw   No E57Exceptions.
+   @brief Get error string associated with the exception.
+
+   @post No visible state is modified.
+
+   @return The error string associated with the exception.
+
+   @throw No E57Exceptions.
    */
    std::string E57Exception::errorStr() const noexcept
    {
@@ -193,15 +201,18 @@ namespace e57
    }
 
    /*!
-   @brief   Get human-readable string that describes the context of the error.
+   @brief Get human-readable string that describes the context of the error.
+
    @details
-   The context string may include values in object state, or function arguments.
-   The format of the context string is not standardized.
-   However, in the Reference Implementation, many strings contain a sequence of "
-   VARNAME=VARVALUE" fields.
-   @post    No visible state is modified.
-   @return  The human-readable string that describes the context of the error.
-   @throw   No E57Exceptions.
+   The context string may include values in object state, or function arguments. The format of the
+   context string is not standardized. However, in the Reference Implementation, many strings
+   contain a sequence of " VARNAME=VARVALUE" fields.
+
+   @post No visible state is modified.
+
+   @return The human-readable string that describes the context of the error.
+
+   @throw No E57Exceptions.
    */
    std::string E57Exception::context() const noexcept
    {
@@ -209,14 +220,17 @@ namespace e57
    }
 
    /*!
-   @brief   Get name of source file where exception occurred, for debugging.
+   @brief Get name of source file where exception occurred, for debugging.
+
    @details
-   May return the value of the macro variable __FILE__ at the location where the
-   E57Exception was constructed. May return the empty string ("") in some E57
-   implementations.
-   @post    No visible state is modified.
-   @return  The name of source file where exception occurred, for debugging.
-   @throw   No E57Exceptions.
+   May return the value of the macro variable __FILE__ at the location where the E57Exception was
+   constructed. May return the empty string ("") in some E57 implementations.
+
+   @post No visible state is modified.
+
+   @return The name of source file where exception occurred, for debugging.
+
+   @throw No E57Exceptions.
    */
    const char *E57Exception::sourceFileName() const noexcept
    {
@@ -224,16 +238,18 @@ namespace e57
    }
 
    /*!
-   @brief   Get name of function in source code where the error occurred , for
+   @brief Get name of function in source code where the error occurred , for
    debugging.
+
    @details
-   May return the value of the macro variable __FUNCTION__ at the location where
-   the E57Exception was constructed. May return the empty string ("") in some E57
-   implementations.
-   @post    No visible state is modified.
-   @return  The name of source code function where the error occurred , for
-   debugging.
-   @throw   No E57Exceptions.
+   May return the value of the macro variable __FUNCTION__ at the location where the E57Exception
+   was constructed. May return the empty string ("") in some E57 implementations.
+
+   @post No visible state is modified.
+
+   @return The name of source code function where the error occurred , for debugging.
+
+   @throw No E57Exceptions.
    */
    const char *E57Exception::sourceFunctionName() const noexcept
    {
@@ -241,16 +257,17 @@ namespace e57
    }
 
    /*!
-   @brief   Get line number in source code file where exception occurred, for
-   debugging.
+   @brief Get line number in source code file where exception occurred, for debugging.
+
    @details
-   May return the value of the macro variable __LINE__ at the location where the
-   E57Exception was constructed. May return the empty string ("") in some E57
-   implementations.
-   @post    No visible state is modified.
-   @return  The line number in source code file where exception occurred, for
-   debugging.
-   @throw   No E57Exceptions.
+   May return the value of the macro variable __LINE__ at the location where the E57Exception was
+   constructed. May return the empty string ("") in some E57 implementations.
+
+   @post No visible state is modified.
+
+   @return The line number in source code file where exception occurred, for debugging.
+
+   @throw No E57Exceptions.
    */
    int E57Exception::sourceLineNumber() const noexcept
    {
@@ -260,23 +277,23 @@ namespace e57
    //=====================================================================================
 
    /*!
-   @brief   Get the version of ASTM E57 standard that the API implementation
-   supports, and library id string.
-   @param   [out] astmMajor    The major version number of the ASTM E57 standard
-   supported.
-   @param   [out] astmMinor    The minor version number of the ASTM E57 standard
-   supported.
-   @param   [out] libraryId    A string identifying the implementation of the API.
+   @brief Get the version of ASTM E57 standard that the API implementation supports, and library id
+   string.
+
+   @param [out] astmMajor The major version number of the ASTM E57 standard supported.
+   @param [out] astmMinor The minor version number of the ASTM E57 standard supported.
+   @param [out] libraryId A string identifying the implementation of the API.
+
    @details
-   Since the E57 implementation may be dynamically linked underneath the API, the
-   version string for the implementation and the ASTM version that it supports
-   can't be determined at compile-time. This function returns these identifiers
-   from the underlying implementation.
-   @throw   No E57Exceptions.
+   Since the E57 implementation may be dynamically linked underneath the API, the version string for
+   the implementation and the ASTM version that it supports can't be determined at compile-time.
+   This function returns these identifiers from the underlying implementation.
+
+   @throw No E57Exceptions.
    */
    void Utilities::getVersions( int &astmMajor, int &astmMinor, std::string &libraryId )
    {
-      /// REVISION_ID should be passed from compiler command line
+      // REVISION_ID should be passed from compiler command line
 
 #ifndef REVISION_ID
 #error "Need to specify REVISION_ID on command line"
@@ -288,69 +305,61 @@ namespace e57
    }
 
    /*!
-   @brief   Get short string description of an E57 ErrorCode.
-   @param   [in] ecode     The numeric errorCode from an E57Exception.
+   @brief Get short string description of an E57 ErrorCode.
+
+   @param [in] ecode The numeric errorCode from an E57Exception.
+
    @details
    The errorCode is translated into a one-line English string.
-   @return  English std::string describing error.
-   @throw   No E57Exceptions.
-   @see     E57Exception::errorCode
+
+   @return English std::string describing error.
+
+   @throw No E57Exceptions.
+
+   @see E57Exception::errorCode
    */
    std::string Utilities::errorCodeToString( ErrorCode ecode ) noexcept
    {
       switch ( ecode )
       {
-         // N.B.  *** When changing error strings here, remember to update the
-         // Doxygen strings in E57Exception.h ****
          case Success:
             return "operation was successful (Success)";
          case ErrorBadCVHeader:
-            return "a CompressedVector binary header was bad "
-                   "(ErrorBadCVHeader)";
+            return "a CompressedVector binary header was bad (ErrorBadCVHeader)";
          case ErrorBadCVPacket:
-            return "a CompressedVector binary packet was bad "
-                   "(ErrorBadCVPacket)";
+            return "a CompressedVector binary packet was bad (ErrorBadCVPacket)";
          case ErrorChildIndexOutOfBounds:
             return "a numerical index identifying a child was out of bounds "
                    "(ErrorChildIndexOutOfBounds)";
          case ErrorSetTwice:
-            return "attempted to set an existing child element to a new value "
-                   "(ErrorSetTwice)";
+            return "attempted to set an existing child element to a new value (ErrorSetTwice)";
          case ErrorHomogeneousViolation:
-            return "attempted to add an E57 Element that would have made the "
-                   "children of a "
-                   "homogeneous Vector have different types "
-                   "(E57_ERROR_HOMOGENEOUS_VIOLATION)";
+            return "attempted to add an E57 Element that would have made the children of a "
+                   "homogeneous Vector have "
+                   "different types (E57_ERROR_HOMOGENEOUS_VIOLATION)";
          case ErrorValueNotRepresentable:
             return "a value could not be represented in the requested type "
                    "(ErrorValueNotRepresentable)";
          case ErrorScaledValueNotRepresentable:
-            return "after scaling the result could not be represented in the "
-                   "requested type "
+            return "after scaling the result could not be represented in the requested type "
                    "(ErrorScaledValueNotRepresentable)";
          case ErrorReal64TooLarge:
-            return "a 64 bit IEEE float was too large to store in a 32 bit IEEE "
-                   "float "
+            return "a 64 bit IEEE float was too large to store in a 32 bit IEEE float "
                    "(ErrorReal64TooLarge)";
          case ErrorExpectingNumeric:
-            return "Expecting numeric representation in user's buffer, found "
-                   "ustring "
+            return "Expecting numeric representation in user's buffer, found ustring "
                    "(ErrorExpectingNumeric)";
          case ErrorExpectingUString:
-            return "Expecting string representation in user's buffer, found "
-                   "numeric "
+            return "Expecting string representation in user's buffer, found numeric "
                    "(ErrorExpectingUString)";
          case ErrorInternal:
-            return "An unrecoverable inconsistent internal state was detected "
-                   "(ErrorInternal)";
+            return "An unrecoverable inconsistent internal state was detected (ErrorInternal)";
          case ErrorBadXMLFormat:
-            return "E57 primitive not encoded in XML correctly "
-                   "(ErrorBadXMLFormat)";
+            return "E57 primitive not encoded in XML correctly (ErrorBadXMLFormat)";
          case ErrorXMLParser:
             return "XML not well formed (ErrorXMLParser)";
          case ErrorBadAPIArgument:
-            return "bad API function argument provided by user "
-                   "(ErrorBadAPIArgument)";
+            return "bad API function argument provided by user (ErrorBadAPIArgument)";
          case ErrorFileReadOnly:
             return "can't modify read only file (ErrorFileReadOnly)";
          case ErrorBadChecksum:
@@ -366,87 +375,68 @@ namespace e57
          case ErrorSeekFailed:
             return "lseek() failed (ErrorSeekFailed)";
          case ErrorPathUndefined:
-            return "E57 element path well formed but not defined "
-                   "(ErrorPathUndefined)";
+            return "E57 element path well formed but not defined (ErrorPathUndefined)";
          case ErrorBadBuffer:
             return "bad SourceDestBuffer (ErrorBadBuffer)";
          case ErrorNoBufferForElement:
-            return "no buffer specified for an element in CompressedVectorNode "
-                   "during write "
+            return "no buffer specified for an element in CompressedVectorNode during write "
                    "(ErrorNoBufferForElement)";
          case ErrorBufferSizeMismatch:
-            return "SourceDestBuffers not all same size "
-                   "(ErrorBufferSizeMismatch)";
+            return "SourceDestBuffers not all same size (ErrorBufferSizeMismatch)";
          case ErrorBufferDuplicatePathName:
             return "duplicate pathname in CompressedVectorNode read/write "
                    "(ErrorBufferDuplicatePathName)";
          case ErrorBadFileSignature:
-            return "file signature not "
-                   "ASTM-E57"
-                   " (ErrorBadFileSignature)";
+            return "file signature not ASTM-E57 (ErrorBadFileSignature)";
          case ErrorUnknownFileVersion:
             return "incompatible file version (ErrorUnknownFileVersion)";
          case ErrorBadFileLength:
-            return "size in file header not same as actual "
-                   "(ErrorBadFileLength)";
+            return "size in file header not same as actual (ErrorBadFileLength)";
          case ErrorXMLParserInit:
             return "XML parser failed to initialize (ErrorXMLParserInit)";
          case ErrorDuplicateNamespacePrefix:
-            return "namespace prefix already defined "
-                   "(ErrorDuplicateNamespacePrefix)";
+            return "namespace prefix already defined (ErrorDuplicateNamespacePrefix)";
          case ErrorDuplicateNamespaceURI:
-            return "namespace URI already defined "
-                   "(ErrorDuplicateNamespaceURI)";
+            return "namespace URI already defined (ErrorDuplicateNamespaceURI)";
          case ErrorBadPrototype:
-            return "bad prototype in CompressedVectorNode "
-                   "(ErrorBadPrototype)";
+            return "bad prototype in CompressedVectorNode (ErrorBadPrototype)";
          case ErrorBadCodecs:
             return "bad codecs in CompressedVectorNode (ErrorBadCodecs)";
          case ErrorValueOutOfBounds:
-            return "element value out of min/max bounds "
-                   "(ErrorValueOutOfBounds)";
+            return "element value out of min/max bounds (ErrorValueOutOfBounds)";
          case ErrorConversionRequired:
-            return "conversion required to assign element value, but not "
-                   "requested "
+            return "conversion required to assign element value, but not requested "
                    "(ErrorConversionRequired)";
          case ErrorBadPathName:
             return "E57 path name is not well formed (ErrorBadPathName)";
          case ErrorNotImplemented:
             return "functionality not implemented (ErrorNotImplemented)";
          case ErrorBadNodeDowncast:
-            return "bad downcast from Node to specific node type "
-                   "(ErrorBadNodeDowncast)";
+            return "bad downcast from Node to specific node type (ErrorBadNodeDowncast)";
          case ErrorWriterNotOpen:
-            return "CompressedVectorWriter is no longer open "
-                   "(ErrorWriterNotOpen)";
+            return "CompressedVectorWriter is no longer open (ErrorWriterNotOpen)";
          case ErrorReaderNotOpen:
-            return "CompressedVectorReader is no longer open "
-                   "(ErrorReaderNotOpen)";
+            return "CompressedVectorReader is no longer open (ErrorReaderNotOpen)";
          case ErrorNodeUnattached:
-            return "node is not yet attached to tree of ImageFile "
-                   "(ErrorNodeUnattached)";
+            return "node is not yet attached to tree of ImageFile (ErrorNodeUnattached)";
          case ErrorAlreadyHasParent:
             return "node already has a parent (ErrorAlreadyHasParent)";
          case ErrorDifferentDestImageFile:
             return "nodes were constructed with different destImageFiles "
                    "(ErrorDifferentDestImageFile)";
          case ErrorImageFileNotOpen:
-            return "destImageFile is no longer open "
-                   "(ErrorImageFileNotOpen)";
+            return "destImageFile is no longer open (ErrorImageFileNotOpen)";
          case ErrorBuffersNotCompatible:
             return "SourceDestBuffers not compatible with previously given ones "
                    "(ErrorBuffersNotCompatible)";
          case ErrorTooManyWriters:
-            return "too many open CompressedVectorWriters of an ImageFile "
-                   "(ErrorTooManyWriters)";
+            return "too many open CompressedVectorWriters of an ImageFile (ErrorTooManyWriters)";
          case ErrorTooManyReaders:
-            return "too many open CompressedVectorReaders of an ImageFile "
-                   "(ErrorTooManyReaders)";
+            return "too many open CompressedVectorReaders of an ImageFile (ErrorTooManyReaders)";
          case ErrorBadConfiguration:
             return "bad configuration string (ErrorBadConfiguration)";
          case ErrorInvarianceViolation:
-            return "class invariance constraint violation in debug mode "
-                   "(ErrorInvarianceViolation)";
+            return "class invariance constraint violation in debug mode (ErrorInvarianceViolation)";
          case ErrorInvalidNodeType:
             return "an invalid node type was passed in Data3D pointFields";
 

--- a/src/E57SimpleData.cpp
+++ b/src/E57SimpleData.cpp
@@ -2,8 +2,8 @@
 // Copyright (c) 2020 PTC Inc.
 // Copyright (c) 2022 Andy Maloney <asmaloney@gmail.com>
 
-// For M_PI. This needs to be first, otherwise we might already include math header
-// without M_PI and we would get nothing because of the header guards.
+// For M_PI. This needs to be first, otherwise we might already include math header without M_PI and
+// we would get nothing because of the header guards.
 #define _USE_MATH_DEFINES
 #include <cmath>
 
@@ -19,7 +19,8 @@ namespace e57
    {
       if ( inData3D.pointCount < 1 )
       {
-         throw E57_EXCEPTION2( ErrorValueOutOfBounds, "pointCount=" + toString( inData3D.pointCount ) + " minimum=1" );
+         throw E57_EXCEPTION2( ErrorValueOutOfBounds,
+                               "pointCount=" + toString( inData3D.pointCount ) + " minimum=1" );
       }
 
       if ( inData3D.pointFields.pointRangeNodeType == NumericalNodeType::Integer )
@@ -33,7 +34,7 @@ namespace e57
       }
    }
 
-   // To avoid exposing M_PI, we define the constructor here.
+   /// To avoid exposing M_PI, we define the constructor here.
    SphericalBounds::SphericalBounds()
    {
       rangeMinimum = 0.;
@@ -69,14 +70,16 @@ namespace e57
       // THEN make sure the proper floating point type is set
       if ( data3D.pointFields.pointRangeNodeType != NumericalNodeType::ScaledInteger )
       {
-         data3D.pointFields.pointRangeNodeType = ( cIsFloat ? NumericalNodeType::Float : NumericalNodeType::Double );
+         data3D.pointFields.pointRangeNodeType =
+            ( cIsFloat ? NumericalNodeType::Float : NumericalNodeType::Double );
       }
 
       // IF angle node type is not ScaledInteger
       // THEN make sure the proper floating point type is set
       if ( data3D.pointFields.angleNodeType != NumericalNodeType::ScaledInteger )
       {
-         data3D.pointFields.angleNodeType = ( cIsFloat ? NumericalNodeType::Float : NumericalNodeType::Double );
+         data3D.pointFields.angleNodeType =
+            ( cIsFloat ? NumericalNodeType::Float : NumericalNodeType::Double );
       }
 
       const auto cPointCount = data3D.pointCount;

--- a/src/E57SimpleReader.cpp
+++ b/src/E57SimpleReader.cpp
@@ -66,21 +66,24 @@ namespace e57
       return impl_->ReadImage2D( imageIndex, image2DHeader );
    };
 
-   bool Reader::GetImage2DSizes( int64_t imageIndex, Image2DProjection &imageProjection, Image2DType &imageType,
-                                 int64_t &imageWidth, int64_t &imageHeight, int64_t &imageSize,
-                                 Image2DType &imageMaskType, Image2DType &imageVisualType ) const
+   bool Reader::GetImage2DSizes( int64_t imageIndex, Image2DProjection &imageProjection,
+                                 Image2DType &imageType, int64_t &imageWidth, int64_t &imageHeight,
+                                 int64_t &imageSize, Image2DType &imageMaskType,
+                                 Image2DType &imageVisualType ) const
    {
-      return impl_->GetImage2DSizes( imageIndex, imageProjection, imageType, imageWidth, imageHeight, imageSize,
-                                     imageMaskType, imageVisualType );
+      return impl_->GetImage2DSizes( imageIndex, imageProjection, imageType, imageWidth,
+                                     imageHeight, imageSize, imageMaskType, imageVisualType );
    };
 
-   int64_t Reader::ReadImage2DData( int64_t imageIndex, Image2DProjection imageProjection, Image2DType imageType,
-                                    void *pBuffer, int64_t start, int64_t count ) const
+   int64_t Reader::ReadImage2DData( int64_t imageIndex, Image2DProjection imageProjection,
+                                    Image2DType imageType, void *pBuffer, int64_t start,
+                                    int64_t count ) const
    {
       auto *buffer = static_cast<uint8_t *>( pBuffer );
       const auto size = static_cast<size_t>( count );
 
-      const size_t read = impl_->ReadImage2DData( imageIndex, imageProjection, imageType, buffer, start, size );
+      const size_t read =
+         impl_->ReadImage2DData( imageIndex, imageProjection, imageType, buffer, start, size );
 
       return static_cast<int64_t>( read );
    };
@@ -115,16 +118,20 @@ namespace e57
       return impl_->ReadData3D( dataIndex, data3DHeader );
    }
 
-   bool Reader::GetData3DSizes( int64_t dataIndex, int64_t &rowMax, int64_t &columnMax, int64_t &pointsSize,
-                                int64_t &groupsSize, int64_t &countSize, bool &bColumnIndex ) const
+   bool Reader::GetData3DSizes( int64_t dataIndex, int64_t &rowMax, int64_t &columnMax,
+                                int64_t &pointsSize, int64_t &groupsSize, int64_t &countSize,
+                                bool &bColumnIndex ) const
    {
-      return impl_->GetData3DSizes( dataIndex, rowMax, columnMax, pointsSize, groupsSize, countSize, bColumnIndex );
+      return impl_->GetData3DSizes( dataIndex, rowMax, columnMax, pointsSize, groupsSize, countSize,
+                                    bColumnIndex );
    }
 
-   bool Reader::ReadData3DGroupsData( int64_t dataIndex, int64_t groupCount, int64_t *idElementValue,
-                                      int64_t *startPointIndex, int64_t *pointCount ) const
+   bool Reader::ReadData3DGroupsData( int64_t dataIndex, int64_t groupCount,
+                                      int64_t *idElementValue, int64_t *startPointIndex,
+                                      int64_t *pointCount ) const
    {
-      return impl_->ReadData3DGroupsData( dataIndex, groupCount, idElementValue, startPointIndex, pointCount );
+      return impl_->ReadData3DGroupsData( dataIndex, groupCount, idElementValue, startPointIndex,
+                                          pointCount );
    }
 
    CompressedVectorReader Reader::SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,

--- a/src/E57SimpleWriter.cpp
+++ b/src/E57SimpleWriter.cpp
@@ -39,7 +39,8 @@ namespace
    ///   - intensity
    ///   - time stamps
    template <typename COORDTYPE>
-   static void _fillMinMaxData( e57::Data3D &ioData3DHeader, const e57::Data3DPointsData_t<COORDTYPE> &inBuffers )
+   static void _fillMinMaxData( e57::Data3D &ioData3DHeader,
+                                const e57::Data3DPointsData_t<COORDTYPE> &inBuffers )
    {
       static_assert( std::is_floating_point<COORDTYPE>::value, "Floating point type required." );
 
@@ -54,9 +55,9 @@ namespace
       auto pointRangeMinimum = cMax;
       auto pointRangeMaximum = cMin;
 
-      const bool writePointRange = ( pointFields.pointRangeNodeType == e57::NumericalNodeType::ScaledInteger ) &&
-                                   ( pointFields.pointRangeMinimum == cMin ) &&
-                                   ( pointFields.pointRangeMaximum == cMax );
+      const bool writePointRange =
+         ( pointFields.pointRangeNodeType == e57::NumericalNodeType::ScaledInteger ) &&
+         ( pointFields.pointRangeMinimum == cMin ) && ( pointFields.pointRangeMaximum == cMax );
 
       // IF we are using scaled ints for spherical angles
       // AND we haven't set either min or max
@@ -64,8 +65,9 @@ namespace
       auto angleMinimum = cMax;
       auto angleMaximum = cMin;
 
-      const bool writeAngle = ( pointFields.angleNodeType == e57::NumericalNodeType::ScaledInteger ) &&
-                              ( pointFields.angleMinimum == cMin ) && ( pointFields.angleMaximum == cMax );
+      const bool writeAngle =
+         ( pointFields.angleNodeType == e57::NumericalNodeType::ScaledInteger ) &&
+         ( pointFields.angleMinimum == cMin ) && ( pointFields.angleMaximum == cMax );
 
       // IF we are using intesity
       // AND we haven't set either min or max
@@ -82,9 +84,10 @@ namespace
       double timeMinimum = std::numeric_limits<double>::max();
       double timeMaximum = std::numeric_limits<double>::lowest();
 
-      const bool writeTimeStamp = pointFields.timeStampField &&
-                                  ( pointFields.timeNodeType == e57::NumericalNodeType::ScaledInteger ) &&
-                                  ( pointFields.timeMinimum == cMin ) && ( pointFields.timeMaximum == cMax );
+      const bool writeTimeStamp =
+         pointFields.timeStampField &&
+         ( pointFields.timeNodeType == e57::NumericalNodeType::ScaledInteger ) &&
+         ( pointFields.timeMinimum == cMin ) && ( pointFields.timeMaximum == cMax );
 
       // Now run through the points and set the things we need to
       for ( int64_t i = 0; i < ioData3DHeader.pointCount; ++i )
@@ -155,8 +158,10 @@ namespace
          pointFields.timeMaximum = timeMaximum;
       }
    }
-   template void _fillMinMaxData( e57::Data3D &ioData3DHeader, const e57::Data3DPointsData &inBuffers );
-   template void _fillMinMaxData( e57::Data3D &ioData3DHeader, const e57::Data3DPointsData_d &inBuffers );
+   template void _fillMinMaxData( e57::Data3D &ioData3DHeader,
+                                  const e57::Data3DPointsData &inBuffers );
+   template void _fillMinMaxData( e57::Data3D &ioData3DHeader,
+                                  const e57::Data3DPointsData_d &inBuffers );
 }
 
 namespace e57
@@ -182,16 +187,17 @@ namespace e57
       return impl_->Close();
    }
 
-   int64_t Writer::WriteImage2DData( Image2D &image2DHeader, Image2DType imageType, Image2DProjection imageProjection,
-                                     int64_t startPos, void *pBuffer, int64_t byteCount )
+   int64_t Writer::WriteImage2DData( Image2D &image2DHeader, Image2DType imageType,
+                                     Image2DProjection imageProjection, int64_t startPos,
+                                     void *pBuffer, int64_t byteCount )
    {
       auto *buffer = static_cast<uint8_t *>( pBuffer );
       const auto sizeInBytes = static_cast<size_t>( byteCount );
 
       const int64_t imageIndex = impl_->NewImage2D( image2DHeader );
 
-      const size_t written =
-         impl_->WriteImage2DData( imageIndex, imageType, imageProjection, buffer, startPos, sizeInBytes );
+      const size_t written = impl_->WriteImage2DData( imageIndex, imageType, imageProjection,
+                                                      buffer, startPos, sizeInBytes );
 
       return static_cast<int64_t>( written );
    };
@@ -201,13 +207,15 @@ namespace e57
       return impl_->NewImage2D( image2DHeader );
    };
 
-   int64_t Writer::WriteImage2DData( int64_t imageIndex, Image2DType imageType, Image2DProjection imageProjection,
-                                     void *pBuffer, int64_t start, int64_t count )
+   int64_t Writer::WriteImage2DData( int64_t imageIndex, Image2DType imageType,
+                                     Image2DProjection imageProjection, void *pBuffer,
+                                     int64_t start, int64_t count )
    {
       auto *buffer = static_cast<uint8_t *>( pBuffer );
       const auto size = static_cast<size_t>( count );
 
-      const size_t written = impl_->WriteImage2DData( imageIndex, imageType, imageProjection, buffer, start, size );
+      const size_t written =
+         impl_->WriteImage2DData( imageIndex, imageType, imageProjection, buffer, start, size );
 
       return static_cast<int64_t>( written );
    }
@@ -259,10 +267,12 @@ namespace e57
       return impl_->SetUpData3DPointsData( dataIndex, pointCount, buffers );
    }
 
-   bool Writer::WriteData3DGroupsData( int64_t dataIndex, int64_t groupCount, int64_t *idElementValue,
-                                       int64_t *startPointIndex, int64_t *pointCount )
+   bool Writer::WriteData3DGroupsData( int64_t dataIndex, int64_t groupCount,
+                                       int64_t *idElementValue, int64_t *startPointIndex,
+                                       int64_t *pointCount )
    {
-      return impl_->WriteData3DGroupsData( dataIndex, groupCount, idElementValue, startPointIndex, pointCount );
+      return impl_->WriteData3DGroupsData( dataIndex, groupCount, idElementValue, startPointIndex,
+                                           pointCount );
    }
 
    ImageFile Writer::GetRawIMF()

--- a/src/E57XmlParser.cpp
+++ b/src/E57XmlParser.cpp
@@ -51,28 +51,34 @@ using namespace e57;
 using namespace XERCES_CPP_NAMESPACE;
 
 // define convenient constants for the attribute names
-static const XMLCh att_minimum[] = {
-   chLatin_m, chLatin_i, chLatin_n, chLatin_i, chLatin_m, chLatin_u, chLatin_m, chNull
-};
-static const XMLCh att_maximum[] = {
-   chLatin_m, chLatin_a, chLatin_x, chLatin_i, chLatin_m, chLatin_u, chLatin_m, chNull
-};
+static const XMLCh att_minimum[] = { chLatin_m, chLatin_i, chLatin_n, chLatin_i,
+                                     chLatin_m, chLatin_u, chLatin_m, chNull };
+static const XMLCh att_maximum[] = { chLatin_m, chLatin_a, chLatin_x, chLatin_i,
+                                     chLatin_m, chLatin_u, chLatin_m, chNull };
 static const XMLCh att_scale[] = { chLatin_s, chLatin_c, chLatin_a, chLatin_l, chLatin_e, chNull };
-static const XMLCh att_offset[] = { chLatin_o, chLatin_f, chLatin_f, chLatin_s, chLatin_e, chLatin_t, chNull };
+static const XMLCh att_offset[] = { chLatin_o, chLatin_f, chLatin_f, chLatin_s,
+                                    chLatin_e, chLatin_t, chNull };
 static const XMLCh att_precision[] = { chLatin_p, chLatin_r, chLatin_e, chLatin_c, chLatin_i,
                                        chLatin_s, chLatin_i, chLatin_o, chLatin_n, chNull };
 static const XMLCh att_allowHeterogeneousChildren[] = {
-   chLatin_a, chLatin_l, chLatin_l, chLatin_o, chLatin_w, chLatin_H, chLatin_e, chLatin_t, chLatin_e,
-   chLatin_r, chLatin_o, chLatin_g, chLatin_e, chLatin_n, chLatin_e, chLatin_o, chLatin_u, chLatin_s,
-   chLatin_C, chLatin_h, chLatin_i, chLatin_l, chLatin_d, chLatin_r, chLatin_e, chLatin_n, chNull
+   chLatin_a, chLatin_l, chLatin_l, chLatin_o, chLatin_w, chLatin_H, chLatin_e,
+   chLatin_t, chLatin_e, chLatin_r, chLatin_o, chLatin_g, chLatin_e, chLatin_n,
+   chLatin_e, chLatin_o, chLatin_u, chLatin_s, chLatin_C, chLatin_h, chLatin_i,
+   chLatin_l, chLatin_d, chLatin_r, chLatin_e, chLatin_n, chNull
 };
-static const XMLCh att_fileOffset[] = { chLatin_f, chLatin_i, chLatin_l, chLatin_e, chLatin_O, chLatin_f,
-                                        chLatin_f, chLatin_s, chLatin_e, chLatin_t, chNull };
+static const XMLCh att_fileOffset[] = { chLatin_f, chLatin_i, chLatin_l, chLatin_e,
+                                        chLatin_O, chLatin_f, chLatin_f, chLatin_s,
+                                        chLatin_e, chLatin_t, chNull };
 
 static const XMLCh att_type[] = { chLatin_t, chLatin_y, chLatin_p, chLatin_e, chNull };
-static const XMLCh att_length[] = { chLatin_l, chLatin_e, chLatin_n, chLatin_g, chLatin_t, chLatin_h, chNull };
-static const XMLCh att_recordCount[] = { chLatin_r, chLatin_e, chLatin_c, chLatin_o, chLatin_r, chLatin_d,
-                                         chLatin_C, chLatin_o, chLatin_u, chLatin_n, chLatin_t, chNull };
+static const XMLCh att_length[] = { chLatin_l, chLatin_e, chLatin_n, chLatin_g,
+                                    chLatin_t, chLatin_h, chNull };
+static const XMLCh att_recordCount[] = { chLatin_r, chLatin_e, chLatin_c, chLatin_o,
+                                         chLatin_r, chLatin_d, chLatin_C, chLatin_o,
+                                         chLatin_u, chLatin_n, chLatin_t, chNull };
+
+static_assert( std::is_same<size_t, XMLSize_t>::value,
+               "size_t and XMLSize_t should be the same type" );
 
 inline int64_t convertStrToLL( const std::string &inStr )
 {
@@ -117,8 +123,10 @@ private:
    uint64_t logicalPosition_;
 };
 
-E57FileInputStream::E57FileInputStream( CheckedFile *cf, uint64_t logicalStart, uint64_t logicalLength ) :
-   cf_( cf ), logicalStart_( logicalStart ), logicalLength_( logicalLength ), logicalPosition_( logicalStart )
+E57FileInputStream::E57FileInputStream( CheckedFile *cf, uint64_t logicalStart,
+                                        uint64_t logicalLength ) :
+   cf_( cf ),
+   logicalStart_( logicalStart ), logicalLength_( logicalLength ), logicalPosition_( logicalStart )
 {
 }
 
@@ -135,24 +143,22 @@ XMLSize_t E57FileInputStream::readBytes( XMLByte *const toFill, const XMLSize_t 
       return ( 0 );
    }
 
-   /// size_t and XMLSize_t should be compatible, should get compiler warning
-   /// here if not
    size_t maxToRead_size = maxToRead;
 
-   /// Be careful if size_t is smaller than int64_t
+   // Be careful if size_t is smaller than int64_t
    size_t available_size;
    if ( sizeof( size_t ) >= sizeof( int64_t ) )
    {
-      /// size_t is at least as big as int64_t
+      // size_t is at least as big as int64_t
       available_size = static_cast<size_t>( available );
    }
    else
    {
-      /// size_t is smaller than int64_t, Calc max that size_t can hold
+      // size_t is smaller than int64_t, Calc max that size_t can hold
       const int64_t size_max = std::numeric_limits<size_t>::max();
 
-      /// read smaller of size_max, available
-      ///??? redo
+      // read smaller of size_max, available
+      //??? redo
       if ( size_max < available )
       {
          available_size = static_cast<size_t>( size_max );
@@ -174,10 +180,10 @@ XMLSize_t E57FileInputStream::readBytes( XMLByte *const toFill, const XMLSize_t 
 //=============================================================================
 // E57XmlFileInputSource
 
-E57XmlFileInputSource::E57XmlFileInputSource( CheckedFile *cf, uint64_t logicalStart, uint64_t logicalLength ) :
+E57XmlFileInputSource::E57XmlFileInputSource( CheckedFile *cf, uint64_t logicalStart,
+                                              uint64_t logicalLength ) :
    InputSource( "E57File",
-                XMLPlatformUtils::fgMemoryManager ), //??? what if want to use our own
-                                                     // memory
+                XMLPlatformUtils::fgMemoryManager ), //??? what if want to use our own memory
                                                      // manager?, what bufid is good?
    cf_( cf ), logicalStart_( logicalStart ), logicalLength_( logicalLength )
 {
@@ -193,8 +199,8 @@ BinInputStream *E57XmlFileInputSource::makeStream() const
 
 E57XmlParser::ParseInfo::ParseInfo() :
    nodeType( static_cast<NodeType>( 0 ) ), minimum( 0 ), maximum( 0 ), scale( 0 ), offset( 0 ),
-   precision( static_cast<FloatPrecision>( 0 ) ), floatMinimum( 0 ), floatMaximum( 0 ), fileOffset( 0 ), length( 0 ),
-   allowHeterogeneousChildren( false ), recordCount( 0 )
+   precision( static_cast<FloatPrecision>( 0 ) ), floatMinimum( 0 ), floatMaximum( 0 ),
+   fileOffset( 0 ), length( 0 ), allowHeterogeneousChildren( false ), recordCount( 0 )
 {
 }
 
@@ -210,7 +216,8 @@ void E57XmlParser::ParseInfo::dump( int indent, std::ostream &os ) const
    os << space( indent ) << "floatMaximum:   " << floatMaximum << std::endl;
    os << space( indent ) << "fileOffset:     " << fileOffset << std::endl;
    os << space( indent ) << "length:         " << length << std::endl;
-   os << space( indent ) << "allowHeterogeneousChildren: " << allowHeterogeneousChildren << std::endl;
+   os << space( indent ) << "allowHeterogeneousChildren: " << allowHeterogeneousChildren
+      << std::endl;
    os << space( indent ) << "recordCount:    " << recordCount << std::endl;
    if ( container_ni )
    {
@@ -248,8 +255,9 @@ void E57XmlParser::init()
    }
    catch ( const XMLException &ex )
    {
-      /// Turn parser exception into E57Exception
-      throw E57_EXCEPTION2( ErrorXMLParserInit, "parserMessage=" + ustring( XMLString::transcode( ex.getMessage() ) ) );
+      // Turn parser exception into E57Exception
+      throw E57_EXCEPTION2( ErrorXMLParserInit,
+                            "parserMessage=" + ustring( XMLString::transcode( ex.getMessage() ) ) );
    }
 
    xmlReader = XMLReaderFactory::createXMLReader(); //??? auto_ptr?
@@ -276,8 +284,8 @@ void E57XmlParser::parse( InputSource &inputSource )
    xmlReader->parse( inputSource );
 }
 
-void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const localName, const XMLCh *const qName,
-                                 const Attributes &attributes )
+void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const localName,
+                                 const XMLCh *const qName, const Attributes &attributes )
 {
 #ifdef E57_MAX_VERBOSE
    std::cout << "startElement" << std::endl;
@@ -289,16 +297,18 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
    {
       std::cout << space( 2 ) << "Attribute[" << i << "]" << std::endl;
       std::cout << space( 4 ) << "URI:       " << toUString( attributes.getURI( i ) ) << std::endl;
-      std::cout << space( 4 ) << "localName: " << toUString( attributes.getLocalName( i ) ) << std::endl;
-      std::cout << space( 4 ) << "qName:     " << toUString( attributes.getQName( i ) ) << std::endl;
-      std::cout << space( 4 ) << "value:     " << toUString( attributes.getValue( i ) ) << std::endl;
+      std::cout << space( 4 ) << "localName: " << toUString( attributes.getLocalName( i ) )
+                << std::endl;
+      std::cout << space( 4 ) << "qName:     " << toUString( attributes.getQName( i ) )
+                << std::endl;
+      std::cout << space( 4 ) << "value:     " << toUString( attributes.getValue( i ) )
+                << std::endl;
    }
 #endif
-   /// Get Type attribute
+   // Get Type attribute
    ustring node_type = lookupAttribute( attributes, att_type );
 
-   //??? check to make sure not in primitive type (can only nest inside compound
-   // types).
+   //??? check to make sure not in primitive type (can only nest inside compound types).
 
    ParseInfo pi;
 
@@ -318,7 +328,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       }
       else
       {
-         /// Not defined defined in XML, so defaults to E57_INT64_MIN
+         // Not defined defined in XML, so defaults to E57_INT64_MIN
          pi.minimum = INT64_MIN;
       }
 
@@ -330,11 +340,10 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       }
       else
       {
-         /// Not defined defined in XML, so defaults to E57_INT64_MAX
+         // Not defined defined in XML, so defaults to E57_INT64_MAX
          pi.maximum = INT64_MAX;
       }
 
-      /// Push info so far onto stack
       stack_.push( pi );
    }
    else if ( node_type == "ScaledInteger" )
@@ -353,7 +362,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       }
       else
       {
-         /// Not defined defined in XML, so defaults to E57_INT64_MIN
+         // Not defined defined in XML, so defaults to E57_INT64_MIN
          pi.minimum = INT64_MIN;
       }
 
@@ -365,7 +374,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       }
       else
       {
-         /// Not defined defined in XML, so defaults to E57_INT64_MAX
+         // Not defined defined in XML, so defaults to E57_INT64_MAX
          pi.maximum = INT64_MAX;
       }
 
@@ -376,7 +385,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       }
       else
       {
-         /// Not defined defined in XML, so defaults to 1.0
+         // Not defined defined in XML, so defaults to 1.0
          pi.scale = 1.0;
       }
 
@@ -387,11 +396,10 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       }
       else
       {
-         /// Not defined defined in XML, so defaults to 0.0
+         // Not defined defined in XML, so defaults to 0.0
          pi.offset = 0.0;
       }
 
-      /// Push info so far onto stack
       stack_.push( pi );
    }
    else if ( node_type == "Float" )
@@ -415,14 +423,15 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
          else
          {
             throw E57_EXCEPTION2( ErrorBadXMLFormat, "precisionString=" + precision_str +
-                                                        " fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
+                                                        " fileName=" + imf_->fileName() +
+                                                        " uri=" + toUString( uri ) +
                                                         " localName=" + toUString( localName ) +
                                                         " qName=" + toUString( qName ) );
          }
       }
       else
       {
-         /// Not defined defined in XML, so defaults to double
+         // Not defined defined in XML, so defaults to double
          pi.precision = PrecisionDouble;
       }
 
@@ -433,8 +442,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       }
       else
       {
-         /// Not defined defined in XML, so defaults to E57_FLOAT_MIN or
-         /// E57_DOUBLE_MIN
+         // Not defined defined in XML, so defaults to E57_FLOAT_MIN or E57_DOUBLE_MIN
          if ( pi.precision == PrecisionSingle )
          {
             pi.floatMinimum = FLOAT_MIN;
@@ -452,7 +460,7 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
       }
       else
       {
-         /// Not defined defined in XML, so defaults to FLOAT_MAX or DOUBLE_MAX
+         // Not defined defined in XML, so defaults to FLOAT_MAX or DOUBLE_MAX
          if ( pi.precision == PrecisionSingle )
          {
             pi.floatMaximum = FLOAT_MAX;
@@ -463,7 +471,6 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
          }
       }
 
-      /// Push info so far onto stack
       stack_.push( pi );
    }
    else if ( node_type == "String" )
@@ -473,7 +480,6 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
 #endif
       pi.nodeType = TypeString;
 
-      /// Push info so far onto stack
       stack_.push( pi );
    }
    else if ( node_type == "Blob" )
@@ -485,17 +491,16 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
 
       //??? check validity of numeric strings
 
-      /// fileOffset is required to be defined
+      // fileOffset is required to be defined
       ustring fileOffset_str = lookupAttribute( attributes, att_fileOffset );
 
       pi.fileOffset = convertStrToLL( fileOffset_str );
 
-      /// length is required to be defined
+      // length is required to be defined
       ustring length_str = lookupAttribute( attributes, att_length );
 
       pi.length = convertStrToLL( length_str );
 
-      /// Push info so far onto stack
       stack_.push( pi );
    }
    else if ( node_type == "Structure" )
@@ -505,56 +510,58 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
 #endif
       pi.nodeType = TypeStructure;
 
-      /// Read name space decls, if e57Root element
+      // Read name space decls, if e57Root element
       if ( toUString( localName ) == "e57Root" )
       {
-         /// Search attributes for namespace declarations (only allowed in
-         /// E57Root structure)
+         // Search attributes for namespace declarations (only allowed in E57Root structure)
          bool gotDefault = false;
          for ( size_t i = 0; i < attributes.getLength(); i++ )
          {
-            /// Check if declaring the default namespace
+            // Check if declaring the default namespace
             if ( toUString( attributes.getQName( i ) ) == "xmlns" )
             {
 #ifdef E57_VERBOSE
-               std::cout << "declared default namespace, URI=" << toUString( attributes.getValue( i ) ) << std::endl;
+               std::cout << "declared default namespace, URI="
+                         << toUString( attributes.getValue( i ) ) << std::endl;
 #endif
                imf_->extensionsAdd( "", toUString( attributes.getValue( i ) ) );
                gotDefault = true;
             }
 
-            /// Check if declaring a namespace
+            // Check if declaring a namespace
             if ( toUString( attributes.getURI( i ) ) == "http://www.w3.org/2000/xmlns/" )
             {
 #ifdef E57_VERBOSE
-               std::cout << "declared extension, prefix=" << toUString( attributes.getLocalName( i ) )
+               std::cout << "declared extension, prefix="
+                         << toUString( attributes.getLocalName( i ) )
                          << " URI=" << toUString( attributes.getValue( i ) ) << std::endl;
 #endif
-               imf_->extensionsAdd( toUString( attributes.getLocalName( i ) ), toUString( attributes.getValue( i ) ) );
+               imf_->extensionsAdd( toUString( attributes.getLocalName( i ) ),
+                                    toUString( attributes.getValue( i ) ) );
             }
          }
 
-         /// If didn't declare a default namespace, have error
+         // If didn't declare a default namespace, have error
          if ( !gotDefault )
          {
-            throw E57_EXCEPTION2( ErrorBadXMLFormat, "fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
+            throw E57_EXCEPTION2( ErrorBadXMLFormat, "fileName=" + imf_->fileName() +
+                                                        " uri=" + toUString( uri ) +
                                                         " localName=" + toUString( localName ) +
                                                         " qName=" + toUString( qName ) );
          }
       }
 
-      /// Create container now, so can hold children
+      // Create container now, so can hold children
       std::shared_ptr<StructureNodeImpl> s_ni( new StructureNodeImpl( imf_ ) );
       pi.container_ni = s_ni;
 
-      /// After have Structure, check again if E57Root, if so mark attached so
-      /// all children will be attached when added
+      // After have Structure, check again if E57Root, if so mark attached so all children will be
+      // attached when added
       if ( toUString( localName ) == "e57Root" )
       {
          s_ni->setAttachedRecursive();
       }
 
-      /// Push info so far onto stack
       stack_.push( pi );
    }
    else if ( node_type == "Vector" )
@@ -580,23 +587,24 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
          }
          else
          {
-            throw E57_EXCEPTION2( ErrorBadXMLFormat, "allowHeterogeneousChildren=" + toString( i64 ) +
-                                                        "fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
-                                                        " localName=" + toUString( localName ) +
-                                                        " qName=" + toUString( qName ) );
+            throw E57_EXCEPTION2( ErrorBadXMLFormat,
+                                  "allowHeterogeneousChildren=" + toString( i64 ) +
+                                     "fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
+                                     " localName=" + toUString( localName ) +
+                                     " qName=" + toUString( qName ) );
          }
       }
       else
       {
-         /// Not defined defined in XML, so defaults to false
+         // Not defined defined in XML, so defaults to false
          pi.allowHeterogeneousChildren = false;
       }
 
-      /// Create container now, so can hold children
-      std::shared_ptr<VectorNodeImpl> v_ni( new VectorNodeImpl( imf_, pi.allowHeterogeneousChildren ) );
+      // Create container now, so can hold children
+      std::shared_ptr<VectorNodeImpl> v_ni(
+         new VectorNodeImpl( imf_, pi.allowHeterogeneousChildren ) );
       pi.container_ni = v_ni;
 
-      /// Push info so far onto stack
       stack_.push( pi );
    }
    else if ( node_type == "CompressedVector" )
@@ -606,51 +614,52 @@ void E57XmlParser::startElement( const XMLCh *const uri, const XMLCh *const loca
 #endif
       pi.nodeType = TypeCompressedVector;
 
-      /// fileOffset is required to be defined
+      // fileOffset is required to be defined
       ustring fileOffset_str = lookupAttribute( attributes, att_fileOffset );
 
       pi.fileOffset = convertStrToLL( fileOffset_str );
 
-      /// recordCount is required to be defined
+      // recordCount is required to be defined
       ustring recordCount_str = lookupAttribute( attributes, att_recordCount );
 
       pi.recordCount = convertStrToLL( recordCount_str );
 
-      /// Create container now, so can hold children
+      // Create container now, so can hold children
       std::shared_ptr<CompressedVectorNodeImpl> cv_ni( new CompressedVectorNodeImpl( imf_ ) );
       cv_ni->setRecordCount( pi.recordCount );
       cv_ni->setBinarySectionLogicalStart(
          imf_->file_->physicalToLogical( pi.fileOffset ) ); //??? what if file_ is NULL?
       pi.container_ni = cv_ni;
 
-      /// Push info so far onto stack
       stack_.push( pi );
    }
    else
    {
-      throw E57_EXCEPTION2( ErrorBadXMLFormat, "nodeType=" + node_type + " fileName=" + imf_->fileName() +
-                                                  " uri=" + toUString( uri ) + " localName=" + toUString( localName ) +
-                                                  " qName=" + toUString( qName ) );
+      throw E57_EXCEPTION2( ErrorBadXMLFormat,
+                            "nodeType=" + node_type + " fileName=" + imf_->fileName() +
+                               " uri=" + toUString( uri ) + " localName=" + toUString( localName ) +
+                               " qName=" + toUString( qName ) );
    }
 #ifdef E57_MAX_VERBOSE
    pi.dump( 4 );
 #endif
 }
 
-void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localName, const XMLCh *const qName )
+void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localName,
+                               const XMLCh *const qName )
 {
 #ifdef E57_MAX_VERBOSE
    std::cout << "endElement" << std::endl;
 #endif
 
-   /// Pop the node that just ended
+   // Pop the node that just ended
    ParseInfo pi = stack_.top(); //??? really want to make a copy here?
    stack_.pop();
 #ifdef E57_MAX_VERBOSE
    pi.dump( 4 );
 #endif
 
-   /// We should now have all the info we need to create the node
+   // We should now have all the info we need to create the node
    NodeImplSharedPtr current_ni;
 
    switch ( pi.nodeType )
@@ -661,14 +670,14 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
          break;
       case TypeCompressedVector:
       {
-         /// Verify that both prototype and codecs child elements were defined
-         /// ???
+         // Verify that both prototype and codecs child elements were defined
+         // ???
          current_ni = pi.container_ni;
       }
       break;
       case TypeInteger:
       {
-         /// Convert child text (if any) to value, else default to 0.0
+         // Convert child text (if any) to value, else default to 0.0
          int64_t intValue;
          if ( pi.childText.length() > 0 )
          {
@@ -678,13 +687,14 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
          {
             intValue = 0;
          }
-         std::shared_ptr<IntegerNodeImpl> i_ni( new IntegerNodeImpl( imf_, intValue, pi.minimum, pi.maximum ) );
+         std::shared_ptr<IntegerNodeImpl> i_ni(
+            new IntegerNodeImpl( imf_, intValue, pi.minimum, pi.maximum ) );
          current_ni = i_ni;
       }
       break;
       case TypeScaledInteger:
       {
-         /// Convert child text (if any) to value, else default to 0.0
+         // Convert child text (if any) to value, else default to 0.0
          int64_t intValue;
          if ( pi.childText.length() > 0 )
          {
@@ -694,14 +704,14 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
          {
             intValue = 0;
          }
-         std::shared_ptr<ScaledIntegerNodeImpl> si_ni(
-            new ScaledIntegerNodeImpl( imf_, intValue, pi.minimum, pi.maximum, pi.scale, pi.offset ) );
+         std::shared_ptr<ScaledIntegerNodeImpl> si_ni( new ScaledIntegerNodeImpl(
+            imf_, intValue, pi.minimum, pi.maximum, pi.scale, pi.offset ) );
          current_ni = si_ni;
       }
       break;
       case TypeFloat:
       {
-         /// Convert child text (if any) to value, else default to 0.0
+         // Convert child text (if any) to value, else default to 0.0
          double floatValue;
          if ( pi.childText.length() > 0 )
          {
@@ -729,22 +739,24 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
       }
       break;
       default:
-         throw E57_EXCEPTION2( ErrorInternal, "nodeType=" + toString( pi.nodeType ) + " fileName=" + imf_->fileName() +
-                                                 " uri=" + toUString( uri ) + " localName=" + toUString( localName ) +
-                                                 " qName=" + toUString( qName ) );
+         throw E57_EXCEPTION2(
+            ErrorInternal, "nodeType=" + toString( pi.nodeType ) + " fileName=" + imf_->fileName() +
+                              " uri=" + toUString( uri ) + " localName=" + toUString( localName ) +
+                              " qName=" + toUString( qName ) );
    }
 #ifdef E57_MAX_VERBOSE
    current_ni->dump( 4 );
 #endif
 
-   /// If first node in file ended, we are all done
+   // If first node in file ended, we are all done
    if ( stack_.empty() )
    {
-      /// Top level should be Structure
+      // Top level should be Structure
       if ( current_ni->type() != TypeStructure )
       {
          throw E57_EXCEPTION2( ErrorBadXMLFormat, "currentType=" + toString( current_ni->type() ) +
-                                                     " fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
+                                                     " fileName=" + imf_->fileName() +
+                                                     " uri=" + toUString( uri ) +
                                                      " localName=" + toUString( localName ) +
                                                      " qName=" + toUString( qName ) );
       }
@@ -752,33 +764,35 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
       return;
    }
 
-   /// Get next level up node (when entered function), which should be a
-   /// container.
+   // Get next level up node (when entered function), which should be a container.
    NodeImplSharedPtr parent_ni = stack_.top().container_ni;
 
    if ( !parent_ni )
    {
-      throw E57_EXCEPTION2( ErrorBadXMLFormat, "fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
+      throw E57_EXCEPTION2( ErrorBadXMLFormat, "fileName=" + imf_->fileName() +
+                                                  " uri=" + toUString( uri ) +
                                                   " localName=" + toUString( localName ) +
                                                   " qName=" + toUString( qName ) );
    }
 
-   /// Add current node into parent at top of stack
+   // Add current node into parent at top of stack
    switch ( parent_ni->type() )
    {
       case TypeStructure:
       {
-         std::shared_ptr<StructureNodeImpl> struct_ni = std::static_pointer_cast<StructureNodeImpl>( parent_ni );
+         std::shared_ptr<StructureNodeImpl> struct_ni =
+            std::static_pointer_cast<StructureNodeImpl>( parent_ni );
 
-         /// Add named child to structure
+         // Add named child to structure
          struct_ni->set( toUString( qName ), current_ni );
       }
       break;
       case TypeVector:
       {
-         std::shared_ptr<VectorNodeImpl> vector_ni = std::static_pointer_cast<VectorNodeImpl>( parent_ni );
+         std::shared_ptr<VectorNodeImpl> vector_ni =
+            std::static_pointer_cast<VectorNodeImpl>( parent_ni );
 
-         /// Add unnamed child to vector
+         // Add unnamed child to vector
          vector_ni->append( current_ni );
       }
       break;
@@ -788,7 +802,7 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
             std::static_pointer_cast<CompressedVectorNodeImpl>( parent_ni );
          ustring uQName = toUString( qName );
 
-         /// n can be either prototype or codecs
+         // n can be either prototype or codecs
          if ( uQName == "prototype" )
          {
             cv_ni->setPrototype( current_ni );
@@ -797,38 +811,42 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
          {
             if ( current_ni->type() != TypeVector )
             {
-               throw E57_EXCEPTION2( ErrorBadXMLFormat,
-                                     "currentType=" + toString( current_ni->type() ) + " fileName=" + imf_->fileName() +
-                                        " uri=" + toUString( uri ) + " localName=" + toUString( localName ) +
-                                        " qName=" + toUString( qName ) );
+               throw E57_EXCEPTION2(
+                  ErrorBadXMLFormat,
+                  "currentType=" + toString( current_ni->type() ) +
+                     " fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
+                     " localName=" + toUString( localName ) + " qName=" + toUString( qName ) );
             }
-            std::shared_ptr<VectorNodeImpl> vi = std::static_pointer_cast<VectorNodeImpl>( current_ni );
+            std::shared_ptr<VectorNodeImpl> vi =
+               std::static_pointer_cast<VectorNodeImpl>( current_ni );
 
-            /// Check VectorNode is hetero
+            // Check VectorNode is hetero
             if ( !vi->allowHeteroChildren() )
             {
-               throw E57_EXCEPTION2( ErrorBadXMLFormat,
-                                     "currentType=" + toString( current_ni->type() ) + " fileName=" + imf_->fileName() +
-                                        " uri=" + toUString( uri ) + " localName=" + toUString( localName ) +
-                                        " qName=" + toUString( qName ) );
+               throw E57_EXCEPTION2(
+                  ErrorBadXMLFormat,
+                  "currentType=" + toString( current_ni->type() ) +
+                     " fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
+                     " localName=" + toUString( localName ) + " qName=" + toUString( qName ) );
             }
 
             cv_ni->setCodecs( vi );
          }
          else
          {
-            /// Found unknown XML child element of CompressedVector, not
-            /// prototype or codecs
-            throw E57_EXCEPTION2( ErrorBadXMLFormat, +"fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
+            // Found unknown XML child element of CompressedVector, not prototype or codecs
+            throw E57_EXCEPTION2( ErrorBadXMLFormat, +"fileName=" + imf_->fileName() +
+                                                        " uri=" + toUString( uri ) +
                                                         " localName=" + toUString( localName ) +
                                                         " qName=" + toUString( qName ) );
          }
       }
       break;
       default:
-         /// Have bad XML nesting, parent should have been a container.
+         // Have bad XML nesting, parent should have been a container.
          throw E57_EXCEPTION2( ErrorBadXMLFormat, "parentType=" + toString( parent_ni->type() ) +
-                                                     " fileName=" + imf_->fileName() + " uri=" + toUString( uri ) +
+                                                     " fileName=" + imf_->fileName() +
+                                                     " uri=" + toUString( uri ) +
                                                      " localName=" + toUString( localName ) +
                                                      " qName=" + toUString( qName ) );
    }
@@ -840,10 +858,10 @@ void E57XmlParser::characters( const XMLCh *const chars, const XMLSize_t length 
 #ifdef E57_MAX_VERBOSE
    std::cout << "characters, chars=\"" << toUString( chars ) << "\" length=" << length << std::endl;
 #endif
-   /// Get active element
+   // Get active element
    ParseInfo &pi = stack_.top();
 
-   /// Check if child text is allowed for current E57 element type
+   // Check if child text is allowed for current E57 element type
    switch ( pi.nodeType )
    {
       case TypeStructure:
@@ -851,7 +869,7 @@ void E57XmlParser::characters( const XMLCh *const chars, const XMLSize_t length 
       case TypeCompressedVector:
       case TypeBlob:
       {
-         /// If characters aren't whitespace, have an error, else ignore
+         // If characters aren't whitespace, have an error, else ignore
          ustring s = toUString( chars );
          if ( s.find_first_not_of( " \t\n\r" ) != std::string::npos )
          {
@@ -860,31 +878,34 @@ void E57XmlParser::characters( const XMLCh *const chars, const XMLSize_t length 
       }
       break;
       default:
-         /// Append to any previous characters
+         // Append to any previous characters
          pi.childText += toUString( chars );
    }
 }
 
 void E57XmlParser::error( const SAXParseException &ex )
 {
-   throw E57_EXCEPTION2( ErrorXMLParser, "systemId=" + ustring( XMLString::transcode( ex.getSystemId() ) ) +
-                                            " xmlLine=" + toString( ex.getLineNumber() ) +
-                                            " xmlColumn=" + toString( ex.getColumnNumber() ) +
-                                            " parserMessage=" + ustring( XMLString::transcode( ex.getMessage() ) ) );
+   throw E57_EXCEPTION2(
+      ErrorXMLParser, "systemId=" + ustring( XMLString::transcode( ex.getSystemId() ) ) +
+                         " xmlLine=" + toString( ex.getLineNumber() ) +
+                         " xmlColumn=" + toString( ex.getColumnNumber() ) +
+                         " parserMessage=" + ustring( XMLString::transcode( ex.getMessage() ) ) );
 }
 
 void E57XmlParser::fatalError( const SAXParseException &ex )
 {
-   throw E57_EXCEPTION2( ErrorXMLParser, "systemId=" + ustring( XMLString::transcode( ex.getSystemId() ) ) +
-                                            " xmlLine=" + toString( ex.getLineNumber() ) +
-                                            " xmlColumn=" + toString( ex.getColumnNumber() ) +
-                                            " parserMessage=" + ustring( XMLString::transcode( ex.getMessage() ) ) );
+   throw E57_EXCEPTION2(
+      ErrorXMLParser, "systemId=" + ustring( XMLString::transcode( ex.getSystemId() ) ) +
+                         " xmlLine=" + toString( ex.getLineNumber() ) +
+                         " xmlColumn=" + toString( ex.getColumnNumber() ) +
+                         " parserMessage=" + ustring( XMLString::transcode( ex.getMessage() ) ) );
 }
 
 void E57XmlParser::warning( const SAXParseException &ex )
 {
-   /// Don't take any action on warning from parser, just report
-   std::cerr << "**** XML parser warning: " << ustring( XMLString::transcode( ex.getMessage() ) ) << std::endl;
+   // Don't take any action on warning from parser, just report
+   std::cerr << "**** XML parser warning: " << ustring( XMLString::transcode( ex.getMessage() ) )
+             << std::endl;
    std::cerr << "  Debug info:" << std::endl;
    std::cerr << "    systemId=" << XMLString::transcode( ex.getSystemId() ) << std::endl;
    std::cerr << ",   xmlLine=" << ex.getLineNumber() << std::endl;

--- a/src/E57XmlParser.h
+++ b/src/E57XmlParser.h
@@ -57,9 +57,10 @@ namespace e57
 
    private:
       /// SAX interface
-      void startElement( const XMLCh *const uri, const XMLCh *const localName, const XMLCh *const qName,
-                         const Attributes &attributes ) override;
-      void endElement( const XMLCh *const uri, const XMLCh *const localName, const XMLCh *const qName ) override;
+      void startElement( const XMLCh *const uri, const XMLCh *const localName,
+                         const XMLCh *const qName, const Attributes &attributes ) override;
+      void endElement( const XMLCh *const uri, const XMLCh *const localName,
+                       const XMLCh *const qName ) override;
       void characters( const XMLCh *const chars, XMLSize_t length ) override;
 
       /// SAX error interface
@@ -75,10 +76,10 @@ namespace e57
 
       struct ParseInfo
       {
-         /// All the fields need to remember while parsing the XML
-         /// Not all fields are used at same time, depends on node type
-         /// Needed because not all info is available at one time to create the
-         /// node.
+         // All the fields need to remember while parsing the XML
+         // Not all fields are used at same time, depends on node type
+         // Needed because not all info is available at one time to create the
+         // node.
          NodeType nodeType;               // used by all types
          int64_t minimum;                 // used in Integer, ScaledInteger
          int64_t maximum;                 // used in Integer, ScaledInteger
@@ -91,10 +92,10 @@ namespace e57
          int64_t length;                  // used in Blob
          bool allowHeterogeneousChildren; // used in Vector
          int64_t recordCount;             // used in CompressedVector
-         ustring childText;               // used by all types, accumulates all child text between tags
+         ustring childText; // used by all types, accumulates all child text between tags
 
-         /// Holds node for Structure, Vector, and CompressedVector so can append
-         /// child elements
+         // Holds node for Structure, Vector, and CompressedVector so can append
+         // child elements
          NodeImplSharedPtr container_ni;
 
          ParseInfo(); // default ctor

--- a/src/Encoder.cpp
+++ b/src/Encoder.cpp
@@ -42,7 +42,8 @@ using namespace e57;
 
 std::shared_ptr<Encoder> Encoder::EncoderFactory( unsigned bytestreamNumber,
                                                   std::shared_ptr<CompressedVectorNodeImpl> cVector,
-                                                  std::vector<SourceDestBuffer> &sbufs, ustring & /*codecPath*/ )
+                                                  std::vector<SourceDestBuffer> &sbufs,
+                                                  ustring & /*codecPath*/ )
 {
    //??? For now, only handle one input
    if ( sbufs.size() != 1 )
@@ -52,7 +53,7 @@ std::shared_ptr<Encoder> Encoder::EncoderFactory( unsigned bytestreamNumber,
 
    SourceDestBuffer sbuf = sbufs.at( 0 );
 
-   /// Get node we are going to encode from the CompressedVector's prototype
+   // Get node we are going to encode from the CompressedVector's prototype
    NodeImplSharedPtr prototype = cVector->getPrototype();
    ustring path = sbuf.pathName();
    NodeImplSharedPtr encodeNode = prototype->get( path );
@@ -68,19 +69,21 @@ std::shared_ptr<Encoder> Encoder::EncoderFactory( unsigned bytestreamNumber,
          std::shared_ptr<IntegerNodeImpl> ini =
             std::static_pointer_cast<IntegerNodeImpl>( encodeNode ); // downcast to correct type
 
-         /// Get pointer to parent ImageFileImpl, to call bitsNeeded()
-         ImageFileImplSharedPtr imf( encodeNode->destImageFile_ ); //??? should be function for this,
-                                                                   // imf->parentFile()
-                                                                   //--> ImageFile?
+         // Get pointer to parent ImageFileImpl, to call bitsNeeded()
+         ImageFileImplSharedPtr imf(
+            encodeNode->destImageFile_ ); //??? should be function for this,
+                                          // imf->parentFile()
+                                          //--> ImageFile?
 
          unsigned bitsPerRecord = imf->bitsNeeded( ini->minimum(), ini->maximum() );
 
-         //!!! need to pick smarter channel buffer sizes, here and elsewhere
-         /// Construct Integer encoder with appropriate register size, based on
-         /// number of bits stored.
+         // !!! need to pick smarter channel buffer sizes, here and elsewhere
+         // Construct Integer encoder with appropriate register size, based on number of bits
+         // stored.
          if ( bitsPerRecord == 0 )
          {
-            std::shared_ptr<Encoder> encoder( new ConstantIntegerEncoder( bytestreamNumber, sbuf, ini->minimum() ) );
+            std::shared_ptr<Encoder> encoder(
+               new ConstantIntegerEncoder( bytestreamNumber, sbuf, ini->minimum() ) );
 
             return encoder;
          }
@@ -88,78 +91,85 @@ std::shared_ptr<Encoder> Encoder::EncoderFactory( unsigned bytestreamNumber,
          if ( bitsPerRecord <= 8 )
          {
             std::shared_ptr<Encoder> encoder( new BitpackIntegerEncoder<uint8_t>(
-               false, bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/, ini->minimum(), ini->maximum(), 1.0, 0.0 ) );
+               false, bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/, ini->minimum(),
+               ini->maximum(), 1.0, 0.0 ) );
             return encoder;
          }
 
          if ( bitsPerRecord <= 16 )
          {
             std::shared_ptr<Encoder> encoder( new BitpackIntegerEncoder<uint16_t>(
-               false, bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/, ini->minimum(), ini->maximum(), 1.0, 0.0 ) );
+               false, bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/, ini->minimum(),
+               ini->maximum(), 1.0, 0.0 ) );
             return encoder;
          }
 
          if ( bitsPerRecord <= 32 )
          {
             std::shared_ptr<Encoder> encoder( new BitpackIntegerEncoder<uint32_t>(
-               false, bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/, ini->minimum(), ini->maximum(), 1.0, 0.0 ) );
+               false, bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/, ini->minimum(),
+               ini->maximum(), 1.0, 0.0 ) );
             return encoder;
          }
 
          std::shared_ptr<Encoder> encoder( new BitpackIntegerEncoder<uint64_t>(
-            false, bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/, ini->minimum(), ini->maximum(), 1.0, 0.0 ) );
+            false, bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/, ini->minimum(), ini->maximum(),
+            1.0, 0.0 ) );
          return encoder;
       }
 
       case TypeScaledInteger:
       {
          std::shared_ptr<ScaledIntegerNodeImpl> sini =
-            std::static_pointer_cast<ScaledIntegerNodeImpl>( encodeNode ); // downcast to correct type
+            std::static_pointer_cast<ScaledIntegerNodeImpl>(
+               encodeNode ); // downcast to correct type
 
-         /// Get pointer to parent ImageFileImpl, to call bitsNeeded()
-         ImageFileImplSharedPtr imf( encodeNode->destImageFile_ ); //??? should be function for this,
-                                                                   // imf->parentFile()
-                                                                   //--> ImageFile?
+         // Get pointer to parent ImageFileImpl, to call bitsNeeded()
+         ImageFileImplSharedPtr imf(
+            encodeNode->destImageFile_ ); //??? should be function for this,
+                                          // imf->parentFile()
+                                          //--> ImageFile?
 
          unsigned bitsPerRecord = imf->bitsNeeded( sini->minimum(), sini->maximum() );
 
-         //!!! need to pick smarter channel buffer sizes, here and elsewhere
-         /// Construct ScaledInteger encoder with appropriate register size,
-         /// based on number of bits stored.
+         // !!! need to pick smarter channel buffer sizes, here and elsewhere
+         // Construct ScaledInteger encoder with appropriate register size,  based on number of bits
+         // stored.
          if ( bitsPerRecord == 0 )
          {
-            std::shared_ptr<Encoder> encoder( new ConstantIntegerEncoder( bytestreamNumber, sbuf, sini->minimum() ) );
+            std::shared_ptr<Encoder> encoder(
+               new ConstantIntegerEncoder( bytestreamNumber, sbuf, sini->minimum() ) );
 
             return encoder;
          }
 
          if ( bitsPerRecord <= 8 )
          {
-            std::shared_ptr<Encoder> encoder(
-               new BitpackIntegerEncoder<uint8_t>( true, bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/,
-                                                   sini->minimum(), sini->maximum(), sini->scale(), sini->offset() ) );
+            std::shared_ptr<Encoder> encoder( new BitpackIntegerEncoder<uint8_t>(
+               true, bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/, sini->minimum(),
+               sini->maximum(), sini->scale(), sini->offset() ) );
             return encoder;
          }
 
          if ( bitsPerRecord <= 16 )
          {
-            std::shared_ptr<Encoder> encoder(
-               new BitpackIntegerEncoder<uint16_t>( true, bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/,
-                                                    sini->minimum(), sini->maximum(), sini->scale(), sini->offset() ) );
+            std::shared_ptr<Encoder> encoder( new BitpackIntegerEncoder<uint16_t>(
+               true, bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/, sini->minimum(),
+               sini->maximum(), sini->scale(), sini->offset() ) );
             return encoder;
          }
 
          if ( bitsPerRecord <= 32 )
          {
-            std::shared_ptr<Encoder> encoder(
-               new BitpackIntegerEncoder<uint32_t>( true, bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/,
-                                                    sini->minimum(), sini->maximum(), sini->scale(), sini->offset() ) );
+            std::shared_ptr<Encoder> encoder( new BitpackIntegerEncoder<uint32_t>(
+               true, bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/, sini->minimum(),
+               sini->maximum(), sini->scale(), sini->offset() ) );
             return encoder;
          }
 
-         std::shared_ptr<Encoder> encoder(
-            new BitpackIntegerEncoder<uint64_t>( true, bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/, sini->minimum(),
-                                                 sini->maximum(), sini->scale(), sini->offset() ) );
+         std::shared_ptr<Encoder> encoder( new BitpackIntegerEncoder<uint64_t>(
+            true, bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/, sini->minimum(), sini->maximum(),
+            sini->scale(), sini->offset() ) );
          return encoder;
       }
 
@@ -168,9 +178,9 @@ std::shared_ptr<Encoder> Encoder::EncoderFactory( unsigned bytestreamNumber,
          std::shared_ptr<FloatNodeImpl> fni =
             std::static_pointer_cast<FloatNodeImpl>( encodeNode ); // downcast to correct type
 
-         //!!! need to pick smarter channel buffer sizes, here and elsewhere
-         std::shared_ptr<Encoder> encoder(
-            new BitpackFloatEncoder( bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/, fni->precision() ) );
+         // !!! need to pick smarter channel buffer sizes, here and elsewhere
+         std::shared_ptr<Encoder> encoder( new BitpackFloatEncoder(
+            bytestreamNumber, sbuf, DATA_PACKET_MAX /*!!!*/, fni->precision() ) );
          return encoder;
       }
 
@@ -200,13 +210,13 @@ void Encoder::dump( int indent, std::ostream &os ) const
 }
 #endif
 
-///================
+//================
 
-BitpackEncoder::BitpackEncoder( unsigned bytestreamNumber, SourceDestBuffer &sbuf, unsigned outputMaxSize,
-                                unsigned alignmentSize ) :
+BitpackEncoder::BitpackEncoder( unsigned bytestreamNumber, SourceDestBuffer &sbuf,
+                                unsigned outputMaxSize, unsigned alignmentSize ) :
    Encoder( bytestreamNumber ),
-   sourceBuffer_( sbuf.impl() ), outBuffer_( outputMaxSize ), outBufferFirst_( 0 ), outBufferEnd_( 0 ),
-   outBufferAlignmentSize_( alignmentSize ), currentRecordIndex_( 0 )
+   sourceBuffer_( sbuf.impl() ), outBuffer_( outputMaxSize ), outBufferFirst_( 0 ),
+   outBufferEnd_( 0 ), outBufferAlignmentSize_( alignmentSize ), currentRecordIndex_( 0 )
 {
 }
 
@@ -228,17 +238,18 @@ size_t BitpackEncoder::outputAvailable() const
 void BitpackEncoder::outputRead( char *dest, const size_t byteCount )
 {
 #ifdef E57_MAX_VERBOSE
-   std::cout << "BitpackEncoder::outputRead() called, dest=" << dest << " byteCount=" << byteCount << std::endl; //???
+   std::cout << "BitpackEncoder::outputRead() called, dest=" << dest << " byteCount=" << byteCount
+             << std::endl; //???
 #endif
 
-   /// Check we have enough bytes in queue
+   // Check we have enough bytes in queue
    if ( byteCount > outputAvailable() )
    {
       throw E57_EXCEPTION2( ErrorInternal, "byteCount=" + toString( byteCount ) +
                                               " outputAvailable=" + toString( outputAvailable() ) );
    }
 
-   /// Copy output bytes to caller
+   // Copy output bytes to caller
    memcpy( dest, &outBuffer_[outBufferFirst_], byteCount );
 
 #ifdef E57_MAX_VERBOSE
@@ -246,8 +257,9 @@ void BitpackEncoder::outputRead( char *dest, const size_t byteCount )
       unsigned i;
       for ( i = 0; i < byteCount && i < 20; i++ )
       {
-         std::cout << "  outBuffer[" << outBufferFirst_ + i
-                   << "]=" << static_cast<unsigned>( static_cast<unsigned char>( outBuffer_[outBufferFirst_ + i] ) )
+         std::cout << "  outBuffer[" << outBufferFirst_ + i << "]="
+                   << static_cast<unsigned>(
+                         static_cast<unsigned char>( outBuffer_[outBufferFirst_ + i] ) )
                    << std::endl; //???
       }
 
@@ -258,11 +270,11 @@ void BitpackEncoder::outputRead( char *dest, const size_t byteCount )
    }
 #endif
 
-   /// Advance head pointer.
+   // Advance head pointer.
    outBufferFirst_ += byteCount;
 
-   /// Don't slide remaining data down now, wait until do some more processing
-   /// (that's when data needs to be aligned).
+   // Don't slide remaining data down now, wait until do some more processing (that's when data
+   // needs to be aligned).
 }
 
 void BitpackEncoder::outputClear()
@@ -273,7 +285,7 @@ void BitpackEncoder::outputClear()
 
 void BitpackEncoder::sourceBufferSetNew( std::vector<SourceDestBuffer> &sbufs )
 {
-   /// Verify that this encoder only has single input buffer
+   // Verify that this encoder only has single input buffer
    if ( sbufs.size() != 1 )
    {
       throw E57_EXCEPTION2( ErrorInternal, "sbufsSize=" + toString( sbufs.size() ) );
@@ -284,13 +296,13 @@ void BitpackEncoder::sourceBufferSetNew( std::vector<SourceDestBuffer> &sbufs )
 
 size_t BitpackEncoder::outputGetMaxSize()
 {
-   /// Its size that matters here, not capacity
+   // Its size that matters here, not capacity
    return ( outBuffer_.size() );
 }
 
 void BitpackEncoder::outputSetMaxSize( unsigned byteCount )
 {
-   /// Ignore if trying to shrink buffer (queue might get messed up).
+   // Ignore if trying to shrink buffer (queue might get messed up).
    if ( byteCount > outBuffer_.size() )
    {
       outBuffer_.resize( byteCount );
@@ -299,20 +311,20 @@ void BitpackEncoder::outputSetMaxSize( unsigned byteCount )
 
 void BitpackEncoder::outBufferShiftDown()
 {
-   /// Move data down closer to beginning of outBuffer_.
-   /// But keep outBufferEnd_ as a multiple of outBufferAlignmentSize_.
-   /// This ensures that writes into buffer can occur on natural boundaries.
-   /// Otherwise some CPUs will fault.
+   // Move data down closer to beginning of outBuffer_.
+   // But keep outBufferEnd_ as a multiple of outBufferAlignmentSize_.
+   // This ensures that writes into buffer can occur on natural boundaries.
+   // Otherwise some CPUs will fault.
 
    if ( outBufferFirst_ == outBufferEnd_ )
    {
-      /// Buffer is empty, reset indices to 0
+      // Buffer is empty, reset indices to 0
       outBufferFirst_ = 0;
       outBufferEnd_ = 0;
       return;
    }
 
-   /// Round newEnd up to nearest multiple of outBufferAlignmentSize_.
+   // Round newEnd up to nearest multiple of outBufferAlignmentSize_.
    size_t newEnd = outputAvailable();
    size_t remainder = newEnd % outBufferAlignmentSize_;
    if ( remainder > 0 )
@@ -322,25 +334,27 @@ void BitpackEncoder::outBufferShiftDown()
    size_t newFirst = outBufferFirst_ - ( outBufferEnd_ - newEnd );
    size_t byteCount = outBufferEnd_ - outBufferFirst_;
 
-   /// Double check round up worked
+   // Double check round up worked
    if ( newEnd % outBufferAlignmentSize_ )
    {
-      throw E57_EXCEPTION2( ErrorInternal, "newEnd=" + toString( newEnd ) +
-                                              " outBufferAlignmentSize=" + toString( outBufferAlignmentSize_ ) );
+      throw E57_EXCEPTION2( ErrorInternal,
+                            "newEnd=" + toString( newEnd ) +
+                               " outBufferAlignmentSize=" + toString( outBufferAlignmentSize_ ) );
    }
 
-   /// Be paranoid before memory copy
+   // Be paranoid before memory copy
    if ( newFirst + byteCount > outBuffer_.size() )
    {
-      throw E57_EXCEPTION2( ErrorInternal, "newFirst=" + toString( newFirst ) + " byteCount=" + toString( byteCount ) +
+      throw E57_EXCEPTION2( ErrorInternal, "newFirst=" + toString( newFirst ) +
+                                              " byteCount=" + toString( byteCount ) +
                                               " outBufferSize=" + toString( outBuffer_.size() ) );
    }
 
-   /// Move available data down closer to beginning of outBuffer_.  Overlapping
-   /// regions ok with memmove().
+   // Move available data down closer to beginning of outBuffer_. Overlapping regions ok with
+   // memmove().
    memmove( &outBuffer_[newFirst], &outBuffer_[outBufferFirst_], byteCount );
 
-   /// Update indexes
+   // Update indexes
    outBufferFirst_ = newFirst;
    outBufferEnd_ = newEnd;
 }
@@ -361,7 +375,8 @@ void BitpackEncoder::dump( int indent, std::ostream &os ) const
    for ( i = 0; i < outBuffer_.size() && i < 20; i++ )
    {
       os << space( indent + 4 ) << "outBuffer[" << i
-         << "]: " << static_cast<unsigned>( static_cast<unsigned char>( outBuffer_.at( i ) ) ) << std::endl;
+         << "]: " << static_cast<unsigned>( static_cast<unsigned char>( outBuffer_.at( i ) ) )
+         << std::endl;
    }
    if ( i < outBuffer_.size() )
    {
@@ -372,8 +387,8 @@ void BitpackEncoder::dump( int indent, std::ostream &os ) const
 
 //================
 
-BitpackFloatEncoder::BitpackFloatEncoder( unsigned bytestreamNumber, SourceDestBuffer &sbuf, unsigned outputMaxSize,
-                                          FloatPrecision precision ) :
+BitpackFloatEncoder::BitpackFloatEncoder( unsigned bytestreamNumber, SourceDestBuffer &sbuf,
+                                          unsigned outputMaxSize, FloatPrecision precision ) :
    BitpackEncoder( bytestreamNumber, sbuf, outputMaxSize,
                    ( precision == PrecisionSingle ) ? sizeof( float ) : sizeof( double ) ),
    precision_( precision )
@@ -383,29 +398,30 @@ BitpackFloatEncoder::BitpackFloatEncoder( unsigned bytestreamNumber, SourceDestB
 uint64_t BitpackFloatEncoder::processRecords( size_t recordCount )
 {
 #ifdef E57_MAX_VERBOSE
-   std::cout << "  BitpackFloatEncoder::processRecords() called, recordCount=" << recordCount << std::endl; //???
+   std::cout << "  BitpackFloatEncoder::processRecords() called, recordCount=" << recordCount
+             << std::endl; //???
 #endif
 
-   /// Before we add any more, try to shift current contents of outBuffer_ down
-   /// to beginning of buffer. This leaves outBufferEnd_ at a natural boundary.
+   // Before we add any more, try to shift current contents of outBuffer_ down to beginning of
+   // buffer. This leaves outBufferEnd_ at a natural boundary.
    outBufferShiftDown();
 
    size_t typeSize = ( precision_ == PrecisionSingle ) ? sizeof( float ) : sizeof( double );
 
 #ifdef E57_DEBUG
-   /// Verify that outBufferEnd_ is multiple of typeSize (so transfers of floats
-   /// are aligned naturally in memory).
+   // Verify that outBufferEnd_ is multiple of typeSize (so transfers of floats are aligned
+   // naturally in memory).
    if ( outBufferEnd_ % typeSize )
    {
-      throw E57_EXCEPTION2( ErrorInternal,
-                            "outBufferEnd=" + toString( outBufferEnd_ ) + " typeSize=" + toString( typeSize ) );
+      throw E57_EXCEPTION2( ErrorInternal, "outBufferEnd=" + toString( outBufferEnd_ ) +
+                                              " typeSize=" + toString( typeSize ) );
    }
 #endif
 
-   /// Figure out how many records will fit in output.
+   // Figure out how many records will fit in output.
    size_t maxOutputRecords = ( outBuffer_.size() - outBufferEnd_ ) / typeSize;
 
-   /// Can't process more records than will safely fit in output stream
+   // Can't process more records than will safely fit in output stream
    if ( recordCount > maxOutputRecords )
    {
       recordCount = maxOutputRecords;
@@ -413,10 +429,10 @@ uint64_t BitpackFloatEncoder::processRecords( size_t recordCount )
 
    if ( precision_ == PrecisionSingle )
    {
-      /// Form the starting address for next available location in outBuffer
+      // Form the starting address for next available location in outBuffer
       auto outp = reinterpret_cast<float *>( &outBuffer_[outBufferEnd_] );
 
-      /// Copy floats from sourceBuffer_ to outBuffer_
+      // Copy floats from sourceBuffer_ to outBuffer_
       for ( unsigned i = 0; i < recordCount; i++ )
       {
          outp[i] = sourceBuffer_->getNextFloat();
@@ -426,11 +442,12 @@ uint64_t BitpackFloatEncoder::processRecords( size_t recordCount )
       }
    }
    else
-   { /// Double precision
-      /// Form the starting address for next available location in outBuffer
+   {
+      // Double precision
+      // Form the starting address for next available location in outBuffer
       auto outp = reinterpret_cast<double *>( &outBuffer_[outBufferEnd_] );
 
-      /// Copy doubles from sourceBuffer_ to outBuffer_
+      // Copy doubles from sourceBuffer_ to outBuffer_
       for ( unsigned i = 0; i < recordCount; i++ )
       {
          outp[i] = sourceBuffer_->getNextDouble();
@@ -440,10 +457,10 @@ uint64_t BitpackFloatEncoder::processRecords( size_t recordCount )
       }
    }
 
-   /// Update end of outBuffer
+   // Update end of outBuffer
    outBufferEnd_ += recordCount * typeSize;
 
-   /// Update counts of records processed
+   // Update counts of records processed
    currentRecordIndex_ += recordCount;
 
    return ( currentRecordIndex_ );
@@ -451,7 +468,7 @@ uint64_t BitpackFloatEncoder::processRecords( size_t recordCount )
 
 bool BitpackFloatEncoder::registerFlushToOutput()
 {
-   /// Since have no registers in encoder, return success
+   // Since have no registers in encoder, return success
    return ( true );
 }
 
@@ -480,34 +497,35 @@ void BitpackFloatEncoder::dump( int indent, std::ostream &os ) const
 BitpackStringEncoder::BitpackStringEncoder( unsigned bytestreamNumber, SourceDestBuffer &sbuf,
                                             unsigned outputMaxSize ) :
    BitpackEncoder( bytestreamNumber, sbuf, outputMaxSize, 1 ),
-   totalBytesProcessed_( 0 ), isStringActive_( false ), prefixComplete_( false ), currentCharPosition_( 0 )
+   totalBytesProcessed_( 0 ), isStringActive_( false ), prefixComplete_( false ),
+   currentCharPosition_( 0 )
 {
 }
 
 uint64_t BitpackStringEncoder::processRecords( size_t recordCount )
 {
 #ifdef E57_MAX_VERBOSE
-   std::cout << "  BitpackStringEncoder::processRecords() called, recordCount=" << recordCount << std::endl; //???
+   std::cout << "  BitpackStringEncoder::processRecords() called, recordCount=" << recordCount
+             << std::endl; //???
 #endif
 
-   /// Before we add any more, try to shift current contents of outBuffer_ down
-   /// to beginning of buffer.
+   // Before we add any more, try to shift current contents of outBuffer_ down to beginning of
+   // buffer.
    outBufferShiftDown();
 
-   /// Figure out how many bytes outBuffer can accept.
+   // Figure out how many bytes outBuffer can accept.
    size_t bytesFree = outBuffer_.size() - outBufferEnd_;
 
-   /// Form the starting address for next available location in outBuffer
+   // Form the starting address for next available location in outBuffer
    char *outp = &outBuffer_[outBufferEnd_];
    unsigned recordsProcessed = 0;
 
-   /// Don't start loop unless have at least 8 bytes for worst case string
-   /// length prefix
+   // Don't start loop unless have at least 8 bytes for worst case string length prefix
    while ( recordsProcessed < recordCount && bytesFree >= 8 )
    { //??? should be able to proceed if only 1 byte free
       if ( isStringActive_ && !prefixComplete_ )
       {
-         /// Calc the length prefix, either 1 byte or 8 bytes
+         // Calc the length prefix, either 1 byte or 8 bytes
          size_t len = currentString_.length();
          if ( len <= 127 )
          {
@@ -520,7 +538,7 @@ uint64_t BitpackStringEncoder::processRecords( size_t recordCount )
                          ""
                       << std::endl;
 #endif
-            /// We can use the short length prefix: b0=0, b7-b1=len
+            // We can use the short length prefix: b0=0, b7-b1=len
             auto lengthPrefix = static_cast<uint8_t>( len << 1 );
             *outp++ = lengthPrefix;
             bytesFree--;
@@ -528,7 +546,7 @@ uint64_t BitpackStringEncoder::processRecords( size_t recordCount )
          else
          {
 #ifdef E57_DEBUG
-            /// Double check have space
+            // Double check have space
             if ( bytesFree < 8 )
             {
                throw E57_EXCEPTION2( ErrorInternal, "bytesFree=" + toString( bytesFree ) );
@@ -543,9 +561,8 @@ uint64_t BitpackStringEncoder::processRecords( size_t recordCount )
                          ""
                       << std::endl;
 #endif
-            /// We use the long length prefix: b0=1, b63-b1=len, and store in
-            /// little endian order Shift the length and set the least
-            /// significant bit, b0=1.
+            // We use the long length prefix: b0=1, b63-b1=len, and store in little endian order
+            // Shift the length and set the least significant bit, b0=1.
             uint64_t lengthPrefix = ( static_cast<uint64_t>( len ) << 1 ) | 1LL;
             *outp++ = static_cast<uint8_t>( lengthPrefix );
             *outp++ = static_cast<uint8_t>( lengthPrefix >> ( 1 * 8 ) );
@@ -562,8 +579,9 @@ uint64_t BitpackStringEncoder::processRecords( size_t recordCount )
       }
       if ( isStringActive_ )
       {
-         /// Copy as much string as will fit in outBuffer
-         size_t bytesToProcess = std::min( currentString_.length() - currentCharPosition_, bytesFree );
+         // Copy as much string as will fit in outBuffer
+         size_t bytesToProcess =
+            std::min( currentString_.length() - currentCharPosition_, bytesFree );
 
          for ( size_t i = 0; i < bytesToProcess; i++ )
          {
@@ -574,7 +592,7 @@ uint64_t BitpackStringEncoder::processRecords( size_t recordCount )
          totalBytesProcessed_ += bytesToProcess;
          bytesFree -= bytesToProcess;
 
-         /// Check if finished string
+         // Check if finished string
          if ( currentCharPosition_ == currentString_.length() )
          {
             isStringActive_ = false;
@@ -583,7 +601,7 @@ uint64_t BitpackStringEncoder::processRecords( size_t recordCount )
       }
       if ( !isStringActive_ && recordsProcessed < recordCount )
       {
-         /// Get next string from sourceBuffer
+         // Get next string from sourceBuffer
          currentString_ = sourceBuffer_->getNextString();
          isStringActive_ = true;
          prefixComplete_ = false;
@@ -594,10 +612,10 @@ uint64_t BitpackStringEncoder::processRecords( size_t recordCount )
       }
    }
 
-   /// Update end of outBuffer
+   // Update end of outBuffer
    outBufferEnd_ = outBuffer_.size() - bytesFree;
 
-   /// Update counts of records processed
+   // Update counts of records processed
    currentRecordIndex_ += recordsProcessed;
 
    return ( currentRecordIndex_ );
@@ -605,19 +623,19 @@ uint64_t BitpackStringEncoder::processRecords( size_t recordCount )
 
 bool BitpackStringEncoder::registerFlushToOutput()
 {
-   /// Since have no registers in encoder, return success
+   // Since have no registers in encoder, return success
    return ( true );
 }
 
 float BitpackStringEncoder::bitsPerRecord()
 {
-   /// Return average number of bits in strings + 8 bits for prefix
+   // Return average number of bits in strings + 8 bits for prefix
    if ( currentRecordIndex_ > 0 )
    {
       return ( 8.0f * totalBytesProcessed_ ) / currentRecordIndex_ + 8;
    }
 
-   /// We haven't completed a record yet, so guess 100 bytes per record
+   // We haven't completed a record yet, so guess 100 bytes per record
    return 100 * 8.0f;
 }
 
@@ -636,13 +654,11 @@ void BitpackStringEncoder::dump( int indent, std::ostream &os ) const
 //================================================================
 
 template <typename RegisterT>
-BitpackIntegerEncoder<RegisterT>::BitpackIntegerEncoder( bool isScaledInteger, unsigned bytestreamNumber,
-                                                         SourceDestBuffer &sbuf, unsigned outputMaxSize,
-                                                         int64_t minimum, int64_t maximum, double scale,
-                                                         double offset ) :
+BitpackIntegerEncoder<RegisterT>::BitpackIntegerEncoder(
+   bool isScaledInteger, unsigned bytestreamNumber, SourceDestBuffer &sbuf, unsigned outputMaxSize,
+   int64_t minimum, int64_t maximum, double scale, double offset ) :
    BitpackEncoder( bytestreamNumber, sbuf, outputMaxSize, sizeof( RegisterT ) )
 {
-   /// Get pointer to parent ImageFileImpl
    ImageFileImplSharedPtr imf( sbuf.impl()->destImageFile() ); //??? should be function for this,
                                                                // imf->parentFile()  --> ImageFile?
 
@@ -657,30 +673,30 @@ BitpackIntegerEncoder<RegisterT>::BitpackIntegerEncoder( bool isScaledInteger, u
    register_ = 0;
 }
 
-template <typename RegisterT> uint64_t BitpackIntegerEncoder<RegisterT>::processRecords( size_t recordCount )
+template <typename RegisterT>
+uint64_t BitpackIntegerEncoder<RegisterT>::processRecords( size_t recordCount )
 {
    //??? what are state guarantees if get an exception during transfer?
 #ifdef E57_MAX_VERBOSE
-   std::cout << "BitpackIntegerEncoder::processRecords() called, sizeof(RegisterT)=" << sizeof( RegisterT )
-             << " recordCount=" << recordCount << std::endl;
+   std::cout << "BitpackIntegerEncoder::processRecords() called, sizeof(RegisterT)="
+             << sizeof( RegisterT ) << " recordCount=" << recordCount << std::endl;
    dump( 4 );
 #endif
 #ifdef E57_MAX_DEBUG
-   /// Double check that register will hold at least one input records worth of
-   /// bits
+   // Double check that register will hold at least one input records worth of bits
    if ( 8 * sizeof( RegisterT ) < bitsPerRecord_ )
    {
       throw E57_EXCEPTION2( ErrorInternal, "bitsPerRecord=" + toString( bitsPerRecord_ ) );
    }
 #endif
 
-   /// Before we add any more, try to shift current contents of outBuffer_ down
-   /// to beginning of buffer. This leaves outBufferEnd_ at a natural boundary.
+   // Before we add any more, try to shift current contents of outBuffer_ down to beginning of
+   // buffer. This leaves outBufferEnd_ at a natural boundary.
    outBufferShiftDown();
 
 #ifdef E57_DEBUG
-   /// Verify that outBufferEnd_ is multiple of sizeof(RegisterT) (so transfers
-   /// of RegisterT are aligned naturally in memory).
+   // Verify that outBufferEnd_ is multiple of sizeof(RegisterT) (so transfers of RegisterT are
+   // aligned naturally in memory).
    if ( outBufferEnd_ % sizeof( RegisterT ) )
    {
       throw E57_EXCEPTION2( ErrorInternal, "outBufferEnd=" + toString( outBufferEnd_ ) );
@@ -688,32 +704,31 @@ template <typename RegisterT> uint64_t BitpackIntegerEncoder<RegisterT>::process
    size_t transferMax = ( outBuffer_.size() - outBufferEnd_ ) / sizeof( RegisterT );
 #endif
 
-   /// Precalculate exact maximum number of records that will fit in output
-   /// before overflow.
+   // Precalculate exact maximum number of records that will fit in output
+   // before overflow.
    size_t outputWordCapacity = ( outBuffer_.size() - outBufferEnd_ ) / sizeof( RegisterT );
-   size_t maxOutputRecords =
-      ( outputWordCapacity * 8 * sizeof( RegisterT ) + 8 * sizeof( RegisterT ) - registerBitsUsed_ - 1 ) /
-      bitsPerRecord_;
+   size_t maxOutputRecords = ( outputWordCapacity * 8 * sizeof( RegisterT ) +
+                               8 * sizeof( RegisterT ) - registerBitsUsed_ - 1 ) /
+                             bitsPerRecord_;
 
-   /// Number of transfers is the smaller of what was requested and what will
-   /// fit.
+   // Number of transfers is the smaller of what was requested and what will fit.
    recordCount = std::min( recordCount, maxOutputRecords );
 #ifdef E57_MAX_VERBOSE
-   std::cout << "  outputWordCapacity=" << outputWordCapacity << " maxOutputRecords=" << maxOutputRecords
-             << " recordCount=" << recordCount << std::endl;
+   std::cout << "  outputWordCapacity=" << outputWordCapacity
+             << " maxOutputRecords=" << maxOutputRecords << " recordCount=" << recordCount
+             << std::endl;
 #endif
 
-   /// Form the starting address for next available location in outBuffer
+   // Form the starting address for next available location in outBuffer
    auto outp = reinterpret_cast<RegisterT *>( &outBuffer_[outBufferEnd_] );
    unsigned outTransferred = 0;
 
-   /// Copy bits from sourceBuffer_ to outBuffer_
+   // Copy bits from sourceBuffer_ to outBuffer_
    for ( unsigned i = 0; i < recordCount; i++ )
    {
       int64_t rawValue;
 
-      /// The parameter isScaledInteger_ determines which version of
-      /// getNextInt64 gets called
+      // The parameter isScaledInteger_ determines which version of getNextInt64 gets called
       if ( isScaledInteger_ )
       {
          rawValue = sourceBuffer_->getNextInt64( scale_, offset_ );
@@ -723,66 +738,68 @@ template <typename RegisterT> uint64_t BitpackIntegerEncoder<RegisterT>::process
          rawValue = sourceBuffer_->getNextInt64();
       }
 
-      /// Enforce min/max specification on value
+      // Enforce min/max specification on value
       if ( rawValue < minimum_ || maximum_ < rawValue )
       {
-         throw E57_EXCEPTION2( ErrorValueOutOfBounds, "rawValue=" + toString( rawValue ) + " minimum=" +
-                                                         toString( minimum_ ) + " maximum=" + toString( maximum_ ) );
+         throw E57_EXCEPTION2( ErrorValueOutOfBounds, "rawValue=" + toString( rawValue ) +
+                                                         " minimum=" + toString( minimum_ ) +
+                                                         " maximum=" + toString( maximum_ ) );
       }
 
       auto uValue = static_cast<uint64_t>( rawValue - minimum_ );
 
 #ifdef E57_MAX_VERBOSE
-      std::cout << "encoding integer rawValue=" << binaryString( rawValue ) << " = " << hexString( rawValue )
-                << std::endl;
-      std::cout << "                 uValue  =" << binaryString( uValue ) << " = " << hexString( uValue ) << std::endl;
+      std::cout << "encoding integer rawValue=" << binaryString( rawValue ) << " = "
+                << hexString( rawValue ) << std::endl;
+      std::cout << "                 uValue  =" << binaryString( uValue ) << " = "
+                << hexString( uValue ) << std::endl;
 #endif
 #ifdef E57_DEBUG
-      /// Double check that no bits outside of the mask are set
+      // Double check that no bits outside of the mask are set
       if ( uValue & ~static_cast<uint64_t>( sourceBitMask_ ) )
       {
          throw E57_EXCEPTION2( ErrorInternal, "uValue=" + toString( uValue ) );
       }
 #endif
-      /// Mask off upper bits (just in case)
+      // Mask off upper bits (just in case)
       uValue &= static_cast<uint64_t>( sourceBitMask_ );
 
-      /// See if uValue bits will fit in register
+      // See if uValue bits will fit in register
       unsigned newRegisterBitsUsed = registerBitsUsed_ + bitsPerRecord_;
 #ifdef E57_MAX_VERBOSE
-      std::cout << "  registerBitsUsed=" << registerBitsUsed_ << "  newRegisterBitsUsed=" << newRegisterBitsUsed
-                << std::endl;
+      std::cout << "  registerBitsUsed=" << registerBitsUsed_
+                << "  newRegisterBitsUsed=" << newRegisterBitsUsed << std::endl;
 #endif
       if ( newRegisterBitsUsed > 8 * sizeof( RegisterT ) )
       {
-         /// Have more than one registers worth, fill register, transfer, then
-         /// fill some more
+         // Have more than one registers worth, fill register, transfer, then fill some more
          register_ |= static_cast<RegisterT>( uValue ) << registerBitsUsed_;
 #ifdef E57_DEBUG
-         /// Before transfer, double check address within bounds
+         // Before transfer, double check address within bounds
          if ( outTransferred >= transferMax )
          {
-            throw E57_EXCEPTION2( ErrorInternal, "outTransferred=" + toString( outTransferred ) + " transferMax" +
-                                                    toString( transferMax ) );
+            throw E57_EXCEPTION2( ErrorInternal, "outTransferred=" + toString( outTransferred ) +
+                                                    " transferMax" + toString( transferMax ) );
          }
 #endif
          outp[outTransferred] = register_;
 
          outTransferred++;
 
-         register_ = static_cast<RegisterT>( uValue ) >> ( 8 * sizeof( RegisterT ) - registerBitsUsed_ );
+         register_ =
+            static_cast<RegisterT>( uValue ) >> ( 8 * sizeof( RegisterT ) - registerBitsUsed_ );
          registerBitsUsed_ = newRegisterBitsUsed - 8 * sizeof( RegisterT );
       }
       else if ( newRegisterBitsUsed == 8 * sizeof( RegisterT ) )
       {
-         /// Input will exactly fill register, insert value, then transfer
+         // Input will exactly fill register, insert value, then transfer
          register_ |= static_cast<RegisterT>( uValue ) << registerBitsUsed_;
 #ifdef E57_DEBUG
-         /// Before transfer, double check address within bounds
+         // Before transfer, double check address within bounds
          if ( outTransferred >= transferMax )
          {
-            throw E57_EXCEPTION2( ErrorInternal, "outTransferred=" + toString( outTransferred ) + " transferMax" +
-                                                    toString( transferMax ) );
+            throw E57_EXCEPTION2( ErrorInternal, "outTransferred=" + toString( outTransferred ) +
+                                                    " transferMax" + toString( transferMax ) );
          }
 #endif
          outp[outTransferred] = register_;
@@ -794,21 +811,21 @@ template <typename RegisterT> uint64_t BitpackIntegerEncoder<RegisterT>::process
       }
       else
       {
-         /// There is extra room in register, insert value, but don't do
-         /// transfer yet
+         // There is extra room in register, insert value, but don't do transfer yet
          register_ |= static_cast<RegisterT>( uValue ) << registerBitsUsed_;
          registerBitsUsed_ = newRegisterBitsUsed;
       }
 #ifdef E57_MAX_VERBOSE
-      std::cout << "  After " << outTransferred << " transfers and " << i + 1 << " records, encoder:" << std::endl;
+      std::cout << "  After " << outTransferred << " transfers and " << i + 1
+                << " records, encoder:" << std::endl;
       dump( 4 );
 #endif
    }
 
-   /// Update tail of output buffer
+   // Update tail of output buffer
    outBufferEnd_ += outTransferred * sizeof( RegisterT );
 #ifdef E57_DEBUG
-   /// Double check end is ok
+   // Double check end is ok
    if ( outBufferEnd_ > outBuffer_.size() )
    {
       throw E57_EXCEPTION2( ErrorInternal, "outBufferEnd=" + toString( outBufferEnd_ ) +
@@ -816,7 +833,7 @@ template <typename RegisterT> uint64_t BitpackIntegerEncoder<RegisterT>::process
    }
 #endif
 
-   /// Update counts of records processed
+   // Update counts of records processed
    currentRecordIndex_ += recordCount;
 
    return ( currentRecordIndex_ );
@@ -830,8 +847,8 @@ template <typename RegisterT> bool BitpackIntegerEncoder<RegisterT>::registerFlu
              << sizeof( RegisterT ) << std::endl;
    dump( 4 );
 #endif
-   /// If have any used bits in register, transfer to output, padded in MSBits
-   /// with zeros to RegisterT boundary
+   // If have any used bits in register, transfer to output, padded in MSBits with zeros to
+   // RegisterT boundary
    if ( registerBitsUsed_ > 0 )
    {
       if ( outBufferEnd_ < outBuffer_.size() - sizeof( RegisterT ) )
@@ -856,7 +873,8 @@ template <typename RegisterT> float BitpackIntegerEncoder<RegisterT>::bitsPerRec
 }
 
 #ifdef E57_DEBUG
-template <typename RegisterT> void BitpackIntegerEncoder<RegisterT>::dump( int indent, std::ostream &os ) const
+template <typename RegisterT>
+void BitpackIntegerEncoder<RegisterT>::dump( int indent, std::ostream &os ) const
 {
    BitpackEncoder::dump( indent, os );
    os << space( indent ) << "isScaledInteger:  " << isScaledInteger_ << std::endl;
@@ -865,40 +883,43 @@ template <typename RegisterT> void BitpackIntegerEncoder<RegisterT>::dump( int i
    os << space( indent ) << "scale:            " << scale_ << std::endl;
    os << space( indent ) << "offset:           " << offset_ << std::endl;
    os << space( indent ) << "bitsPerRecord:    " << bitsPerRecord_ << std::endl;
-   os << space( indent ) << "sourceBitMask:    " << binaryString( sourceBitMask_ ) << " " << hexString( sourceBitMask_ )
-      << std::endl;
-   os << space( indent ) << "register:         " << binaryString( register_ ) << " " << hexString( register_ )
-      << std::endl;
+   os << space( indent ) << "sourceBitMask:    " << binaryString( sourceBitMask_ ) << " "
+      << hexString( sourceBitMask_ ) << std::endl;
+   os << space( indent ) << "register:         " << binaryString( register_ ) << " "
+      << hexString( register_ ) << std::endl;
    os << space( indent ) << "registerBitsUsed: " << registerBitsUsed_ << std::endl;
 }
 #endif
 
 //================================================================
 
-ConstantIntegerEncoder::ConstantIntegerEncoder( unsigned bytestreamNumber, SourceDestBuffer &sbuf, int64_t minimum ) :
-   Encoder( bytestreamNumber ), sourceBuffer_( sbuf.impl() ), currentRecordIndex_( 0 ), minimum_( minimum )
+ConstantIntegerEncoder::ConstantIntegerEncoder( unsigned bytestreamNumber, SourceDestBuffer &sbuf,
+                                                int64_t minimum ) :
+   Encoder( bytestreamNumber ),
+   sourceBuffer_( sbuf.impl() ), currentRecordIndex_( 0 ), minimum_( minimum )
 {
 }
 
 uint64_t ConstantIntegerEncoder::processRecords( size_t recordCount )
 {
 #ifdef E57_MAX_VERBOSE
-   std::cout << "ConstantIntegerEncoder::processRecords() called, recordCount=" << recordCount << std::endl;
+   std::cout << "ConstantIntegerEncoder::processRecords() called, recordCount=" << recordCount
+             << std::endl;
    dump( 4 );
 #endif
 
-   /// Check that all source values are == minimum_
+   // Check that all source values are == minimum_
    for ( unsigned i = 0; i < recordCount; i++ )
    {
       int64_t nextInt64 = sourceBuffer_->getNextInt64();
       if ( nextInt64 != minimum_ )
       {
-         throw E57_EXCEPTION2( ErrorValueOutOfBounds,
-                               "nextInt64=" + toString( nextInt64 ) + " minimum=" + toString( minimum_ ) );
+         throw E57_EXCEPTION2( ErrorValueOutOfBounds, "nextInt64=" + toString( nextInt64 ) +
+                                                         " minimum=" + toString( minimum_ ) );
       }
    }
 
-   /// Update counts of records processed
+   // Update counts of records processed
    currentRecordIndex_ += recordCount;
 
    return ( currentRecordIndex_ );
@@ -916,7 +937,7 @@ uint64_t ConstantIntegerEncoder::currentRecordIndex()
 
 float ConstantIntegerEncoder::bitsPerRecord()
 {
-   /// We don't produce any output
+   // We don't produce any output
    return ( 0.0 );
 }
 
@@ -927,13 +948,13 @@ bool ConstantIntegerEncoder::registerFlushToOutput()
 
 size_t ConstantIntegerEncoder::outputAvailable() const
 {
-   /// We don't produce any output
+   // We don't produce any output
    return 0;
 }
 
 void ConstantIntegerEncoder::outputRead( char * /*dest*/, const size_t byteCount )
 {
-   /// Should never request any output data
+   // Should never request any output data
    if ( byteCount > 0 )
    {
       throw E57_EXCEPTION2( ErrorInternal, "byteCount=" + toString( byteCount ) );
@@ -946,7 +967,7 @@ void ConstantIntegerEncoder::outputClear()
 
 void ConstantIntegerEncoder::sourceBufferSetNew( std::vector<SourceDestBuffer> &sbufs )
 {
-   /// Verify that this encoder only has single input buffer
+   // Verify that this encoder only has single input buffer
    if ( sbufs.size() != 1 )
    {
       throw E57_EXCEPTION2( ErrorInternal, "sbufsSize=" + toString( sbufs.size() ) );
@@ -957,13 +978,13 @@ void ConstantIntegerEncoder::sourceBufferSetNew( std::vector<SourceDestBuffer> &
 
 size_t ConstantIntegerEncoder::outputGetMaxSize()
 {
-   /// We don't produce any output
+   // We don't produce any output
    return ( 0 );
 }
 
 void ConstantIntegerEncoder::outputSetMaxSize( unsigned /*byteCount*/ )
 {
-   /// Ignore, since don't produce any output
+   // Ignore, since don't produce any output
 }
 
 #ifdef E57_DEBUG

--- a/src/Encoder.h
+++ b/src/Encoder.h
@@ -34,9 +34,9 @@ namespace e57
    class Encoder
    {
    public:
-      static std::shared_ptr<Encoder> EncoderFactory( unsigned bytestreamNumber,
-                                                      std::shared_ptr<CompressedVectorNodeImpl> cVector,
-                                                      std::vector<SourceDestBuffer> &sbuf, ustring &codecPath );
+      static std::shared_ptr<Encoder> EncoderFactory(
+         unsigned bytestreamNumber, std::shared_ptr<CompressedVectorNodeImpl> cVector,
+         std::vector<SourceDestBuffer> &sbuf, ustring &codecPath );
 
       virtual ~Encoder() = default;
 
@@ -46,7 +46,7 @@ namespace e57
       virtual float bitsPerRecord() = 0;
       virtual bool registerFlushToOutput() = 0;
 
-      virtual size_t outputAvailable() const = 0;                  /// number of bytes that can be read
+      virtual size_t outputAvailable() const = 0; /// number of bytes that can be read
       virtual void outputRead( char *dest, size_t byteCount ) = 0; /// get data from encoder
       virtual void outputClear() = 0;
 
@@ -62,6 +62,7 @@ namespace e57
 #ifdef E57_DEBUG
       virtual void dump( int indent = 0, std::ostream &os = std::cout ) const;
 #endif
+
    protected:
       explicit Encoder( unsigned bytestreamNumber );
 
@@ -88,6 +89,7 @@ namespace e57
 #ifdef E57_DEBUG
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
+
    protected:
       BitpackEncoder( unsigned bytestreamNumber, SourceDestBuffer &sbuf, unsigned outputMaxSize,
                       unsigned alignmentSize );
@@ -107,8 +109,8 @@ namespace e57
    class BitpackFloatEncoder : public BitpackEncoder
    {
    public:
-      BitpackFloatEncoder( unsigned bytestreamNumber, SourceDestBuffer &sbuf, unsigned outputMaxSize,
-                           FloatPrecision precision );
+      BitpackFloatEncoder( unsigned bytestreamNumber, SourceDestBuffer &sbuf,
+                           unsigned outputMaxSize, FloatPrecision precision );
 
       uint64_t processRecords( size_t recordCount ) override;
       bool registerFlushToOutput() override;
@@ -117,6 +119,7 @@ namespace e57
 #ifdef E57_DEBUG
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
+
    protected:
       FloatPrecision precision_;
    };
@@ -124,7 +127,8 @@ namespace e57
    class BitpackStringEncoder : public BitpackEncoder
    {
    public:
-      BitpackStringEncoder( unsigned bytestreamNumber, SourceDestBuffer &sbuf, unsigned outputMaxSize );
+      BitpackStringEncoder( unsigned bytestreamNumber, SourceDestBuffer &sbuf,
+                            unsigned outputMaxSize );
 
       uint64_t processRecords( size_t recordCount ) override;
       bool registerFlushToOutput() override;
@@ -133,6 +137,7 @@ namespace e57
 #ifdef E57_DEBUG
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
+
    protected:
       uint64_t totalBytesProcessed_;
       bool isStringActive_;
@@ -144,8 +149,9 @@ namespace e57
    template <typename RegisterT> class BitpackIntegerEncoder : public BitpackEncoder
    {
    public:
-      BitpackIntegerEncoder( bool isScaledInteger, unsigned bytestreamNumber, SourceDestBuffer &sbuf,
-                             unsigned outputMaxSize, int64_t minimum, int64_t maximum, double scale, double offset );
+      BitpackIntegerEncoder( bool isScaledInteger, unsigned bytestreamNumber,
+                             SourceDestBuffer &sbuf, unsigned outputMaxSize, int64_t minimum,
+                             int64_t maximum, double scale, double offset );
 
       uint64_t processRecords( size_t recordCount ) override;
       bool registerFlushToOutput() override;
@@ -154,6 +160,7 @@ namespace e57
 #ifdef E57_DEBUG
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
+
    protected:
       bool isScaledInteger_;
       int64_t minimum_;
@@ -187,6 +194,7 @@ namespace e57
 #ifdef E57_DEBUG
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
+
    protected:
       std::shared_ptr<SourceDestBufferImpl> sourceBuffer_;
       uint64_t currentRecordIndex_;

--- a/src/FloatNode.cpp
+++ b/src/FloatNode.cpp
@@ -27,230 +27,19 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-//! @file FloatNode.cpp
+/// @file FloatNode.cpp
 
 #include "FloatNodeImpl.h"
 #include "StringFunctions.h"
 
 using namespace e57;
 
-/*!
-@class e57::FloatNode
-@brief   An E57 element encoding a single or double precision IEEE floating
-point number.
-@details
-An FloatNode is a terminal node (i.e. having no children) that holds an IEEE
-floating point value, and minimum/maximum bounds. The precision of the floating
-point value and attributes may be either single or double precision. Once the
-FloatNode value and attributes are set at creation, they may not be modified.
-
-If the precision option of the FloatNode is Single:
-The minimum attribute may be a number in the interval
-[-3.402823466e+38, 3.402823466e+38]. The maximum attribute may be a number in
-the interval [maximum, 3.402823466e+38]. The value may be a number in the
-interval [minimum, maximum].
-
-If the precision option of the FloatNode is Double:
-The minimum attribute may be a number in the interval
-[-1.7976931348623158e+308, 1.7976931348623158e+308]. The maximum attribute may
-be a number in the interval [maximum, 1.7976931348623158e+308]. The value may be
-a number in the interval [minimum, maximum].
-
-See Node class discussion for discussion of the common functions that
-StructureNode supports.
-
-@section FloatNode_invariant Class Invariant
-A class invariant is a list of statements about an object that are always true
-before and after any operation on the object. An invariant is useful for testing
-correct operation of an implementation. Statements in an invariant can involve
-only externally visible state, or can refer to internal implementation-specific
-state that is not visible to the API user. The following C++ code checks
-externally visible state for consistency and throws an exception if the
-invariant is violated:
-@dontinclude FloatNode.cpp
-@skip beginExample FloatNode::checkInvariant
-@until endExample FloatNode::checkInvariant
-
-@see     Node
-*/
-
-/*!
-@brief   Create an E57 element for storing an double precision IEEE floating point number.
-@param   [in] destImageFile   The ImageFile where the new node will eventually be stored.
-@param   [in] value     The double precision IEEE floating point value of the element.
-@param   [in] precision The precision of IEEE floating point to use. May be ::PrecisionSingle or ::PrecisionDouble.
-@param   [in] minimum   The smallest value that the value may take.
-@param   [in] maximum   The largest value that the value may take.
-@details
-An FloatNode stores an IEEE floating point number and a lower and upper bound.
-The FloatNode class corresponds to the ASTM E57 standard Float element.
-See the class discussion at bottom of FloatNode page for more details.
-
-The @a destImageFile indicates which ImageFile the FloatNode will eventually be
-attached to. A node is attached to an ImageFile by adding it underneath the
-predefined root of the ImageFile (gotten from ImageFile::root). It is not an
-error to fail to attach the FloatNode to the @a destImageFile. It is an error to
-attempt to attach the FloatNode to a different ImageFile.
-
-There is only one FloatNode constructor that handles both ::PrecisionSingle and
-::PrecisionDouble precision cases. If @a precision = ::PrecisionSingle, then the object will
-silently round the double precision @a value to the nearest representable single
-precision value. In this case, the lower bits will be lost, and if the value is
-outside the representable range of a single precision number, the exponent may
-be changed. The same is true for the @a minimum and @a maximum arguments.
-
-@b Warning: it is an error to give an @a value outside the @a minimum / @a
-maximum bounds, even if the FloatNode is destined to be used in a
-CompressedVectorNode prototype (where the @a value will be ignored). If the
-FloatNode is to be used in a prototype, it is recommended to specify a @a value
-= 0 if 0 is within bounds, or a @a value = @a minimum if 0 is not within bounds.
-@pre     The @a destImageFile must be open (i.e. destImageFile.isOpen() must be
-true).
-@pre     The @a destImageFile must have been opened in write mode (i.e.
-destImageFile.isWritable() must be true).
-@pre     minimum <= value <= maximum
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorFileReadOnly
-@throw   ::ErrorValueOutOfBounds
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     FloatPrecision, FloatNode::value, Node, CompressedVectorNode, CompressedVectorNode::prototype
-*/
-FloatNode::FloatNode( ImageFile destImageFile, double value, FloatPrecision precision, double minimum,
-                      double maximum ) :
-   impl_( new FloatNodeImpl( destImageFile.impl(), value, precision, minimum, maximum ) )
-{
-}
-
-//! @brief   Is this a root node.
-//! @copydetails Node::isRoot()
-bool FloatNode::isRoot() const
-{
-   return impl_->isRoot();
-}
-
-//! @brief   Return parent of node, or self if a root node.
-//! @copydetails Node::parent()
-Node FloatNode::parent() const
-{
-   return Node( impl_->parent() );
-}
-
-//! @brief   Get absolute pathname of node.
-//! @copydetails Node::pathName()
-ustring FloatNode::pathName() const
-{
-   return impl_->pathName();
-}
-
-//! @brief   Get elementName string, that identifies the node in its parent..
-//! @copydetails Node::elementName()
-ustring FloatNode::elementName() const
-{
-   return impl_->elementName();
-}
-
-//! @brief   Get the ImageFile that was declared as the destination for the node
-//! when it was created.
-//! @copydetails Node::destImageFile()
-ImageFile FloatNode::destImageFile() const
-{
-   return ImageFile( impl_->destImageFile() );
-}
-
-//! @brief   Has node been attached into the tree of an ImageFile.
-//! @copydetails Node::isAttached()
-bool FloatNode::isAttached() const
-{
-   return impl_->isAttached();
-}
-
-/*!
-@brief   Get IEEE floating point value stored.
-@details
-If precision is ::PrecisionSingle, the single precision value is returned as a double. If precision is
-::PrecisionDouble, the double precision value is returned as a double.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The IEEE floating point value stored, represented as a double.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     FloatNode::minimum, FloatNode::maximum
-*/
-double FloatNode::value() const
-{
-   return impl_->value();
-}
-
-/*!
-@brief   Get declared precision of the floating point number.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The declared precision of the floating point number, either ::PrecisionSingle or ::PrecisionDouble.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     FloatPrecision
-*/
-FloatPrecision FloatNode::precision() const
-{
-   return impl_->precision();
-}
-
-/*!
-@brief   Get the declared minimum that the value may take.
-@details
-If precision is ::PrecisionSingle, the single precision minimum is returned as a double. If precision is
-::PrecisionDouble, the double precision minimum is returned as a double.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The declared minimum that the value may take.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     FloatNode::maximum, FloatNode::value
-*/
-double FloatNode::minimum() const
-{
-   return impl_->minimum();
-}
-
-/*!
-@brief   Get the declared maximum that the value may take.
-@details
-If precision is ::PrecisionSingle, the single precision maximum is returned as a double. If precision is
-::PrecisionDouble, the double precision maximum is returned as a double.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The declared maximum that the value may take.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     FloatNode::minimum, FloatNode::value
-*/
-double FloatNode::maximum() const
-{
-   return impl_->maximum();
-}
-
-//! @brief   Diagnostic function to print internal state of object to output
-//! stream in an indented format.
-//! @copydetails Node::dump()
-#ifdef E57_DEBUG
-void FloatNode::dump( int indent, std::ostream &os ) const
-{
-   impl_->dump( indent, os );
-}
-#else
-void FloatNode::dump( int indent, std::ostream &os ) const
-{
-}
-#endif
-
-//! @brief Check whether FloatNode class invariant is true
-//! @copydetails IntegerNode::checkInvariant()
-// beginExample FloatNode::checkInvariant
+// Putting this function first so we can reference the code in doxygen using @skip
+/// @brief Check whether FloatNode class invariant is true
+/// @copydetails IntegerNode::checkInvariant()
 void FloatNode::checkInvariant( bool /*doRecurse*/, bool doUpcast )
 {
-   // If destImageFile not open, can't test invariant (almost every call would
-   // throw)
+   // If destImageFile not open, can't test invariant (almost every call would throw)
    if ( !destImageFile().isOpen() )
    {
       return;
@@ -264,7 +53,8 @@ void FloatNode::checkInvariant( bool /*doRecurse*/, bool doUpcast )
 
    if ( precision() == PrecisionSingle )
    {
-      if ( static_cast<float>( minimum() ) < FLOAT_MIN || static_cast<float>( maximum() ) > FLOAT_MAX )
+      if ( static_cast<float>( minimum() ) < FLOAT_MIN ||
+           static_cast<float>( maximum() ) > FLOAT_MAX )
       {
          throw E57_EXCEPTION1( ErrorInvarianceViolation );
       }
@@ -276,33 +66,280 @@ void FloatNode::checkInvariant( bool /*doRecurse*/, bool doUpcast )
       throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 }
-// endExample FloatNode::checkInvariant
 
 /*!
-@brief   Upcast a FloatNode handle to a generic Node handle.
-@details An upcast is always safe, and the compiler can automatically insert it
-for initializations of Node variables and Node function arguments.
-@return  A smart Node handle referencing the underlying object.
-@throw   No E57Exceptions.
-@see     Explanation in Node, Node::type()
+@class e57::FloatNode
+
+@brief An E57 element encoding a single or double precision IEEE floating point number.
+
+@details
+An FloatNode is a terminal node (i.e. having no children) that holds an IEEE floating point value,
+and minimum/maximum bounds. The precision of the floating point value and attributes may be either
+single or double precision. Once the FloatNode value and attributes are set at creation, they may
+not be modified.
+
+If the precision option of the FloatNode is Single:
+The minimum attribute may be a number in the interval [-3.402823466e+38, 3.402823466e+38]. The
+maximum attribute may be a number in the interval [maximum, 3.402823466e+38]. The value may be a
+number in the interval [minimum, maximum].
+
+If the precision option of the FloatNode is Double:
+The minimum attribute may be a number in the interval
+[-1.7976931348623158e+308, 1.7976931348623158e+308]. The maximum attribute may be a number in the
+interval [maximum, 1.7976931348623158e+308]. The value may be a number in the interval [minimum,
+maximum].
+
+See Node class discussion for discussion of the common functions that StructureNode supports.
+
+@section FloatNode_invariant Class Invariant
+A class invariant is a list of statements about an object that are always true before and after any
+operation on the object. An invariant is useful for testing correct operation of an implementation.
+Statements in an invariant can involve only externally visible state, or can refer to internal
+implementation-specific state that is not visible to the API user. The following C++ code checks
+externally visible state for consistency and throws an exception if the invariant is violated:
+
+@dontinclude FloatNode.cpp
+@skip void FloatNode::checkInvariant
+@until ^}
+
+@see  Node
+*/
+
+/*!
+@brief Create an E57 element for storing an double precision IEEE floating point number.
+
+@param [in] destImageFile The ImageFile where the new node will eventually be stored.
+@param [in] value The double precision IEEE floating point value of the element.
+@param [in] precision The precision of IEEE floating point to use. May be ::PrecisionSingle or
+::PrecisionDouble.
+@param [in] minimum The smallest value that the value may take.
+@param [in] maximum The largest value that the value may take.
+
+@details
+An FloatNode stores an IEEE floating point number and a lower and upper bound. The FloatNode class
+corresponds to the ASTM E57 standard Float element. See the class discussion at bottom of FloatNode
+page for more details.
+
+The @a destImageFile indicates which ImageFile the FloatNode will eventually be attached to. A node
+is attached to an ImageFile by adding it underneath the predefined root of the ImageFile (gotten
+from ImageFile::root). It is not an error to fail to attach the FloatNode to the @a destImageFile.
+It is an error to attempt to attach the FloatNode to a different ImageFile.
+
+There is only one FloatNode constructor that handles both ::PrecisionSingle and ::PrecisionDouble
+precision cases. If @a precision = ::PrecisionSingle, then the object will silently round the double
+precision @a value to the nearest representable single precision value. In this case, the lower bits
+will be lost, and if the value is outside the representable range of a single precision number, the
+exponent may be changed. The same is true for the @a minimum and @a maximum arguments.
+
+@warning It is an error to give an @a value outside the @a minimum / @a maximum bounds, even if the
+FloatNode is destined to be used in a CompressedVectorNode prototype (where the @a value will be
+ignored). If the FloatNode is to be used in a prototype, it is recommended to specify a @a value = 0
+if 0 is within bounds, or a @a value = @a minimum if 0 is not within bounds.
+
+@pre The @a destImageFile must be open (i.e. destImageFile.isOpen() must be true).
+@pre The @a destImageFile must have been opened in write mode (i.e. destImageFile.isWritable() must
+be true).
+@pre minimum <= value <= maximum
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorFileReadOnly
+@throw ::ErrorValueOutOfBounds
+@throw ::ErrorInternal All objects in undocumented state
+
+@see FloatPrecision, FloatNode::value, Node, CompressedVectorNode, CompressedVectorNode::prototype
+*/
+FloatNode::FloatNode( ImageFile destImageFile, double value, FloatPrecision precision,
+                      double minimum, double maximum ) :
+   impl_( new FloatNodeImpl( destImageFile.impl(), value, precision, minimum, maximum ) )
+{
+}
+
+/*!
+@brief Is this a root node.
+@copydetails Node::isRoot()
+*/
+bool FloatNode::isRoot() const
+{
+   return impl_->isRoot();
+}
+
+/*!
+@brief Return parent of node, or self if a root node.
+@copydetails Node::parent()
+*/
+Node FloatNode::parent() const
+{
+   return Node( impl_->parent() );
+}
+
+/*!
+@brief Get absolute pathname of node.
+@copydetails Node::pathName()
+*/
+ustring FloatNode::pathName() const
+{
+   return impl_->pathName();
+}
+
+/*!
+@brief Get elementName string, that identifies the node in its parent.
+@copydetails Node::elementName()
+*/
+ustring FloatNode::elementName() const
+{
+   return impl_->elementName();
+}
+
+/*!
+@brief Get the ImageFile that was declared as the destination for the node when it was created.
+@copydetails Node::destImageFile()
+*/
+ImageFile FloatNode::destImageFile() const
+{
+   return ImageFile( impl_->destImageFile() );
+}
+
+/*!
+@brief Has node been attached into the tree of an ImageFile.
+@copydetails Node::isAttached()
+*/
+bool FloatNode::isAttached() const
+{
+   return impl_->isAttached();
+}
+
+/*!
+@brief Get IEEE floating point value stored.
+
+@details
+If precision is ::PrecisionSingle, the single precision value is returned as a double. If precision
+is ::PrecisionDouble, the double precision value is returned as a double.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return The IEEE floating point value stored, represented as a double.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal           All objects in undocumented state
+
+@see FloatNode::minimum, FloatNode::maximum
+*/
+double FloatNode::value() const
+{
+   return impl_->value();
+}
+
+/*!
+@brief Get declared precision of the floating point number.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return The declared precision of the floating point number, either ::PrecisionSingle or
+::PrecisionDouble.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see FloatPrecision
+*/
+FloatPrecision FloatNode::precision() const
+{
+   return impl_->precision();
+}
+
+/*!
+@brief Get the declared minimum that the value may take.
+
+@details
+If precision is ::PrecisionSingle, the single precision minimum is returned as a double. If
+precision is ::PrecisionDouble, the double precision minimum is returned as a double.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return The declared minimum that the value may take.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see FloatNode::maximum, FloatNode::value
+*/
+double FloatNode::minimum() const
+{
+   return impl_->minimum();
+}
+
+/*!
+@brief Get the declared maximum that the value may take.
+
+@details
+If precision is ::PrecisionSingle, the single precision maximum is returned as a double. If
+precision is ::PrecisionDouble, the double precision maximum is returned as a double.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return The declared maximum that the value may take.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see FloatNode::minimum, FloatNode::value
+*/
+double FloatNode::maximum() const
+{
+   return impl_->maximum();
+}
+
+/*!
+@brief Diagnostic function to print internal state of object to output stream in an indented format.
+@copydetails Node::dump()
+*/
+#ifdef E57_DEBUG
+void FloatNode::dump( int indent, std::ostream &os ) const
+{
+   impl_->dump( indent, os );
+}
+#else
+void FloatNode::dump( int indent, std::ostream &os ) const
+{
+}
+#endif
+
+/*!
+@brief Upcast a FloatNode handle to a generic Node handle.
+
+@details An upcast is always safe, and the compiler can automatically insert it for initializations
+of Node variables and Node function arguments.
+
+@return A smart Node handle referencing the underlying object.
+
+@throw No E57Exceptions.
+
+@see Explanation in Node, Node::type()
 */
 FloatNode::operator Node() const
 {
-   /// Upcast from shared_ptr<FloatNodeImpl> to SharedNodeImplPtr and construct
-   /// a Node object
+   // Upcast from shared_ptr<FloatNodeImpl> to SharedNodeImplPtr and construct a Node object
    return Node( impl_ );
 }
 
 /*!
-@brief   Downcast a generic Node handle to a FloatNode handle.
-@param   [in] n The generic handle to downcast.
-@details The handle @a n must be for an underlying FloatNode, otherwise an
-exception is thrown. In designs that need to avoid the exception, use
-Node::type() to determine the actual type of the @a n before downcasting. This
-function must be explicitly called (c++ compiler cannot insert it
-automatically).
-@throw   ::ErrorBadNodeDowncast
-@see     Node::type(), FloatNode::operator Node()
+@brief Downcast a generic Node handle to a FloatNode handle.
+
+@param [in] n The generic handle to downcast.
+
+@details
+The handle @a n must be for an underlying FloatNode, otherwise an exception is thrown. In designs
+that need to avoid the exception, use Node::type() to determine the actual type of the @a n before
+downcasting. This function must be explicitly called (c++ compiler cannot insert it automatically).
+
+@throw ::ErrorBadNodeDowncast
+
+@see Node::type(), FloatNode::operator Node()
 */
 FloatNode::FloatNode( const Node &n )
 {
@@ -311,13 +348,12 @@ FloatNode::FloatNode( const Node &n )
       throw E57_EXCEPTION2( ErrorBadNodeDowncast, "nodeType=" + toString( n.type() ) );
    }
 
-   /// Set our shared_ptr to the downcast shared_ptr
+   // Set our shared_ptr to the downcast shared_ptr
    impl_ = std::static_pointer_cast<FloatNodeImpl>( n.impl() );
 }
 
-//! @cond documentNonPublic   The following isn't part of the API, and isn't
-//! documented.
+/// @cond documentNonPublic The following isn't part of the API, and isn't documented.
 FloatNode::FloatNode( std::shared_ptr<FloatNodeImpl> ni ) : impl_( ni )
 {
 }
-//! @endcond
+/// @endcond

--- a/src/FloatNodeImpl.cpp
+++ b/src/FloatNodeImpl.cpp
@@ -31,16 +31,15 @@
 
 namespace e57
 {
-   FloatNodeImpl::FloatNodeImpl( ImageFileImplWeakPtr destImageFile, double value, FloatPrecision precision,
-                                 double minimum, double maximum ) :
+   FloatNodeImpl::FloatNodeImpl( ImageFileImplWeakPtr destImageFile, double value,
+                                 FloatPrecision precision, double minimum, double maximum ) :
       NodeImpl( destImageFile ),
       value_( value ), precision_( precision ), minimum_( minimum ), maximum_( maximum )
    {
       // don't checkImageFileOpen, NodeImpl() will do it
 
-      /// Since this ctor also used to construct single precision, and defaults for
-      /// minimum/maximum are for double precision, adjust bounds smaller if
-      /// single.
+      // Since this ctor also used to construct single precision, and defaults for minimum/maximum
+      // are for double precision, adjust bounds smaller if single.
       if ( precision_ == PrecisionSingle )
       {
          if ( minimum_ < FLOAT_MIN )
@@ -53,12 +52,13 @@ namespace e57
          }
       }
 
-      /// Enforce the given bounds on raw value
+      // Enforce the given bounds on raw value
       if ( value < minimum || maximum < value )
       {
-         throw E57_EXCEPTION2( ErrorValueOutOfBounds,
-                               "this->pathName=" + this->pathName() + " value=" + toString( value ) +
-                                  " minimum=" + toString( minimum ) + " maximum=" + toString( maximum ) );
+         throw E57_EXCEPTION2( ErrorValueOutOfBounds, "this->pathName=" + this->pathName() +
+                                                         " value=" + toString( value ) +
+                                                         " minimum=" + toString( minimum ) +
+                                                         " maximum=" + toString( maximum ) );
       }
    }
 
@@ -66,36 +66,36 @@ namespace e57
    {
       // don't checkImageFileOpen
 
-      /// Same node type?
+      // Same node type?
       if ( ni->type() != TypeFloat )
       {
          return ( false );
       }
 
-      /// Downcast to shared_ptr<FloatNodeImpl>
+      // Downcast to shared_ptr<FloatNodeImpl>
       std::shared_ptr<FloatNodeImpl> fi( std::static_pointer_cast<FloatNodeImpl>( ni ) );
 
-      /// precision must match
+      // precision must match
       if ( precision_ != fi->precision_ )
       {
          return ( false );
       }
 
-      /// minimum must match
+      // minimum must match
       if ( minimum_ != fi->minimum_ )
       {
          return ( false );
       }
 
-      /// maximum must match
+      // maximum must match
       if ( maximum_ != fi->maximum_ )
       {
          return ( false );
       }
 
-      /// ignore value_, doesn't have to match
+      // ignore value_, doesn't have to match
 
-      /// Types match
+      // Types match
       return ( true );
    }
 
@@ -103,7 +103,7 @@ namespace e57
    {
       // don't checkImageFileOpen
 
-      /// We have no sub-structure, so if path not empty return false
+      // We have no sub-structure, so if path not empty return false
       return pathName.empty();
    }
 
@@ -135,8 +135,7 @@ namespace e57
    {
       // don't checkImageFileOpen
 
-      /// We are a leaf node, so verify that we are listed in set (either relative
-      /// or absolute form)
+      // We are a leaf node, so verify that we are listed in set (either relative or absolute form)
       if ( pathNames.find( relativePathName( origin ) ) == pathNames.end() &&
            pathNames.find( pathName() ) == pathNames.end() )
       {
@@ -164,7 +163,7 @@ namespace e57
       {
          cf << " precision=\"single\"";
 
-         /// Don't need to write if are default values
+         // Don't need to write if are default values
          if ( minimum_ > FLOAT_MIN )
          {
             cf << " minimum=\"" << static_cast<float>( minimum_ ) << "\"";
@@ -174,7 +173,7 @@ namespace e57
             cf << " maximum=\"" << static_cast<float>( maximum_ ) << "\"";
          }
 
-         /// Write value as child text, unless it is the default value
+         // Write value as child text, unless it is the default value
          if ( value_ != 0.0 )
          {
             cf << ">" << static_cast<float>( value_ ) << "</" << fieldName << ">\n";
@@ -186,9 +185,9 @@ namespace e57
       }
       else
       {
-         /// Don't need to write precision="double", because that's the default
+         // Don't need to write precision="double", because that's the default
 
-         /// Don't need to write if are default values
+         // Don't need to write if are default values
          if ( minimum_ > DOUBLE_MIN )
          {
             cf << " minimum=\"" << minimum_ << "\"";
@@ -198,7 +197,7 @@ namespace e57
             cf << " maximum=\"" << maximum_ << "\"";
          }
 
-         /// Write value as child text, unless it is the default value
+         // Write value as child text, unless it is the default value
          if ( value_ != 0.0 )
          {
             cf << ">" << value_ << "</" << fieldName << ">\n";
@@ -227,15 +226,16 @@ namespace e57
          os << "double" << std::endl;
       }
 
-      /// Save old stream config
+      // Save old stream config
       const std::streamsize oldPrecision = os.precision();
       const std::ios_base::fmtflags oldFlags = os.flags();
 
-      os << space( indent ) << std::scientific << std::setprecision( 17 ) << "value:       " << value_ << std::endl;
+      os << space( indent ) << std::scientific << std::setprecision( 17 )
+         << "value:       " << value_ << std::endl;
       os << space( indent ) << "minimum:     " << minimum_ << std::endl;
       os << space( indent ) << "maximum:     " << maximum_ << std::endl;
 
-      /// Restore old stream config
+      // Restore old stream config
       os.precision( oldPrecision );
       os.flags( oldFlags );
    }

--- a/src/FloatNodeImpl.h
+++ b/src/FloatNodeImpl.h
@@ -34,8 +34,8 @@ namespace e57
    {
    public:
       explicit FloatNodeImpl( ImageFileImplWeakPtr destImageFile, double value = 0,
-                              FloatPrecision precision = PrecisionDouble, double minimum = DOUBLE_MIN,
-                              double maximum = DOUBLE_MAX );
+                              FloatPrecision precision = PrecisionDouble,
+                              double minimum = DOUBLE_MIN, double maximum = DOUBLE_MAX );
       ~FloatNodeImpl() override = default;
 
       NodeType type() const override

--- a/src/ImageFile.cpp
+++ b/src/ImageFile.cpp
@@ -27,550 +27,33 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-//! @file ImageFile.cpp
+/// @file ImageFile.cpp
 
 #include "ImageFileImpl.h"
 
 using namespace e57;
 
-/*!
-@class e57::ImageFile
-@brief   An ASTM E57 3D format file object.
-@details
-@section imagefile_ClassOverview Class overview
-The ImageFile class represents the state of an ASTM E57 format data file.
-An ImageFile may be created from an E57 file on the disk (read mode).
-An new ImageFile may be created to write an E57 file to disk (write mode).
-
-E57 files are organized in a tree structure.
-Each ImageFile object has a predefined root node (of type StructureNode).
-In a write mode ImageFile, the root node is initially empty.
-In a read mode ImageFile, the root node is populated by the tree stored in the
-.e57 file on disk.
-
-@section imagefile_OpenClose The open/close state
-An ImageFile object, opened in either mode (read/write), can be in one of two
-states: open or closed. An ImageFile in the open state is ready to perform
-transfers of data and to be interrogated. An ImageFile in the closed state
-cannot perform any further transfers, and has very limited ability to be
-interrogated. Note entering the closed state is different than destroying the
-ImageFile object. An ImageFile object can still exist and be in the closed
-state. When created, the ImageFile is initially open.
-
-The ImageFile state can transition to the closed state in two ways.
-The programmer can call ImageFile::close after all required processing has
-completed. The programmer can call ImageFile::cancel if it is determined that
-the ImageFile is no longer needed.
-
-@section imagefile_Extensions Extensions
-
-Basically in an E57 file, "extension = namespace + rules + meaning".
-The "namespace" ensures that element names don't collide.
-The "rules" may be written on paper, or partly codified in a computer grammar.
-The "meaning" is a definition of what was measured, what the numbers in the file
-mean.
-
-Extensions are identified by URIs.
-Extensions are not identified by prefixes.
-Prefixes are a shorthand, used in a particular file, to make the element names
-more palatable for humans. When thinking about a prefixed element name, in your
-mind you should immediately substitute the URI for the prefix. For example,
-think "http://www.example.com/DemoExtension:extra2" rather than "demo:extra2",
-if the prefix "demo" is declared in the file to be a shorthand for the URI
-"http://www.example.com/DemoExtension".
-
-The rules are statements of: what is valid, what element names are possible,
-what values are possible. The rules establish the answer to the following yes/no
-question: "Is this extended E57 file valid?". The rules divide all possible
-files into two sets: valid files and invalid files.
-
-The "meanings" part of the above equation defines what the files in the first
-set, the valid files, actually mean. This definition usually comes in the form
-of documentation of the content of each new element in the format and how they
-relate to the other elements.
-
-An element name in an E57 file is a member of exactly one namespace (either the
-default namespace defined in the ASTM standard, or an extension namespace).
-Rules about the structure of an E57 extension (what element names can appear
-where), are implicitly assumed only to govern the element names within the
-namespace of the extension. Element names in other namespaces are unconstrained.
-This is because a reader is required to ignore elements in namespaces that are
-unfamiliar (to treat them as if they didn't exist). This enables a writer to
-"tack on" new elements into pre-defined structures (e.g. structures defined in
-the ASTM standard), without fear that it will confuse a reader that is only
-familiar with the old format. This allows an extension designer to communicate
-to two sets of readers: the old readers that will understand the information in
-the old base format, and the new-fangled readers that will be able to read the
-base format and the extra information stored in element names in the extended
-namespace.
-
-@section ImageFile_invariant Class Invariant
-A class invariant is a list of statements about an object that are always true
-before and after any operation on the object. An invariant is useful for testing
-correct operation of an implementation. Statements in an invariant can involve
-only externally visible state, or can refer to internal implementation-specific
-state that is not visible to the API user. The following C++ code checks
-externally visible state for consistency and throws an exception if the
-invariant is violated:
-@dontinclude ImageFile.cpp
-@skip beginExample ImageFile::checkInvariant
-@until endExample ImageFile::checkInvariant
-*/
-
-/*!
-@brief   Open an ASTM E57 imaging data file for reading/writing.
-@param   [in] fname File name to open.
-Support of '\' as a directory separating character is system dependent.
-For maximum portability, it is recommended that '/' be used as a directory
-separator in file names. Special device file name support are implementation
-dependent (e.g. "\\.\PhysicalDrive3" or
-"/dev/hd3"). It is recommended that files that meet all of the requirements for
-a legal ASTM E57 file format use the extension @c ".e57". It is recommended that
-files that utilize the low-level E57 element data types, but do not have all the
-required element names required by ASTM E57 file format standard use the file
-extension @c "._e57".
-@param   [in] mode Either "w" for writing or "r" for reading.
-@param   [in] checksumPolicy The percentage of checksums we compute and verify
-as an int. Clamped to 0-100.
-@details
-
-@par Write Mode
-In write mode, the file cannot be already open.
-A file with name given by @a fname is immediately created on the disk.
-This file may grow as a result of operations on the ImageFile.
-Which API functions write data to the file are implementation dependent.
-Thus any API operation that stores data may fail as a result of insufficient
-free disk space. Read API operations are legal for an ImageFile opened in write
-mode.
-
-@par Read Mode
-Read mode files may be shared.
-Write API operations are not legal for an ImageFile opened in read mode (i.e.
-the ImageFile is read-only). There is no API support for appending data onto an
-existing E57 data file.
-
-@post    Resulting ImageFile is in @c open state if constructor succeeds (no
-exception thrown).
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorOpenFailed
-@throw   ::ErrorSeekFailed
-@throw   ::ErrorReadFailed
-@throw   ::ErrorWriteFailed
-@throw   ::ErrorBadChecksum
-@throw   ::ErrorBadFileSignature
-@throw   ::ErrorUnknownFileVersion
-@throw   ::ErrorBadFileLength
-@throw   ::ErrorXMLParserInit
-@throw   ::ErrorXMLParser
-@throw   ::ErrorBadXMLFormat
-@throw   ::ErrorBadConfiguration
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     IntegerNode, ScaledIntegerNode, FloatNode,
-StringNode, BlobNode, StructureNode, VectorNode, CompressedVectorNode,
-E57Exception, E57Utilities::E57Utilities
-*/
-ImageFile::ImageFile( const ustring &fname, const ustring &mode, ReadChecksumPolicy checksumPolicy ) :
-   impl_( new ImageFileImpl( checksumPolicy ) )
-{
-   /// Do second phase of construction, now that ImageFile object is complete.
-   impl_->construct2( fname, mode );
-}
-
-ImageFile::ImageFile( const char *input, const uint64_t size, ReadChecksumPolicy checksumPolicy ) :
-   impl_( new ImageFileImpl( checksumPolicy ) )
-{
-   impl_->construct2( input, size );
-}
-
-/*!
-@brief   Get the pre-established root StructureNode of the E57 ImageFile.
-@details The root node of an ImageFile always exists and is always type
-StructureNode. The root node is empty in a newly created write mode ImageFile.
-@pre     This ImageFile must be open (i.e. isOpen()).
-@return  A smart StructureNode handle referencing the underlying object.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     StructureNode.
-*/
-StructureNode ImageFile::root() const
-{
-   return StructureNode( impl_->root() );
-}
-
-/*!
-@brief   Complete any write operations on an ImageFile, and close the file on
-the disk.
-@details
-Completes the writing of the state of the ImageFile to the disk.
-Some API implementations may store significant portions of the state of the
-ImageFile in memory. This state is moved into the disk file before it is closed.
-Any errors in finishing the writing are reported by throwing an exception.
-If an exception is thrown, depending on the error code, the ImageFile may enter
-the closed state. If no exception is thrown, then the file on disk will be an
-accurate representation of the ImageFile.
-
-@b Warning: if the ImageFile::close function is not called, and the ImageFile
-destructor is invoked with the ImageFile in the open state, the associated disk
-file will be deleted and the ImageFile will @em not be saved to the disk (the
-same outcome as calling ImageFile::cancel). The reason for this is that any
-error conditions can't be reported from a destructor, so the user can't be
-assured that the destruction/close completed successfully. It is strongly
-recommended that this close function be called before the ImageFile is
-destroyed.
-
-It is not an error if ImageFile is already closed.
-@post    ImageFile is in @c closed state.
-@throw   ::ErrorSeekFailed
-@throw   ::ErrorReadFailed
-@throw   ::ErrorWriteFailed
-@throw   ::ErrorCloseFailed
-@throw   ::ErrorBadChecksum
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ImageFile::cancel, ImageFile::isOpen
-*/
-void ImageFile::close()
-{
-   impl_->close();
-}
-
-/*!
-@brief   Stop I/O operations and delete a partially written ImageFile on the
-disk.
-@details
-If the ImageFile is write mode, the associated file on the disk is closed and
-deleted, and the ImageFile goes to the closed state. If the ImageFile is read
-mode, the behavior is same as calling ImageFile::close, but no exceptions are
-thrown. It is not an error if ImageFile is already closed.
-@post    ImageFile is in @c closed state.
-@throw   No E57Exceptions.
-@see     ImageFile::ImageFile, ImageFile::close, ImageFile::isOpen
-*/
-void ImageFile::cancel()
-{
-   impl_->cancel();
-}
-
-/*!
-@brief   Test whether ImageFile is still open for accessing.
-@post    No visible state is modified.
-@return  true if ImageFile is in @c open state.
-@throw   No E57Exceptions.
-@see     ImageFile::ImageFile, ImageFile::close
-*/
-bool ImageFile::isOpen() const
-{
-   return impl_->isOpen();
-}
-
-/*!
-@brief   Test whether ImageFile was opened in write mode.
-@post    No visible state is modified.
-@return  true if ImageFile was opened in write mode.
-@throw   No E57Exceptions.
-@see     ImageFile::ImageFile, ImageFile::isOpen
-*/
-bool ImageFile::isWritable() const
-{
-   return impl_->isWriter();
-}
-
-/*!
-@brief   Get the file name the ImageFile was created with.
-@post    No visible state is modified.
-@return  The file name the ImageFile was created with.
-@throw   No E57Exceptions.
-@see     Cancel.cpp example, ImageFile::ImageFile
-*/
-ustring ImageFile::fileName() const
-{
-   return impl_->fileName();
-}
-
-/*!
-@brief   Get current number of open CompressedVectorWriter objects writing to
-ImageFile.
-@details
-CompressedVectorWriter objects that still exist, but are in the closed state
-aren't counted. CompressedVectorWriter objects are created by the
-CompressedVectorNode::writer function.
-@pre     This ImageFile must be open (i.e. isOpen()).
-@post    No visible state is modified.
-@return  The current number of open CompressedVectorWriter objects writing to
-ImageFile.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorNode::writer, CompressedVectorWriter
-*/
-int ImageFile::writerCount() const
-{
-   return impl_->writerCount();
-}
-
-/*!
-@brief   Get current number of open CompressedVectorReader objects reading from
-ImageFile.
-@details
-CompressedVectorReader objects that still exist, but are in the closed state
-aren't counted. CompressedVectorReader objects are created by the
-CompressedVectorNode::reader function.
-@pre     This ImageFile must be open (i.e. isOpen()).
-@post    No visible state is modified.
-@return  The current number of open CompressedVectorReader objects reading from
-ImageFile.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVectorNode::reader, CompressedVectorReader
-*/
-int ImageFile::readerCount() const
-{
-   return impl_->readerCount();
-}
-
-/*!
-@brief   Declare the use of an E57 extension in an ImageFile being written.
-@param   [in] prefix    The shorthand name of the extension to use in element
-names.
-@param   [in] uri       The Uniform Resource Identifier string to associate with
-the prefix in the ImageFile.
-@details
-The (@a prefix, @a uri) pair is registered in the known extensions of the
-ImageFile. Both @a prefix and @a uri must be unique in the ImageFile. It is not
-legal to declare a URI associated with the default namespace (@a prefix = "").
-It is not an error to declare a namespace and not use it in an element name.
-It is an error to use a namespace prefix in an element name that is not declared
-beforehand.
-
-A writer is free to "hard code" the prefix names in the element name strings
-that it uses (since it established the prefix declarations in the file). A
-reader cannot assume that any given prefix is always mapped to the same URI or
-vice versa. A reader might check an ImageFile, and if the prefixes aren't the
-way it likes, the reader could give up.
-
-A better scheme would be to lookup the URI that the reader is familiar with, and
-store the prefix that the particular file uses in a variable. Then every time
-the reader needs to form a prefixed element name, it can assemble the full
-element name from the stored prefix variable and the constant documented base
-name string. This is less convenient than using a single "hard coded" string
-constant for an element name, but it is robust against any choice of prefix/URI
-combination.
-
-See the class discussion at bottom of ImageFile page for more details about
-namespaces.
-@pre     This ImageFile must be open (i.e. isOpen()).
-@pre     ImageFile must have been opened in write mode (i.e. isWritable()).
-@pre     prefix != ""
-@pre     uri != ""
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorFileReadOnly
-@throw   ::ErrorDuplicateNamespacePrefix
-@throw   ::ErrorDuplicateNamespaceURI
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ImageFile::extensionsCount, ImageFile::extensionsLookupPrefix, ImageFile::extensionsLookupUri
-*/
-void ImageFile::extensionsAdd( const ustring &prefix, const ustring &uri )
-{
-   impl_->extensionsAdd( prefix, uri );
-}
-
-/*!
-@brief   Look up an E57 extension prefix in the ImageFile.
-@param   [in] prefix The shorthand name of the extension to look up.
-@details
-If @a prefix = "" or @a prefix is declared in the ImageFile, then the function returns true. It is an error if @a prefix
-contains an illegal character combination for E57 namespace prefixes.
-@pre     This ImageFile must be open (i.e. isOpen()).
-@post    No visible state is modified.
-@return  true if prefix is declared in the ImageFile.
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ImageFile::extensionsLookupUri
-*/
-bool ImageFile::extensionsLookupPrefix( const ustring &prefix ) const
-{
-   ustring uri;
-   return impl_->extensionsLookupPrefix( prefix, uri );
-}
-
-/*!
-@brief   Get URI associated with an E57 extension prefix in the ImageFile.
-@param   [in] prefix    The shorthand name of the extension to look up.
-@param   [out] uri      The URI that was associated with the given @a prefix.
-@details
-If @a prefix = "", then @a uri is set to the default namespace URI, and the
-function returns true. if @a prefix is declared in the ImageFile, then @a uri is
-set the corresponding URI, and the function returns true. It is an error if @a
-prefix contains an illegal character combination for E57 namespace prefixes. It
-is not an error if @a prefix is well-formed, but not defined in the ImageFile
-(the function just returns false).
-@pre     This ImageFile must be open (i.e. isOpen()).
-@post    No visible state is modified.
-@return  true if prefix is declared in the ImageFile.
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ImageFile::extensionsLookupUri
-*/
-bool ImageFile::extensionsLookupPrefix( const ustring &prefix, ustring &uri ) const
-{
-   return impl_->extensionsLookupPrefix( prefix, uri );
-}
-
-/*!
-@brief   Get an E57 extension prefix associated with a URI in the ImageFile.
-@param   [in] uri       The URI of the extension to look up.
-@param   [out] prefix   The shorthand prefix that was associated with the given
-@a uri.
-@details
-If @a uri is declared in the ImageFile, then @a prefix is set the corresponding
-prefix, and the function returns true. It is an error if @a uri contains an
-illegal character combination for E57 namespace URIs. It is not an error if @a
-uri is well-formed, but not defined in the ImageFile (the function just returns
-false).
-@pre     This ImageFile must be open (i.e. isOpen()).
-@pre     uri != ""
-@post    No visible state is modified.
-@return  true if URI is declared in the ImageFile.
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ImageFile::extensionsLookupPrefix
-*/
-bool ImageFile::extensionsLookupUri( const ustring &uri, ustring &prefix ) const
-{
-   return impl_->extensionsLookupUri( uri, prefix );
-}
-
-/*!
-@brief   Get number of E57 extensions declared in the ImageFile.
-@details
-The default E57 namespace does not count as an extension.
-@pre     This ImageFile must be open (i.e. isOpen()).
-@post    No visible state is modified.
-@return  The number of E57 extensions defined in the ImageFile.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ImageFile::extensionsPrefix, ImageFile::extensionsUri
-*/
-size_t ImageFile::extensionsCount() const
-{
-   return impl_->extensionsCount();
-}
-
-/*!
-@brief   Get an E57 extension prefix declared in an ImageFile by index.
-@param   [in] index The index of the prefix to get, starting at 0.
-@details
-The order that the prefixes are stored in is not necessarily the same as the
-order they were created. However the prefix order will correspond to the URI
-order. The default E57 namespace is not counted as an extension.
-@pre     This ImageFile must be open (i.e. isOpen()).
-@pre     0 <= index < extensionsCount()
-@post    No visible state is modified.
-@return  The E57 extension prefix at the given index.
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ImageFile::extensionsCount, ImageFile::extensionsUri
-*/
-ustring ImageFile::extensionsPrefix( const size_t index ) const
-{
-   return impl_->extensionsPrefix( index );
-}
-
-/*!
-@brief   Get an E57 extension URI declared in an ImageFile by index.
-@param   [in] index The index of the URI to get, starting at 0.
-@details
-The order that the URIs are stored is not necessarily the same as the order they
-were created. However the URI order will correspond to the prefix order. The
-default E57 namespace is not counted as an extension.
-@pre     This ImageFile must be open (i.e. isOpen()).
-@pre     0 <= index < extensionsCount()
-@post    No visible state is modified.
-@return  The E57 extension URI at the given index.
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ImageFile::extensionsCount, ImageFile::extensionsPrefix
-*/
-ustring ImageFile::extensionsUri( const size_t index ) const
-{
-   return impl_->extensionsUri( index );
-}
-
-/*!
-@brief   Test whether an E57 element name has an extension prefix.
-@details
-The element name has a prefix if the function
-elementNameParse(elementName,prefix,dummy) would succeed, and returned prefix !=
-"".
-@param   [in] elementName   The string element name to test.
-@post    No visible state is modified.
-@return  True if the E57 element name has an extension prefix.
-@throw   No E57Exceptions.
-*/
-bool ImageFile::isElementNameExtended( const ustring &elementName ) const
-{
-   return impl_->isElementNameExtended( elementName );
-}
-
-/*!
-@brief   Parse element name into prefix and localPart substrings.
-@param   [in] elementName   The string element name to parse into prefix and
-local parts.
-@param   [out] prefix       The prefix (if any) in the @a elementName.
-@param   [out] localPart    The part of the element name after the prefix.
-@details
-A legal element name may be in prefixed (ID:ID) or unprefixed (ID) form,
-where ID is a string whose first character is in {a-z,A-Z,_} followed by zero or
-more characters in {a-z,A-Z,_,0-9,-,.}. If in prefixed form, the prefix does not
-have to be declared in the ImageFile.
-@post    No visible state is modified.
-@throw   ::ErrorBadPathName
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ImageFile::isElementNameExtended
-*/
-void ImageFile::elementNameParse( const ustring &elementName, ustring &prefix, ustring &localPart ) const
-{
-   impl_->elementNameParse( elementName, prefix, localPart );
-}
-
-/*!
-@brief   Diagnostic function to print internal state of object to output stream
-in an indented format.
-@copydetails Node::dump()
-*/
-#ifdef E57_DEBUG
-void ImageFile::dump( int indent, std::ostream &os ) const
-{
-   impl_->dump( indent, os );
-}
-#else
-void ImageFile::dump( int indent, std::ostream &os ) const
-{
-}
-#endif
-
+// Put this function first so we can reference the code in doxygen using @skip
 /*!
 @brief Check whether ImageFile class invariant is true
-@param   [in] doRecurse   If true, also check invariants of all children or
-sub-objects recursively.
+
+@param [in] doRecurse If true, also check invariants of all children or sub-objects recursively.
+
 @details
-This function checks at least the assertions in the documented class invariant
-description (see class reference page for this object). Other internal
-invariants that are implementation-dependent may also be checked. If any
-invariant clause is violated, an E57Exception with errorCode of
+This function checks at least the assertions in the documented class invariant description (see
+class reference page for this object). Other internal invariants that are implementation-dependent
+may also be checked. If any invariant clause is violated, an E57Exception with errorCode of
 ErrorInvarianceViolation is thrown.
 
-Checking the invariant recursively may be expensive if the tree is large, so
-should be used judiciously, in debug versions of the application.
-@post    No visible state is modified.
-@throw   ::ErrorInvarianceViolation or any other E57 ErrorCode
-@see     Node::checkInvariant
+Checking the invariant recursively may be expensive if the tree is large, so should be used
+judiciously, in debug versions of the application.
+
+@post No visible state is modified.
+
+@throw ::ErrorInvarianceViolation or any other E57 ErrorCode
+
+@see Node::checkInvariant
 */
-// beginExample ImageFile::checkInvariant
 void ImageFile::checkInvariant( bool doRecurse ) const
 {
    // If this ImageFile is not open, can't test invariant (almost every call
@@ -677,14 +160,587 @@ void ImageFile::checkInvariant( bool doRecurse ) const
       root().checkInvariant( doRecurse );
    }
 }
-// endExample ImageFile::checkInvariant
 
 /*!
-@brief   Test if two ImageFile handles refer to the same underlying ImageFile
-@param   [in] imf2        The ImageFile to compare this ImageFile with
-@post    No visible object state is modified.
-@return  @c true if ImageFile handles refer to the same underlying ImageFile.
-@throw   No E57Exceptions
+@class e57::ImageFile
+
+@brief An ASTM E57 3D format file object.
+
+@details
+@section imagefile_ClassOverview Class overview
+The ImageFile class represents the state of an ASTM E57 format data file. An ImageFile may be
+created from an E57 file on the disk (read mode). An new ImageFile may be created to write an E57
+file to disk (write mode).
+
+E57 files are organized in a tree structure.
+Each ImageFile object has a predefined root node (of type StructureNode). In a write mode ImageFile,
+the root node is initially empty. In a read mode ImageFile, the root node is populated by the tree
+stored in the .e57 file on disk.
+
+@section imagefile_OpenClose The open/close state
+An ImageFile object, opened in either mode (read/write), can be in one of two states: open or
+closed. An ImageFile in the open state is ready to perform transfers of data and to be interrogated.
+An ImageFile in the closed state cannot perform any further transfers, and has very limited ability
+to be interrogated. Note entering the closed state is different than destroying the ImageFile
+object. An ImageFile object can still exist and be in the closed state. When created, the ImageFile
+is initially open.
+
+The ImageFile state can transition to the closed state in two ways. The programmer can call
+ImageFile::close after all required processing has completed. The programmer can call
+ImageFile::cancel if it is determined that the ImageFile is no longer needed.
+
+@section imagefile_Extensions Extensions
+Basically in an E57 file, "extension = namespace + rules + meaning".
+The "namespace" ensures that element names don't collide.
+The "rules" may be written on paper, or partly codified in a computer grammar.
+The "meaning" is a definition of what was measured, what the numbers in the file mean.
+
+Extensions are identified by URIs.
+Extensions are not identified by prefixes.
+Prefixes are a shorthand, used in a particular file, to make the element names more palatable for
+humans. When thinking about a prefixed element name, in your mind you should immediately substitute
+the URI for the prefix. For example, think "http://www.example.com/DemoExtension:extra2" rather than
+"demo:extra2", if the prefix "demo" is declared in the file to be a shorthand for the URI
+"http://www.example.com/DemoExtension".
+
+The rules are statements of: what is valid, what element names are possible, what values are
+possible. The rules establish the answer to the following yes/no question: "Is this extended E57
+file valid?". The rules divide all possible files into two sets: valid files and invalid files.
+
+The "meanings" part of the above equation defines what the files in the first set, the valid files,
+actually mean. This definition usually comes in the form of documentation of the content of each new
+element in the format and how they relate to the other elements.
+
+An element name in an E57 file is a member of exactly one namespace (either the default namespace
+defined in the ASTM standard, or an extension namespace). Rules about the structure of an E57
+extension (what element names can appear where), are implicitly assumed only to govern the element
+names within the namespace of the extension. Element names in other namespaces are unconstrained.
+This is because a reader is required to ignore elements in namespaces that are unfamiliar (to treat
+them as if they didn't exist). This enables a writer to "tack on" new elements into pre-defined
+structures (e.g. structures defined in the ASTM standard), without fear that it will confuse a
+reader that is only familiar with the old format. This allows an extension designer to communicate
+to two sets of readers: the old readers that will understand the information in the old base format,
+and the new-fangled readers that will be able to read the base format and the extra information
+stored in element names in the extended namespace.
+
+@section ImageFile_invariant Class Invariant
+A class invariant is a list of statements about an object that are always true before and after any
+operation on the object. An invariant is useful for testing correct operation of an implementation.
+Statements in an invariant can involve only externally visible state, or can refer to internal
+implementation-specific state that is not visible to the API user. The following C++ code checks
+externally visible state for consistency and throws an exception if the invariant is violated:
+
+@dontinclude ImageFile.cpp
+@skip void ImageFile::checkInvariant
+@until ^}
+*/
+
+/*!
+@brief Open an ASTM E57 imaging data file for reading/writing.
+
+@param [in] fname File name to open.
+Support of '\' as a directory separating character is system dependent. For maximum portability, it
+is recommended that '/' be used as a directory separator in file names. Special device file name
+support are implementation dependent (e.g. "\\.\PhysicalDrive3" or "/dev/hd3"). It is recommended
+that files that meet all of the requirements for a legal ASTM E57 file format use the extension @c
+".e57". It is recommended that files that utilize the low-level E57 element data types, but do not
+have all the required element names required by ASTM E57 file format standard use the file extension
+@c "._e57".
+@param [in] mode Either "w" for writing or "r" for reading.
+@param [in] checksumPolicy The percentage of checksums we compute and verify as an int. Clamped to
+0-100.
+
+@details
+@par Write Mode
+In write mode, the file cannot be already open.
+A file with name given by @a fname is immediately created on the disk.
+This file may grow as a result of operations on the ImageFile.
+Which API functions write data to the file are implementation dependent.
+Thus any API operation that stores data may fail as a result of insufficient free disk space. Read
+API operations are legal for an ImageFile opened in write mode.
+
+@par Read Mode
+Read mode files may be shared.
+Write API operations are not legal for an ImageFile opened in read mode (i.e. the ImageFile is
+read-only). There is no API support for appending data onto an existing E57 data file.
+
+@post Resulting ImageFile is in @c open state if constructor succeeds (no exception thrown).
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorOpenFailed
+@throw ::ErrorSeekFailed
+@throw ::ErrorReadFailed
+@throw ::ErrorWriteFailed
+@throw ::ErrorBadChecksum
+@throw ::ErrorBadFileSignature
+@throw ::ErrorUnknownFileVersion
+@throw ::ErrorBadFileLength
+@throw ::ErrorXMLParserInit
+@throw ::ErrorXMLParser
+@throw ::ErrorBadXMLFormat
+@throw ::ErrorBadConfiguration
+@throw ::ErrorInternal All objects in undocumented state
+
+@see IntegerNode, ScaledIntegerNode, FloatNode, StringNode, BlobNode, StructureNode, VectorNode,
+CompressedVectorNode, E57Exception, E57Utilities::E57Utilities
+*/
+ImageFile::ImageFile( const ustring &fname, const ustring &mode,
+                      ReadChecksumPolicy checksumPolicy ) :
+   impl_( new ImageFileImpl( checksumPolicy ) )
+{
+   // Do second phase of construction, now that ImageFile object is complete.
+   impl_->construct2( fname, mode );
+}
+
+ImageFile::ImageFile( const char *input, const uint64_t size, ReadChecksumPolicy checksumPolicy ) :
+   impl_( new ImageFileImpl( checksumPolicy ) )
+{
+   impl_->construct2( input, size );
+}
+
+/*!
+@brief Get the pre-established root StructureNode of the E57 ImageFile.
+
+@details The root node of an ImageFile always exists and is always type StructureNode. The root node
+is empty in a newly created write mode ImageFile.
+
+@pre This ImageFile must be open (i.e. isOpen()).
+
+@return A smart StructureNode handle referencing the underlying object.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see StructureNode.
+*/
+StructureNode ImageFile::root() const
+{
+   return StructureNode( impl_->root() );
+}
+
+/*!
+@brief Complete any write operations on an ImageFile, and close the file on the disk.
+
+@details
+Completes the writing of the state of the ImageFile to the disk.
+Some API implementations may store significant portions of the state of the ImageFile in memory.
+This state is moved into the disk file before it is closed. Any errors in finishing the writing are
+reported by throwing an exception. If an exception is thrown, depending on the error code, the
+ImageFile may enter the closed state. If no exception is thrown, then the file on disk will be an
+accurate representation of the ImageFile.
+
+@warning If the ImageFile::close function is not called, and the ImageFile destructor is invoked
+with the ImageFile in the open state, the associated disk file will be deleted and the ImageFile
+will @em not be saved to the disk (the same outcome as calling ImageFile::cancel). The reason for
+this is that any error conditions can't be reported from a destructor, so the user can't be assured
+that the destruction/close completed successfully. It is strongly recommended that this close
+function be called before the ImageFile is destroyed.
+
+It is not an error if ImageFile is already closed.
+
+@post ImageFile is in @c closed state.
+
+@throw ::ErrorSeekFailed
+@throw ::ErrorReadFailed
+@throw ::ErrorWriteFailed
+@throw ::ErrorCloseFailed
+@throw ::ErrorBadChecksum
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ImageFile::cancel, ImageFile::isOpen
+*/
+void ImageFile::close()
+{
+   impl_->close();
+}
+
+/*!
+@brief Stop I/O operations and delete a partially written ImageFile on the disk.
+
+@details
+If the ImageFile is write mode, the associated file on the disk is closed and deleted, and the
+ImageFile goes to the closed state. If the ImageFile is read mode, the behavior is same as calling
+ImageFile::close, but no exceptions are thrown. It is not an error if ImageFile is already closed.
+
+@post ImageFile is in @c closed state.
+
+@throw No E57Exceptions.
+
+@see ImageFile::ImageFile, ImageFile::close, ImageFile::isOpen
+*/
+void ImageFile::cancel()
+{
+   impl_->cancel();
+}
+
+/*!
+@brief Test whether ImageFile is still open for accessing.
+
+@post No visible state is modified.
+
+@return true if ImageFile is in @c open state.
+
+@throw No E57Exceptions.
+
+@see ImageFile::ImageFile, ImageFile::close
+*/
+bool ImageFile::isOpen() const
+{
+   return impl_->isOpen();
+}
+
+/*!
+@brief Test whether ImageFile was opened in write mode.
+
+@post No visible state is modified.
+
+@return true if ImageFile was opened in write mode.
+
+@throw No E57Exceptions.
+
+@see ImageFile::ImageFile, ImageFile::isOpen
+*/
+bool ImageFile::isWritable() const
+{
+   return impl_->isWriter();
+}
+
+/*!
+@brief Get the file name the ImageFile was created with.
+
+@post No visible state is modified.
+
+@return The file name the ImageFile was created with.
+
+@throw No E57Exceptions.
+
+@see ImageFile::ImageFile
+*/
+ustring ImageFile::fileName() const
+{
+   return impl_->fileName();
+}
+
+/*!
+@brief Get current number of open CompressedVectorWriter objects writing to ImageFile.
+
+@details
+CompressedVectorWriter objects that still exist, but are in the closed state aren't counted.
+CompressedVectorWriter objects are created by the CompressedVectorNode::writer function.
+
+@pre This ImageFile must be open (i.e. isOpen()).
+@post No visible state is modified.
+
+@return The current number of open CompressedVectorWriter objects writing to ImageFile.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see  CompressedVectorNode::writer, CompressedVectorWriter
+*/
+int ImageFile::writerCount() const
+{
+   return impl_->writerCount();
+}
+
+/*!
+@brief Get current number of open CompressedVectorReader objects reading from ImageFile.
+
+@details
+CompressedVectorReader objects that still exist, but are in the closed state aren't counted.
+CompressedVectorReader objects are created by the CompressedVectorNode::reader function.
+
+@pre This ImageFile must be open (i.e. isOpen()).
+@post No visible state is modified.
+
+@return The current number of open CompressedVectorReader objects reading from ImageFile.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see CompressedVectorNode::reader, CompressedVectorReader
+*/
+int ImageFile::readerCount() const
+{
+   return impl_->readerCount();
+}
+
+/*!
+@brief Declare the use of an E57 extension in an ImageFile being written.
+
+@param [in] prefix The shorthand name of the extension to use in element names.
+@param [in] uri The Uniform Resource Identifier string to associate with the prefix in the
+ImageFile.
+
+@details
+The (@a prefix, @a uri) pair is registered in the known extensions of the ImageFile. Both @a prefix
+and @a uri must be unique in the ImageFile. It is not legal to declare a URI associated with the
+default namespace (@a prefix = ""). It is not an error to declare a namespace and not use it in an
+element name. It is an error to use a namespace prefix in an element name that is not declared
+beforehand.
+
+A writer is free to "hard code" the prefix names in the element name strings that it uses (since it
+established the prefix declarations in the file). A reader cannot assume that any given prefix is
+always mapped to the same URI or vice versa. A reader might check an ImageFile, and if the prefixes
+aren't the way it likes, the reader could give up.
+
+A better scheme would be to lookup the URI that the reader is familiar with, and store the prefix
+that the particular file uses in a variable. Then every time the reader needs to form a prefixed
+element name, it can assemble the full element name from the stored prefix variable and the constant
+documented base name string. This is less convenient than using a single "hard coded" string
+constant for an element name, but it is robust against any choice of prefix/URI combination.
+
+See the class discussion at bottom of ImageFile page for more details about namespaces.
+
+@pre This ImageFile must be open (i.e. isOpen()).
+@pre ImageFile must have been opened in write mode (i.e. isWritable()).
+@pre prefix != ""
+@pre uri != ""
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorFileReadOnly
+@throw ::ErrorDuplicateNamespacePrefix
+@throw ::ErrorDuplicateNamespaceURI
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ImageFile::extensionsCount, ImageFile::extensionsLookupPrefix, ImageFile::extensionsLookupUri
+*/
+void ImageFile::extensionsAdd( const ustring &prefix, const ustring &uri )
+{
+   impl_->extensionsAdd( prefix, uri );
+}
+
+/*!
+@brief Look up an E57 extension prefix in the ImageFile.
+
+@param [in] prefix The shorthand name of the extension to look up.
+
+@details
+If @a prefix = "" or @a prefix is declared in the ImageFile, then the function returns true. It is
+an error if @a prefix contains an illegal character combination for E57 namespace prefixes.
+
+@pre This ImageFile must be open (i.e. isOpen()).
+@post No visible state is modified.
+
+@return true if prefix is declared in the ImageFile.
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ImageFile::extensionsLookupUri
+*/
+bool ImageFile::extensionsLookupPrefix( const ustring &prefix ) const
+{
+   ustring uri;
+   return impl_->extensionsLookupPrefix( prefix, uri );
+}
+
+/*!
+@brief Get URI associated with an E57 extension prefix in the ImageFile.
+
+@param [in] prefix The shorthand name of the extension to look up.
+@param [out] uri The URI that was associated with the given @a prefix.
+
+@details
+If @a prefix = "", then @a uri is set to the default namespace URI, and the function returns true.
+if @a prefix is declared in the ImageFile, then @a uri is set the corresponding URI, and the
+function returns true. It is an error if @a prefix contains an illegal character combination for E57
+namespace prefixes. It is not an error if @a prefix is well-formed, but not defined in the ImageFile
+(the function just returns false).
+
+@pre This ImageFile must be open (i.e. isOpen()).
+@post No visible state is modified.
+
+@return true if prefix is declared in the ImageFile.
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ImageFile::extensionsLookupUri
+*/
+bool ImageFile::extensionsLookupPrefix( const ustring &prefix, ustring &uri ) const
+{
+   return impl_->extensionsLookupPrefix( prefix, uri );
+}
+
+/*!
+@brief Get an E57 extension prefix associated with a URI in the ImageFile.
+
+@param [in] uri The URI of the extension to look up.
+@param [out] prefix The shorthand prefix that was associated with the given @a uri.
+
+@details
+If @a uri is declared in the ImageFile, then @a prefix is set the corresponding prefix, and the
+function returns true. It is an error if @a uri contains an illegal character combination for E57
+namespace URIs. It is not an error if @a uri is well-formed, but not defined in the ImageFile (the
+function just returns false).
+
+@pre This ImageFile must be open (i.e. isOpen()).
+@pre uri != ""
+@post No visible state is modified.
+
+@return true if URI is declared in the ImageFile.
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ImageFile::extensionsLookupPrefix
+*/
+bool ImageFile::extensionsLookupUri( const ustring &uri, ustring &prefix ) const
+{
+   return impl_->extensionsLookupUri( uri, prefix );
+}
+
+/*!
+@brief Get number of E57 extensions declared in the ImageFile.
+
+@details
+The default E57 namespace does not count as an extension.
+
+@pre This ImageFile must be open (i.e. isOpen()).
+@post No visible state is modified.
+
+@return The number of E57 extensions defined in the ImageFile.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ImageFile::extensionsPrefix, ImageFile::extensionsUri
+*/
+size_t ImageFile::extensionsCount() const
+{
+   return impl_->extensionsCount();
+}
+
+/*!
+@brief Get an E57 extension prefix declared in an ImageFile by index.
+
+@param [in] index The index of the prefix to get, starting at 0.
+
+@details
+The order that the prefixes are stored in is not necessarily the same as the order they were
+created. However the prefix order will correspond to the URI order. The default E57 namespace is not
+counted as an extension.
+
+@pre This ImageFile must be open (i.e. isOpen()).
+@pre 0 <= index < extensionsCount()
+@post No visible state is modified.
+
+@return The E57 extension prefix at the given index.
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see  ImageFile::extensionsCount, ImageFile::extensionsUri
+*/
+ustring ImageFile::extensionsPrefix( const size_t index ) const
+{
+   return impl_->extensionsPrefix( index );
+}
+
+/*!
+@brief Get an E57 extension URI declared in an ImageFile by index.
+
+@param [in] index The index of the URI to get, starting at 0.
+
+@details
+The order that the URIs are stored is not necessarily the same as the order they were created.
+However the URI order will correspond to the prefix order. The default E57 namespace is not counted
+as an extension.
+
+@pre This ImageFile must be open (i.e. isOpen()).
+@pre 0 <= index < extensionsCount()
+@post No visible state is modified.
+
+@return The E57 extension URI at the given index.
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ImageFile::extensionsCount, ImageFile::extensionsPrefix
+*/
+ustring ImageFile::extensionsUri( const size_t index ) const
+{
+   return impl_->extensionsUri( index );
+}
+
+/*!
+@brief Test whether an E57 element name has an extension prefix.
+
+@details
+The element name has a prefix if the function elementNameParse(elementName,prefix,dummy) would
+succeed, and returned prefix != "".
+
+@param [in] elementName The string element name to test.
+
+@post No visible state is modified.
+
+@return True if the E57 element name has an extension prefix.
+
+@throw No E57Exceptions.
+*/
+bool ImageFile::isElementNameExtended( const ustring &elementName ) const
+{
+   return impl_->isElementNameExtended( elementName );
+}
+
+/*!
+@brief Parse element name into prefix and localPart substrings.
+
+@param [in] elementName The string element name to parse into prefix and local parts.
+@param [out] prefix The prefix (if any) in the @a elementName.
+@param [out] localPart The part of the element name after the prefix.
+
+@details
+A legal element name may be in prefixed (ID:ID) or unprefixed (ID) form, where ID is a string whose
+first character is in {a-z,A-Z,_} followed by zero or more characters in {a-z,A-Z,_,0-9,-,.}. If in
+prefixed form, the prefix does not have to be declared in the ImageFile.
+
+@post No visible state is modified.
+
+@throw ::ErrorBadPathName
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ImageFile::isElementNameExtended
+*/
+void ImageFile::elementNameParse( const ustring &elementName, ustring &prefix,
+                                  ustring &localPart ) const
+{
+   impl_->elementNameParse( elementName, prefix, localPart );
+}
+
+/*!
+@brief Diagnostic function to print internal state of object to output stream in an indented format.
+@copydetails Node::dump()
+*/
+#ifdef E57_DEBUG
+void ImageFile::dump( int indent, std::ostream &os ) const
+{
+   impl_->dump( indent, os );
+}
+#else
+void ImageFile::dump( int indent, std::ostream &os ) const
+{
+}
+#endif
+
+/*!
+@brief Test if two ImageFile handles refer to the same underlying ImageFile
+
+@param [in] imf2 The ImageFile to compare this ImageFile with
+
+@post No visible object state is modified.
+
+@return @c true if ImageFile handles refer to the same underlying ImageFile.
+
+@throw No E57Exceptions
 */
 bool ImageFile::operator==( ImageFile imf2 ) const
 {
@@ -692,19 +748,23 @@ bool ImageFile::operator==( ImageFile imf2 ) const
 }
 
 /*!
-@brief   Test if two ImageFile handles refer to different underlying ImageFile
-@param   [in] imf2        The ImageFile to compare this ImageFile with
-@post    No visible object state is modified.
-@return  @c true if ImageFile handles refer to different underlying ImageFiles.
-@throw   No E57Exceptions
+@brief Test if two ImageFile handles refer to different underlying ImageFile
+
+@param [in] imf2 The ImageFile to compare this ImageFile with
+
+@post No visible object state is modified.
+
+@return @c true if ImageFile handles refer to different underlying ImageFiles.
+
+@throw No E57Exceptions
 */
 bool ImageFile::operator!=( ImageFile imf2 ) const
 {
    return ( impl_ != imf2.impl_ );
 }
 
-//! @cond documentNonPublic   The following isn't part of the API, and isn't documented.
+/// @cond documentNonPublic The following isn't part of the API, and isn't documented.
 ImageFile::ImageFile( ImageFileImplSharedPtr imfi ) : impl_( imfi )
 {
 }
-//! @endcond
+/// @endcond

--- a/src/ImageFileImpl.cpp
+++ b/src/ImageFileImpl.cpp
@@ -53,7 +53,6 @@ namespace e57
       uint64_t xmlPhysicalOffset = 0;
       uint64_t xmlLogicalLength = 0;
       uint64_t pageSize = 0;
-      //  char        e57LibraryVersion[8];   //Not in V1.0 Standard
 
 #ifdef E57_DEBUG
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
@@ -77,16 +76,16 @@ namespace e57
 
    ImageFileImpl::ImageFileImpl( ReadChecksumPolicy policy ) :
       isWriter_( false ), writerCount_( 0 ), readerCount_( 0 ),
-      checksumPolicy( std::max( 0, std::min( policy, 100 ) ) ), file_( nullptr ), xmlLogicalOffset_( 0 ),
-      xmlLogicalLength_( 0 ), unusedLogicalStart_( 0 )
+      checksumPolicy( std::max( 0, std::min( policy, 100 ) ) ), file_( nullptr ),
+      xmlLogicalOffset_( 0 ), xmlLogicalLength_( 0 ), unusedLogicalStart_( 0 )
    {
-      /// First phase of construction, can't do much until have the ImageFile
-      /// object. See ImageFileImpl::construct2() for second phase.
+      // First phase of construction, can't do much until have the ImageFile object. See
+      // ImageFileImpl::construct2() for second phase.
    }
 
    void ImageFileImpl::construct2( const ustring &fileName, const ustring &mode )
    {
-      /// Second phase of construction, now we have a well-formed ImageFile object.
+      // Second phase of construction, now we have a well-formed ImageFile object.
 
 #ifdef E57_MAX_VERBOSE
       std::cout << "ImageFileImpl() called, fileName=" << fileName << " mode=" << mode << std::endl;
@@ -94,7 +93,7 @@ namespace e57
       unusedLogicalStart_ = sizeof( E57FileHeader );
       fileName_ = fileName;
 
-      /// Get shared_ptr to this object
+      // Get shared_ptr to this object
       ImageFileImplSharedPtr imf = shared_from_this();
 
       // Accept "w" or "r" modes
@@ -112,7 +111,7 @@ namespace e57
       {
          try
          {
-            /// Open file for writing, truncate if already exists.
+            // Open file for writing, truncate if already exists.
             file_ = new CheckedFile( fileName_, CheckedFile::WriteCreate, checksumPolicy );
 
             std::shared_ptr<StructureNodeImpl> root( new StructureNodeImpl( imf ) );
@@ -137,7 +136,7 @@ namespace e57
       // Reading
       try
       {
-         /// Open file for reading.
+         // Open file for reading.
          file_ = new CheckedFile( fileName_, CheckedFile::ReadOnly, checksumPolicy );
 
          std::shared_ptr<StructureNodeImpl> root( new StructureNodeImpl( imf ) );
@@ -160,17 +159,17 @@ namespace e57
 
       try
       {
-         /// Create parser state, attach its event handers to the SAX2 reader
+         // Create parser state, attach its event handers to the SAX2 reader
          E57XmlParser parser( imf );
 
          parser.init();
 
-         /// Create input source (XML section of E57 file turned into a stream).
+         // Create input source (XML section of E57 file turned into a stream).
          E57XmlFileInputSource xmlSection( file_, xmlLogicalOffset_, xmlLogicalLength_ );
 
          unusedLogicalStart_ = sizeof( E57FileHeader );
 
-         /// Do the parse, building up the node tree
+         // Do the parse, building up the node tree
          parser.parse( xmlSection );
       }
       catch ( ... )
@@ -184,7 +183,7 @@ namespace e57
 
    void ImageFileImpl::construct2( const char *input, const uint64_t size )
    {
-      /// Second phase of construction, now we have a well-formed ImageFile object.
+      // Second phase of construction, now we have a well-formed ImageFile object.
 
 #ifdef E57_MAX_VERBOSE
       std::cout << "ImageFileImpl() called, fileName=<StreamBuffer> mode=r" << std::endl;
@@ -192,7 +191,7 @@ namespace e57
       unusedLogicalStart_ = sizeof( E57FileHeader );
       fileName_ = "<StreamBuffer>";
 
-      /// Get shared_ptr to this object
+      // Get shared_ptr to this object
       ImageFileImplSharedPtr imf = shared_from_this();
 
       isWriter_ = false;
@@ -200,7 +199,7 @@ namespace e57
 
       try
       {
-         /// Open file for reading.
+         // Open file for reading.
          file_ = new CheckedFile( input, size, checksumPolicy );
 
          std::shared_ptr<StructureNodeImpl> root( new StructureNodeImpl( imf ) );
@@ -223,17 +222,17 @@ namespace e57
 
       try
       {
-         /// Create parser state, attach its event handers to the SAX2 reader
+         // Create parser state, attach its event handers to the SAX2 reader
          E57XmlParser parser( imf );
 
          parser.init();
 
-         /// Create input source (XML section of E57 file turned into a stream).
+         // Create input source (XML section of E57 file turned into a stream).
          E57XmlFileInputSource xmlSection( file_, xmlLogicalOffset_, xmlLogicalLength_ );
 
          unusedLogicalStart_ = sizeof( E57FileHeader );
 
-         /// Do the parse, building up the node tree
+         // Do the parse, building up the node tree
          parser.parse( xmlSection );
       }
       catch ( ... )
@@ -256,7 +255,8 @@ namespace e57
 #ifdef E57_MAX_DEBUG
       if ( writerCount_ < 0 )
       {
-         throw E57_EXCEPTION2( ErrorInternal, "fileName=" + fileName_ + " writerCount=" + toString( writerCount_ ) +
+         throw E57_EXCEPTION2( ErrorInternal, "fileName=" + fileName_ +
+                                                 " writerCount=" + toString( writerCount_ ) +
                                                  " readerCount=" + toString( readerCount_ ) );
       }
 #endif
@@ -273,7 +273,8 @@ namespace e57
 #ifdef E57_MAX_DEBUG
       if ( readerCount_ < 0 )
       {
-         throw E57_EXCEPTION2( ErrorInternal, "fileName=" + fileName_ + " writerCount=" + toString( writerCount_ ) +
+         throw E57_EXCEPTION2( ErrorInternal, "fileName=" + fileName_ +
+                                                 " writerCount=" + toString( writerCount_ ) +
                                                  " readerCount=" + toString( readerCount_ ) );
       }
 #endif
@@ -288,7 +289,7 @@ namespace e57
 
    void ImageFileImpl::close()
    {
-      /// If file already closed, have nothing to do
+      // If file already closed, have nothing to do
       if ( file_ == nullptr )
       {
          return;
@@ -296,30 +297,25 @@ namespace e57
 
       if ( isWriter_ )
       {
-         /// Go to end of file, note physical position
+         // Go to end of file, note physical position
          xmlLogicalOffset_ = unusedLogicalStart_;
          file_->seek( xmlLogicalOffset_, CheckedFile::Logical );
          uint64_t xmlPhysicalOffset = file_->position( CheckedFile::Physical );
          *file_ << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
-#ifdef E57_OXYGEN_SUPPORT //???                                                             \
-                          //???        *file_ << "<?oxygen                                  \
-                          // RNGSchema=\"file:/C:/kevin/astm/DataFormat/xif/las_v0_05.rnc\" \
-                          // type=\"compact\"?>\n";
-#endif
 
          //??? need to add name space attributes to e57Root
          root_->writeXml( shared_from_this(), *file_, 0, "e57Root" );
 
-         /// Pad XML section so length is multiple of 4
+         // Pad XML section so length is multiple of 4
          while ( ( file_->position( CheckedFile::Logical ) - xmlLogicalOffset_ ) % 4 != 0 )
          {
             *file_ << " ";
          }
 
-         /// Note logical length
+         // Note logical length
          xmlLogicalLength_ = file_->position( CheckedFile::Logical ) - xmlLogicalOffset_;
 
-         /// Init header contents
+         // Init header contents
          E57FileHeader header;
 
          memcpy( &header.fileSignature, "ASTM-E57", 8 );
@@ -334,7 +330,7 @@ namespace e57
          header.dump();
 #endif
 
-         /// Write header at beginning of file
+         // Write header at beginning of file
          file_->seek( 0 );
          file_->write( reinterpret_cast<char *>( &header ), sizeof( header ) );
 
@@ -347,14 +343,14 @@ namespace e57
 
    void ImageFileImpl::cancel()
    {
-      /// If file already closed, have nothing to do
+      // If file already closed, have nothing to do
       if ( file_ == nullptr )
       {
          return;
       }
 
-      /// Close the file and ulink (delete) it.
-      /// It is legal to cancel a read file, but file isn't deleted.
+      // Close the file and ulink (delete) it.
+      // It is legal to cancel a read file, but file isn't deleted.
       if ( isWriter_ )
       {
          file_->unlink();
@@ -390,9 +386,9 @@ namespace e57
 
    ImageFileImpl::~ImageFileImpl()
    {
-      /// Try to cancel if not already closed, but don't allow any exceptions to
-      /// propagate to caller (because in dtor). If writing, this will unlink the
-      /// file, so make sure call ImageFileImpl::close explicitly before dtor runs.
+      // Try to cancel if not already closed, but don't allow any exceptions to propagate to caller
+      // (because in dtor). If writing, this will unlink the file, so make sure call
+      // ImageFileImpl::close explicitly before dtor runs.
       try
       {
          cancel();
@@ -401,7 +397,7 @@ namespace e57
       {
       };
 
-      /// Just in case cancel failed without freeing file_, do free here.
+      // Just in case cancel failed without freeing file_, do free here.
       delete file_;
       file_ = nullptr;
    }
@@ -410,11 +406,11 @@ namespace e57
    {
       uint64_t oldLogicalStart = unusedLogicalStart_;
 
-      /// Reserve space at end of file
+      // Reserve space at end of file
       unusedLogicalStart_ += byteCount;
 
-      /// If caller won't write to file immediately, it should request that the
-      /// file be extended with zeros here
+      // If caller won't write to file immediately, it should request that the file be extended with
+      // zeros here.
       if ( doExtendNow )
       {
          file_->extend( unusedLogicalStart_ );
@@ -440,7 +436,7 @@ namespace e57
       //??? check if prefix characters ok, check if uri has a double quote char
       //(others?)
 
-      /// Check to make sure that neither prefix or uri is already defined.
+      // Check to make sure that neither prefix or uri is already defined.
       ustring dummy;
 
       if ( extensionsLookupPrefix( prefix, dummy ) )
@@ -454,7 +450,7 @@ namespace e57
          ;
       }
 
-      /// Append at end of list
+      // Append at end of list
       nameSpaces_.emplace_back( prefix, uri );
    }
 
@@ -462,7 +458,7 @@ namespace e57
    {
       checkImageFileOpen( __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) );
 
-      /// Linear search for matching prefix
+      // Linear search for matching prefix
       std::vector<NameSpace>::const_iterator it;
 
       for ( it = nameSpaces_.begin(); it < nameSpaces_.end(); ++it )
@@ -481,7 +477,7 @@ namespace e57
    {
       checkImageFileOpen( __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) );
 
-      /// Linear search for matching URI
+      // Linear search for matching URI
       std::vector<NameSpace>::const_iterator it;
 
       for ( it = nameSpaces_.begin(); it < nameSpaces_.end(); ++it )
@@ -519,9 +515,9 @@ namespace e57
 
    bool ImageFileImpl::isElementNameExtended( const ustring &elementName )
    {
-      /// don't checkImageFileOpen
+      // don't checkImageFileOpen
 
-      /// Make sure doesn't have any "/" in it
+      // Make sure doesn't have any "/" in it
       size_t found = elementName.find_first_of( '/' );
 
       if ( found != std::string::npos )
@@ -533,7 +529,7 @@ namespace e57
 
       try
       {
-         /// Throws if elementName bad
+         // Throws if elementName bad
          elementNameParse( elementName, prefix, localPart );
       }
       catch ( E57Exception & /*ex*/ )
@@ -541,7 +537,7 @@ namespace e57
          return false;
       }
 
-      /// If get here, the name was good, so test if found a prefix part
+      // If get here, the name was good, so test if found a prefix part
       return ( prefix.length() > 0 );
    }
 
@@ -555,7 +551,7 @@ namespace e57
       {
          checkImageFileOpen( __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) );
 
-         /// Throws if elementName bad
+         // Throws if elementName bad
          checkElementNameLegal( elementName, allowNumber );
       }
       catch ( E57Exception & /*ex*/ )
@@ -563,7 +559,7 @@ namespace e57
          return false;
       }
 
-      /// If get here, the name was good
+      // If get here, the name was good
       return true;
    }
 
@@ -576,7 +572,7 @@ namespace e57
       {
          checkImageFileOpen( __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) );
 
-         /// Throws if pathName bad
+         // Throws if pathName bad
          pathNameCheckWellFormed( pathName );
       }
       catch ( E57Exception & /*ex*/ )
@@ -584,39 +580,40 @@ namespace e57
          return false;
       }
 
-      /// If get here, the name was good
+      // If get here, the name was good
       return true;
    }
 
    void ImageFileImpl::checkElementNameLegal( const ustring &elementName, bool allowNumber )
    {
-      /// no checkImageFileOpen(__FILE__, __LINE__, __FUNCTION__)
+      // no checkImageFileOpen(__FILE__, __LINE__, __FUNCTION__)
 
       ustring prefix;
       ustring localPart;
 
-      /// Throws if bad elementName
+      // Throws if bad elementName
       elementNameParse( elementName, prefix, localPart, allowNumber );
 
-      /// If has prefix, it must be registered
+      // If has prefix, it must be registered
       ustring uri;
 
       if ( prefix.length() > 0 && !extensionsLookupPrefix( prefix, uri ) )
       {
-         throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName + " prefix=" + prefix );
+         throw E57_EXCEPTION2( ErrorBadPathName,
+                               "elementName=" + elementName + " prefix=" + prefix );
       }
    }
 
-   void ImageFileImpl::elementNameParse( const ustring &elementName, ustring &prefix, ustring &localPart,
-                                         bool allowNumber )
+   void ImageFileImpl::elementNameParse( const ustring &elementName, ustring &prefix,
+                                         ustring &localPart, bool allowNumber )
    {
-      /// no checkImageFileOpen(__FILE__, __LINE__, __FUNCTION__)
+      // no checkImageFileOpen(__FILE__, __LINE__, __FUNCTION__)
 
       //??? check if elementName is good UTF-8?
 
       size_t len = elementName.length();
 
-      /// Empty name is bad
+      // Empty name is bad
       if ( len == 0 )
       {
          throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName );
@@ -624,10 +621,10 @@ namespace e57
 
       unsigned char c = elementName[0];
 
-      /// If allowing numeric element name, check if first char is digit
+      // If allowing numeric element name, check if first char is digit
       if ( allowNumber && '0' <= c && c <= '9' )
       {
-         /// All remaining characters must be digits
+         // All remaining characters must be digits
          for ( size_t i = 1; i < len; i++ )
          {
             c = elementName[i];
@@ -641,47 +638,47 @@ namespace e57
          return;
       }
 
-      /// If first char is ASCII (< 128), check for legality
-      /// Don't test any part of a multi-byte code point sequence (c >= 128).
-      /// Don't allow ':' as first char.
+      // If first char is ASCII (< 128), check for legality
+      // Don't test any part of a multi-byte code point sequence (c >= 128).
+      // Don't allow ':' as first char.
       if ( c < 128 && !( ( 'a' <= c && c <= 'z' ) || ( 'A' <= c && c <= 'Z' ) || c == '_' ) )
       {
          throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName );
       }
 
-      /// If each following char is ASCII (<128), check for legality
-      /// Don't test any part of a multi-byte code point sequence (c >= 128).
+      // If each following char is ASCII (<128), check for legality
+      // Don't test any part of a multi-byte code point sequence (c >= 128).
       for ( size_t i = 1; i < len; i++ )
       {
          c = elementName[i];
 
-         if ( c < 128 && !( ( 'a' <= c && c <= 'z' ) || ( 'A' <= c && c <= 'Z' ) || c == '_' || c == ':' ||
-                            ( '0' <= c && c <= '9' ) || c == '-' || c == '.' ) )
+         if ( c < 128 && !( ( 'a' <= c && c <= 'z' ) || ( 'A' <= c && c <= 'Z' ) || c == '_' ||
+                            c == ':' || ( '0' <= c && c <= '9' ) || c == '-' || c == '.' ) )
          {
             throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName );
          }
       }
 
-      /// Check if has at least one colon, try to split it into prefix & localPart
+      // Check if has at least one colon, try to split it into prefix & localPart
       size_t found = elementName.find_first_of( ':' );
 
       if ( found != std::string::npos )
       {
-         /// Check doesn't have two colons
+         // Check doesn't have two colons
          if ( elementName.find_first_of( ':', found + 1 ) != std::string::npos )
          {
             throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName );
          }
 
-         /// Split element name at the colon
-         /// ??? split before check first/subsequent char legal?
+         // Split element name at the colon
+         // ??? split before check first/subsequent char legal?
          prefix = elementName.substr( 0, found );
          localPart = elementName.substr( found + 1 );
 
          if ( prefix.length() == 0 || localPart.length() == 0 )
          {
-            throw E57_EXCEPTION2( ErrorBadPathName,
-                                  "elementName=" + elementName + " prefix=" + prefix + " localPart=" + localPart );
+            throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName + " prefix=" +
+                                                       prefix + " localPart=" + localPart );
          }
       }
       else
@@ -693,16 +690,17 @@ namespace e57
 
    void ImageFileImpl::pathNameCheckWellFormed( const ustring &pathName )
    {
-      /// no checkImageFileOpen(__FILE__, __LINE__, __FUNCTION__)
+      // no checkImageFileOpen(__FILE__, __LINE__, __FUNCTION__)
 
-      /// Just call pathNameParse() which throws if not well formed
+      // Just call pathNameParse() which throws if not well formed
       bool isRelative = false;
       StringList fields;
 
       pathNameParse( pathName, isRelative, fields );
    }
 
-   void ImageFileImpl::pathNameParse( const ustring &pathName, bool &isRelative, StringList &fields )
+   void ImageFileImpl::pathNameParse( const ustring &pathName, bool &isRelative,
+                                      StringList &fields )
    {
 #ifdef E57_MAX_VERBOSE
       std::cout << "pathNameParse pathname="
@@ -712,14 +710,14 @@ namespace e57
                    ""
                 << std::endl;
 #endif
-      /// no checkImageFileOpen(__FILE__, __LINE__, __FUNCTION__)
+      // no checkImageFileOpen(__FILE__, __LINE__, __FUNCTION__)
 
-      /// Clear previous contents of fields vector
+      // Clear previous contents of fields vector
       fields.clear();
 
       size_t start = 0;
 
-      /// Check if absolute path
+      // Check if absolute path
       if ( pathName[start] == '/' )
       {
          isRelative = false;
@@ -730,21 +728,22 @@ namespace e57
          isRelative = true;
       }
 
-      /// Save strings in between each forward slash '/'
-      /// Don't ignore whitespace
+      // Save strings in between each forward slash '/'
+      // Don't ignore whitespace
       while ( start < pathName.size() )
       {
          size_t slash = pathName.find_first_of( '/', start );
 
-         /// Get element name from in between '/', check valid
+         // Get element name from in between '/', check valid
          ustring elementName = pathName.substr( start, slash - start );
 
          if ( !isElementNameLegal( elementName ) )
          {
-            throw E57_EXCEPTION2( ErrorBadPathName, "pathName=" + pathName + " elementName=" + elementName );
+            throw E57_EXCEPTION2( ErrorBadPathName,
+                                  "pathName=" + pathName + " elementName=" + elementName );
          }
 
-         /// Add to list
+         // Add to list
          fields.push_back( elementName );
 
          if ( slash == std::string::npos )
@@ -752,27 +751,26 @@ namespace e57
             break;
          }
 
-         /// Handle case when pathname ends in /, e.g. "/foo/", add empty field at
-         /// end of list
+         // Handle case when pathname ends in /, e.g. "/foo/", add empty field at end of list
          if ( slash == pathName.size() - 1 )
          {
             fields.emplace_back( "" );
             break;
          }
 
-         /// Skip over the slash and keep going
+         // Skip over the slash and keep going
          start = slash + 1;
       }
 
-      /// Empty relative path is not allowed
+      // Empty relative path is not allowed
       if ( isRelative && fields.empty() )
       {
          throw E57_EXCEPTION2( ErrorBadPathName, "pathName=" + pathName );
       }
 
 #ifdef E57_MAX_VERBOSE
-      std::cout << "pathNameParse returning: isRelative=" << isRelative << " fields.size()=" << fields.size()
-                << " fields=";
+      std::cout << "pathNameParse returning: isRelative=" << isRelative
+                << " fields.size()=" << fields.size() << " fields=";
       for ( auto &field : fields )
       {
          std::cout << field << ",";
@@ -805,51 +803,52 @@ namespace e57
 
    void ImageFileImpl::readFileHeader( CheckedFile *file, E57FileHeader &header )
    {
-      /// Double check that compiler thinks sizeof header is what it is supposed to
-      /// be
+      // Double check that compiler thinks sizeof header is what it is supposed to be
       static_assert( sizeof( E57FileHeader ) == 48, "Unexpected size of E57FileHeader" );
 
-      /// Fetch the file header
+      // Fetch the file header
       file->read( reinterpret_cast<char *>( &header ), sizeof( header ) );
 
 #ifdef E57_MAX_VERBOSE
       header.dump();
 #endif
 
-      /// Check signature
+      // Check signature
       if ( strncmp( header.fileSignature, "ASTM-E57", 8 ) != 0 )
       {
          throw E57_EXCEPTION2( ErrorBadFileSignature, "fileName=" + file->fileName() );
       }
 
-      /// Check file version compatibility
+      // Check file version compatibility
       if ( header.majorVersion > E57_FORMAT_MAJOR )
       {
-         throw E57_EXCEPTION2( ErrorUnknownFileVersion, "fileName=" + file->fileName() +
-                                                           " header.majorVersion=" + toString( header.majorVersion ) +
-                                                           " header.minorVersion=" + toString( header.minorVersion ) );
+         throw E57_EXCEPTION2( ErrorUnknownFileVersion,
+                               "fileName=" + file->fileName() +
+                                  " header.majorVersion=" + toString( header.majorVersion ) +
+                                  " header.minorVersion=" + toString( header.minorVersion ) );
       }
 
-      /// If is a prototype version (majorVersion==0), then minorVersion has to
-      /// match too. In production versions (majorVersion==E57_FORMAT_MAJOR),
-      /// should be able to handle any minor version.
+      // If is a prototype version (majorVersion==0), then minorVersion has to  match too. In
+      // production versions (majorVersion==E57_FORMAT_MAJOR), should be able to handle any minor
+      // version.
       if ( header.majorVersion == E57_FORMAT_MAJOR && header.minorVersion > E57_FORMAT_MINOR )
       {
-         throw E57_EXCEPTION2( ErrorUnknownFileVersion, "fileName=" + file->fileName() +
-                                                           " header.majorVersion=" + toString( header.majorVersion ) +
-                                                           " header.minorVersion=" + toString( header.minorVersion ) );
+         throw E57_EXCEPTION2( ErrorUnknownFileVersion,
+                               "fileName=" + file->fileName() +
+                                  " header.majorVersion=" + toString( header.majorVersion ) +
+                                  " header.minorVersion=" + toString( header.minorVersion ) );
       }
 
-      /// Check if file length matches actual physical length
+      // Check if file length matches actual physical length
       if ( header.filePhysicalLength != file->length( CheckedFile::Physical ) )
       {
          throw E57_EXCEPTION2( ErrorBadFileLength,
-                               "fileName=" + file->fileName() +
-                                  " header.filePhysicalLength=" + toString( header.filePhysicalLength ) +
-                                  " file->length=" + toString( file->length( CheckedFile::Physical ) ) );
+                               "fileName=" + file->fileName() + " header.filePhysicalLength=" +
+                                  toString( header.filePhysicalLength ) + " file->length=" +
+                                  toString( file->length( CheckedFile::Physical ) ) );
       }
 
-      /// Check that page size is correct constant
+      // Check that page size is correct constant
       if ( header.majorVersion != 0 && header.pageSize != CheckedFile::physicalPageSize )
       {
          throw E57_EXCEPTION2( ErrorBadFileLength, "fileName=" + file->fileName() );
@@ -861,15 +860,15 @@ namespace e57
    {
       if ( !isOpen() )
       {
-         throw E57Exception( ErrorImageFileNotOpen, "fileName=" + fileName(), srcFileName, srcLineNumber,
-                             srcFunctionName );
+         throw E57Exception( ErrorImageFileNotOpen, "fileName=" + fileName(), srcFileName,
+                             srcLineNumber, srcFunctionName );
       }
    }
 
 #ifdef E57_DEBUG
    void ImageFileImpl::dump( int indent, std::ostream &os ) const
    {
-      /// no checkImageFileOpen(__FILE__, __LINE__, __FUNCTION__)
+      // no checkImageFileOpen(__FILE__, __LINE__, __FUNCTION__)
       os << space( indent ) << "fileName:    " << fileName_ << std::endl;
       os << space( indent ) << "writerCount: " << writerCount_ << std::endl;
       os << space( indent ) << "readerCount: " << readerCount_ << std::endl;
@@ -886,11 +885,10 @@ namespace e57
 
    unsigned ImageFileImpl::bitsNeeded( int64_t minimum, int64_t maximum )
    {
-      /// Relatively quick way to compute ceil(log2(maximum - minimum + 1)));
-      /// Uses only integer operations and is machine independent (no assembly
-      /// code). Find the bit position of the first 1 (from left) in the binary
-      /// form of stateCountMinus1.
-      ///??? move to E57Utility?
+      // Relatively quick way to compute ceil(log2(maximum - minimum + 1)));
+      // Uses only integer operations and is machine independent (no assembly code). Find the bit
+      // position of the first 1 (from left) in the binary form of stateCountMinus1.
+      //??? move to E57Utility?
 
       uint64_t stateCountMinus1 = maximum - minimum;
 

--- a/src/ImageFileImpl.h
+++ b/src/ImageFileImpl.h
@@ -42,9 +42,12 @@ namespace e57
    {
    public:
       explicit ImageFileImpl( ReadChecksumPolicy policy );
+
       void construct2( const ustring &fileName, const ustring &mode );
       void construct2( const char *input, uint64_t size );
+
       std::shared_ptr<StructureNodeImpl> root();
+
       void close();
       void cancel();
       bool isOpen() const;
@@ -70,7 +73,8 @@ namespace e57
       bool isElementNameLegal( const ustring &elementName, bool allowNumber = true );
       bool isPathNameLegal( const ustring &pathName );
       void checkElementNameLegal( const ustring &elementName, bool allowNumber = true );
-      void elementNameParse( const ustring &elementName, ustring &prefix, ustring &localPart, bool allowNumber = true );
+      void elementNameParse( const ustring &elementName, ustring &prefix, ustring &localPart,
+                             bool allowNumber = true );
 
       void pathNameCheckWellFormed( const ustring &pathName );
       void pathNameParse( const ustring &pathName, bool &isRelative, StringList &fields );
@@ -82,7 +86,6 @@ namespace e57
       void incrReaderCount();
       void decrReaderCount();
 
-      /// Diagnostic functions:
 #ifdef E57_DEBUG
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
 #endif
@@ -91,13 +94,12 @@ namespace e57
       friend class E57XmlParser;
       friend class BlobNodeImpl;
       friend class CompressedVectorWriterImpl;
-      friend class CompressedVectorReaderImpl; //??? add file() instead of
-                                               // accessing file_, others
-                                               // friends too
+      friend class CompressedVectorReaderImpl;
 
       static void readFileHeader( CheckedFile *file, E57FileHeader &header );
 
-      void checkImageFileOpen( const char *srcFileName, int srcLineNumber, const char *srcFunctionName ) const;
+      void checkImageFileOpen( const char *srcFileName, int srcLineNumber,
+                               const char *srcFunctionName ) const;
 
       ustring fileName_;
       bool isWriter_;
@@ -108,11 +110,11 @@ namespace e57
 
       CheckedFile *file_;
 
-      /// Read file attributes
+      // Read file attributes
       uint64_t xmlLogicalOffset_;
       uint64_t xmlLogicalLength_;
 
-      /// Write file attributes
+      // Write file attributes
       uint64_t unusedLogicalStart_;
 
       /// Bidirectional map from namespace prefix to uri

--- a/src/IntegerNode.cpp
+++ b/src/IntegerNode.cpp
@@ -27,205 +27,36 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-//! @file IntegerNode.cpp
+/// @file IntegerNode.cpp
 
 #include "IntegerNodeImpl.h"
 #include "StringFunctions.h"
 
 using namespace e57;
 
-/*!
-@class e57::IntegerNode
-@brief   An E57 element encoding an integer value.
-@details
-An IntegerNode is a terminal node (i.e. having no children) that holds an
-integer value, and minimum/maximum bounds. Once the IntegerNode value and
-attributes are set at creation, they may not be modified.
-
-The minimum attribute may be a number in the interval [-2^63, 2^63).
-The maximum attribute may be a number in the interval [minimum, 2^63).
-The value may be a number in the interval [minimum, maximum].
-
-See Node class discussion for discussion of the common functions that
-StructureNode supports.
-
-@section IntegerNode_invariant Class Invariant
-A class invariant is a list of statements about an object that are always true
-before and after any operation on the object. An invariant is useful for testing
-correct operation of an implementation. Statements in an invariant can involve
-only externally visible state, or can refer to internal implementation-specific
-state that is not visible to the API user. The following C++ code checks
-externally visible state for consistency and throws an exception if the
-invariant is violated:
-@dontinclude IntegerNode.cpp
-@skip beginExample IntegerNode::checkInvariant
-@until endExample IntegerNode::checkInvariant
-
-@see     Node, CompressedVector
-*/
-
-/*!
-@brief   Create an E57 element for storing a integer value.
-@param   [in] destImageFile   The ImageFile where the new node will eventually
-be stored.
-@param   [in] value     The integer value of the element.
-@param   [in] minimum   The smallest value that the element may take.
-@param   [in] maximum   The largest value that the element may take.
-@details
-An IntegerNode stores an integer value, and a lower and upper bound.
-The IntegerNode class corresponds to the ASTM E57 standard Integer element.
-See the class discussion at bottom of IntegerNode page for more details.
-
-The @a destImageFile indicates which ImageFile the IntegerNode will eventually
-be attached to. A node is attached to an ImageFile by adding it underneath the
-predefined root of the ImageFile (gotten from ImageFile::root). It is not an
-error to fail to attach the IntegerNode to the @a destImageFile. It is an error
-to attempt to attach the IntegerNode to a different ImageFile.
-
-@b Warning: it is an error to give an @a value outside the @a minimum / @a
-maximum bounds, even if the IntegerNode is destined to be used in a
-CompressedVectorNode prototype (where the @a value will be ignored). If the
-IntegerNode is to be used in a prototype, it is recommended to specify a @a
-value = 0 if 0 is within bounds, or a @a value = @a minimum if 0 is not within
-bounds.
-@pre     The @a destImageFile must be open (i.e. destImageFile.isOpen() must be
-true).
-@pre     The @a destImageFile must have been opened in write mode (i.e.
-destImageFile.isWritable() must be true).
-@pre     minimum <= value <= maximum
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorFileReadOnly
-@throw   ::ErrorValueOutOfBounds
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     IntegerNode::value, Node, CompressedVectorNode, CompressedVectorNode::prototype
-*/
-IntegerNode::IntegerNode( ImageFile destImageFile, int64_t value, int64_t minimum, int64_t maximum ) :
-   impl_( new IntegerNodeImpl( destImageFile.impl(), value, minimum, maximum ) )
-{
-}
-
-//! @brief   Is this a root node.
-//! @copydetails Node::isRoot()
-bool IntegerNode::isRoot() const
-{
-   return impl_->isRoot();
-}
-
-//! @brief   Return parent of node, or self if a root node.
-//! @copydetails Node::parent()
-Node IntegerNode::parent() const
-{
-   return Node( impl_->parent() );
-}
-
-//! @brief   Get absolute pathname of node.
-//! @copydetails Node::pathName()
-ustring IntegerNode::pathName() const
-{
-   return impl_->pathName();
-}
-
-//! @brief   Get elementName string, that identifies the node in its parent..
-//! @copydetails Node::elementName()
-ustring IntegerNode::elementName() const
-{
-   return impl_->elementName();
-}
-
-//! @brief   Get the ImageFile that was declared as the destination for the node
-//! when it was created.
-//! @copydetails Node::destImageFile()
-ImageFile IntegerNode::destImageFile() const
-{
-   return ImageFile( impl_->destImageFile() );
-}
-
-//! @brief   Has node been attached into the tree of an ImageFile.
-//! @copydetails Node::isAttached()
-bool IntegerNode::isAttached() const
-{
-   return impl_->isAttached();
-}
-
-/*!
-@brief   Get integer value stored.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  integer value stored.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     IntegerNode::minimum, IntegerNode::maximum
-*/
-int64_t IntegerNode::value() const
-{
-   return impl_->value();
-}
-
-/*!
-@brief   Get the declared minimum that the value may take.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The declared minimum that the value may take.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     IntegerCreate.cpp example, IntegerNode::value
-*/
-int64_t IntegerNode::minimum() const
-{
-   return impl_->minimum();
-}
-
-/*!
-@brief   Get the declared maximum that the value may take.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The declared maximum that the value may take.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     IntegerNode::value
-*/
-int64_t IntegerNode::maximum() const
-{
-   return impl_->maximum();
-}
-
-//! @brief   Diagnostic function to print internal state of object to output
-//! stream in an indented format.
-//! @copydetails Node::dump()
-#ifdef E57_DEBUG
-void IntegerNode::dump( int indent, std::ostream &os ) const
-{
-   impl_->dump( indent, os );
-}
-#else
-void IntegerNode::dump( int indent, std::ostream &os ) const
-{
-}
-#endif
-
+// Put this function first so we can reference the code in doxygen using @skip
 /*!
 @brief Check whether IntegerNode class invariant is true
-@param   [in] doRecurse   If true, also check invariants of all children or
-sub-objects recursively.
-@param   [in] doUpcast    If true, also check invariants of the generic Node
-class.
-@details
-This function checks at least the assertions in the documented class invariant
-description (see class reference page for this object). Other internal
-invariants that are implementation-dependent may also be checked. If any
-invariant clause is violated, an ::ErrorInvarianceViolation E57Exception is thrown.
 
-Checking the invariant recursively may be expensive if the tree is large, so
-should be used judiciously, in debug versions of the application.
-@post    No visible state is modified.
-@throw   ::ErrorInvarianceViolation or any other E57 ErrorCode
+@param [in] doRecurse If true, also check invariants of all children or sub-objects recursively.
+@param [in] doUpcast If true, also check invariants of the generic Node class.
+
+@details
+This function checks at least the assertions in the documented class invariant description (see
+class reference page for this object). Other internal invariants that are implementation-dependent
+may also be checked. If any invariant clause is violated, an ::ErrorInvarianceViolation E57Exception
+is thrown.
+
+Checking the invariant recursively may be expensive if the tree is large, so should be used
+judiciously, in debug versions of the application.
+
+@post No visible state is modified.
+
+@throw ::ErrorInvarianceViolation or any other E57 ErrorCode
 */
-// beginExample IntegerNode::checkInvariant
 void IntegerNode::checkInvariant( bool /*doRecurse*/, bool doUpcast )
 {
-   // If destImageFile not open, can't test invariant (almost every call would
-   // throw)
+   // If destImageFile not open, can't test invariant (almost every call would throw)
    if ( !destImageFile().isOpen() )
    {
       return;
@@ -242,33 +73,234 @@ void IntegerNode::checkInvariant( bool /*doRecurse*/, bool doUpcast )
       throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 }
-// endExample IntegerNode::checkInvariant
 
 /*!
-@brief   Upcast a IntegerNode handle to a generic Node handle.
-@details An upcast is always safe, and the compiler can automatically insert it
-for initializations of Node variables and Node function arguments.
-@return  A smart Node handle referencing the underlying object.
-@throw   No E57Exceptions.
-@see     explanation in Node, Node::type(), IntegerNode(const Node&)
+@class e57::IntegerNode
+
+@brief An E57 element encoding an integer value.
+
+@details
+An IntegerNode is a terminal node (i.e. having no children) that holds an integer value, and
+minimum/maximum bounds. Once the IntegerNode value and attributes are set at creation, they may not
+be modified.
+
+The minimum attribute may be a number in the interval [-2^63, 2^63).
+The maximum attribute may be a number in the interval [minimum, 2^63).
+The value may be a number in the interval [minimum, maximum].
+
+See Node class discussion for discussion of the common functions that StructureNode supports.
+
+@section IntegerNode_invariant Class Invariant
+A class invariant is a list of statements about an object that are always true before and after any
+operation on the object. An invariant is useful for testing correct operation of an implementation.
+Statements in an invariant can involve only externally visible state, or can refer to internal
+implementation-specific state that is not visible to the API user. The following C++ code checks
+externally visible state for consistency and throws an exception if the invariant is violated:
+
+@dontinclude IntegerNode.cpp
+@skip void IntegerNode::checkInvariant
+@until ^}
+
+@see Node, CompressedVector
+*/
+
+/*!
+@brief Create an E57 element for storing a integer value.
+
+@param [in] destImageFile The ImageFile where the new node will eventually be stored.
+@param [in] value The integer value of the element.
+@param [in] minimum The smallest value that the element may take.
+@param [in] maximum The largest value that the element may take.
+
+@details
+An IntegerNode stores an integer value, and a lower and upper bound.
+The IntegerNode class corresponds to the ASTM E57 standard Integer element.
+See the class discussion at bottom of IntegerNode page for more details.
+
+The @a destImageFile indicates which ImageFile the IntegerNode will eventually be attached to. A
+node is attached to an ImageFile by adding it underneath the predefined root of the ImageFile
+(gotten from ImageFile::root). It is not an error to fail to attach the IntegerNode to the @a
+destImageFile. It is an error to attempt to attach the IntegerNode to a different ImageFile.
+
+@warning It is an error to give an @a value outside the @a minimum / @a maximum bounds, even if the
+IntegerNode is destined to be used in a CompressedVectorNode prototype (where the @a value will be
+ignored). If the IntegerNode is to be used in a prototype, it is recommended to specify a @a value =
+0 if 0 is within bounds, or a @a value = @a minimum if 0 is not within bounds.
+
+@pre The @a destImageFile must be open (i.e. destImageFile.isOpen() must be true).
+@pre The @a destImageFile must have been opened in write mode (i.e. destImageFile.isWritable() must
+be true).
+@pre minimum <= value <= maximum
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorFileReadOnly
+@throw ::ErrorValueOutOfBounds
+@throw ::ErrorInternal All objects in undocumented state
+
+@see IntegerNode::value, Node, CompressedVectorNode, CompressedVectorNode::prototype
+*/
+IntegerNode::IntegerNode( ImageFile destImageFile, int64_t value, int64_t minimum,
+                          int64_t maximum ) :
+   impl_( new IntegerNodeImpl( destImageFile.impl(), value, minimum, maximum ) )
+{
+}
+
+/*!
+@brief Is this a root node.
+@copydetails Node::isRoot()
+*/
+bool IntegerNode::isRoot() const
+{
+   return impl_->isRoot();
+}
+
+/*!
+@brief Return parent of node, or self if a root node.
+@copydetails Node::parent()
+*/
+Node IntegerNode::parent() const
+{
+   return Node( impl_->parent() );
+}
+
+/*!
+@brief Get absolute pathname of node.
+@copydetails Node::pathName()
+*/
+ustring IntegerNode::pathName() const
+{
+   return impl_->pathName();
+}
+
+/*!
+@brief Get elementName string, that identifies the node in its parent.
+@copydetails Node::elementName()
+*/
+ustring IntegerNode::elementName() const
+{
+   return impl_->elementName();
+}
+
+/*!
+@brief Get the ImageFile that was declared as the destination for the node when it was created.
+@copydetails Node::destImageFile()
+*/
+ImageFile IntegerNode::destImageFile() const
+{
+   return ImageFile( impl_->destImageFile() );
+}
+
+/*!
+@brief Has node been attached into the tree of an ImageFile.
+@copydetails Node::isAttached()
+*/
+bool IntegerNode::isAttached() const
+{
+   return impl_->isAttached();
+}
+
+/*!
+@brief Get integer value stored.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return integer value stored.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal  All objects in undocumented state
+
+@see IntegerNode::minimum, IntegerNode::maximum
+*/
+int64_t IntegerNode::value() const
+{
+   return impl_->value();
+}
+
+/*!
+@brief Get the declared minimum that the value may take.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return The declared minimum that the value may take.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see IntegerNode::value
+*/
+int64_t IntegerNode::minimum() const
+{
+   return impl_->minimum();
+}
+
+/*!
+@brief Get the declared maximum that the value may take.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return The declared maximum that the value may take.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see IntegerNode::value
+*/
+int64_t IntegerNode::maximum() const
+{
+   return impl_->maximum();
+}
+
+/*!
+@brief Diagnostic function to print internal state of object to output stream in an indented format.
+@copydetails Node::dump()
+*/
+#ifdef E57_DEBUG
+void IntegerNode::dump( int indent, std::ostream &os ) const
+{
+   impl_->dump( indent, os );
+}
+#else
+void IntegerNode::dump( int indent, std::ostream &os ) const
+{
+}
+#endif
+
+/*!
+@brief Upcast a IntegerNode handle to a generic Node handle.
+
+@details
+An upcast is always safe, and the compiler can automatically insert it for initializations of Node
+variables and Node function arguments.
+
+@return A smart Node handle referencing the underlying object.
+
+@throw No E57Exceptions.
+
+@see explanation in Node, Node::type(), IntegerNode(const Node&)
 */
 IntegerNode::operator Node() const
 {
-   /// Upcast from shared_ptr<IntegerNodeImpl> to SharedNodeImplPtr and
-   /// construct a Node object
+   // Upcast from shared_ptr<IntegerNodeImpl> to SharedNodeImplPtr and construct a Node object
    return Node( impl_ );
 }
 
 /*!
-@brief   Downcast a generic Node handle to a IntegerNode handle.
-@param   [in] n The generic handle to downcast.
-@details The handle @a n must be for an underlying IntegerNode, otherwise an
-exception is thrown. In designs that need to avoid the exception, use
-Node::type() to determine the actual type of the @a n before downcasting. This
-function must be explicitly called (c++ compiler cannot insert it
-automatically).
-@throw   ::ErrorBadNodeDowncast
-@see     Node::type(), IntegerNode::operator Node()
+@brief Downcast a generic Node handle to a IntegerNode handle.
+
+@param [in] n The generic handle to downcast.
+
+@details
+The handle @a n must be for an underlying IntegerNode, otherwise an exception is thrown. In designs
+that need to avoid the exception, use Node::type() to determine the actual type of the @a n before
+downcasting. This function must be explicitly called (c++ compiler cannot insert it automatically).
+
+@throw ::ErrorBadNodeDowncast
+
+@see Node::type(), IntegerNode::operator Node()
 */
 IntegerNode::IntegerNode( const Node &n )
 {
@@ -277,13 +309,12 @@ IntegerNode::IntegerNode( const Node &n )
       throw E57_EXCEPTION2( ErrorBadNodeDowncast, "nodeType=" + toString( n.type() ) );
    }
 
-   /// Set our shared_ptr to the downcast shared_ptr
+   // Set our shared_ptr to the downcast shared_ptr
    impl_ = std::static_pointer_cast<IntegerNodeImpl>( n.impl() );
 }
 
-//! @cond documentNonPublic   The following isn't part of the API, and isn't
-//! documented.
+/// @cond documentNonPublic The following isn't part of the API, and isn't documented.
 IntegerNode::IntegerNode( std::shared_ptr<IntegerNodeImpl> ni ) : impl_( ni )
 {
 }
-//! @endcond
+/// @endcond

--- a/src/IntegerNodeImpl.cpp
+++ b/src/IntegerNodeImpl.cpp
@@ -31,19 +31,20 @@
 
 namespace e57
 {
-   IntegerNodeImpl::IntegerNodeImpl( ImageFileImplWeakPtr destImageFile, int64_t value, int64_t minimum,
-                                     int64_t maximum ) :
+   IntegerNodeImpl::IntegerNodeImpl( ImageFileImplWeakPtr destImageFile, int64_t value,
+                                     int64_t minimum, int64_t maximum ) :
       NodeImpl( destImageFile ),
       value_( value ), minimum_( minimum ), maximum_( maximum )
    {
       // don't checkImageFileOpen, NodeImpl() will do it
 
-      /// Enforce the given bounds
+      // Enforce the given bounds
       if ( value < minimum || maximum < value )
       {
-         throw E57_EXCEPTION2( ErrorValueOutOfBounds,
-                               "this->pathName=" + this->pathName() + " value=" + toString( value ) +
-                                  " minimum=" + toString( minimum ) + " maximum=" + toString( maximum ) );
+         throw E57_EXCEPTION2( ErrorValueOutOfBounds, "this->pathName=" + this->pathName() +
+                                                         " value=" + toString( value ) +
+                                                         " minimum=" + toString( minimum ) +
+                                                         " maximum=" + toString( maximum ) );
       }
    }
 
@@ -51,30 +52,30 @@ namespace e57
    {
       // don't checkImageFileOpen
 
-      /// Same node type?
+      // Same node type?
       if ( ni->type() != TypeInteger )
       {
          return ( false );
       }
 
-      /// Downcast to shared_ptr<IntegerNodeImpl>
+      // Downcast to shared_ptr<IntegerNodeImpl>
       std::shared_ptr<IntegerNodeImpl> ii( std::static_pointer_cast<IntegerNodeImpl>( ni ) );
 
-      /// minimum must match
+      // minimum must match
       if ( minimum_ != ii->minimum_ )
       {
          return ( false );
       }
 
-      /// maximum must match
+      // maximum must match
       if ( maximum_ != ii->maximum_ )
       {
          return ( false );
       }
 
-      /// ignore value_, doesn't have to match
+      // ignore value_, doesn't have to match
 
-      /// Types match
+      // Types match
       return ( true );
    }
 
@@ -82,7 +83,7 @@ namespace e57
    {
       // don't checkImageFileOpen
 
-      /// We have no sub-structure, so if path not empty return false
+      // We have no sub-structure, so if path not empty return false
       return pathName.empty();
    }
 
@@ -108,7 +109,7 @@ namespace e57
    {
       // don't checkImageFileOpen
 
-      /// We are a leaf node, so verify that we are listed in set.
+      // We are a leaf node, so verify that we are listed in set.
       if ( pathNames.find( relativePathName( origin ) ) == pathNames.end() )
       {
          throw E57_EXCEPTION2( ErrorNoBufferForElement, "this->pathName=" + this->pathName() );
@@ -132,7 +133,7 @@ namespace e57
 
       cf << space( indent ) << "<" << fieldName << " type=\"Integer\"";
 
-      /// Don't need to write if are default values
+      // Don't need to write if are default values
       if ( minimum_ != INT64_MIN )
       {
          cf << " minimum=\"" << minimum_ << "\"";
@@ -142,7 +143,7 @@ namespace e57
          cf << " maximum=\"" << maximum_ << "\"";
       }
 
-      /// Write value as child text, unless it is the default value
+      // Write value as child text, unless it is the default value
       if ( value_ != 0 )
       {
          cf << ">" << value_ << "</" << fieldName << ">\n";

--- a/src/IntegerNodeImpl.h
+++ b/src/IntegerNodeImpl.h
@@ -33,8 +33,8 @@ namespace e57
    class IntegerNodeImpl : public NodeImpl
    {
    public:
-      explicit IntegerNodeImpl( ImageFileImplWeakPtr destImageFile, int64_t value = 0, int64_t minimum = 0,
-                                int64_t maximum = 0 );
+      explicit IntegerNodeImpl( ImageFileImplWeakPtr destImageFile, int64_t value = 0,
+                                int64_t minimum = 0, int64_t maximum = 0 );
       ~IntegerNodeImpl() override = default;
 
       NodeType type() const override

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -27,334 +27,43 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-//! @file Node.cpp
+/// @file Node.cpp
 
 #include "NodeImpl.h"
 
 using namespace e57;
 
-/*!
-@class e57::Node
-@brief   Generic handle to any of the 8 types of E57 element objects.
-@details
-A Node is a generic handle to an underlying object that is any of the eight type
-of E57 element objects. Each of the eight node types support the all the
-functions of the Node class. A Node is a vertex in a tree (acyclic graph), which
-is a hierarchical organization of nodes. At the top of the hierarchy is a single
-root Node. If a Node is a container type (StructureNode, VectorNode,
-CompressedVectorNode) it may have child nodes. The following are non-container
-type nodes (also known as terminal nodes): IntegerNode, ScaledIntegerNode,
-FloatNode, StringNode, BlobNode. Terminal nodes store various types of values
-and cannot have children. Each Node has an elementName, which is a string that
-uniquely identifies it within the children of its parent. Children of a
-StructureNode have elementNames that are explicitly given by the API user.
-Children of a VectorNode or CompressedVectorNode have element names that are
-string reorientations of the Node's positional index, starting at "0". A path
-name is a sequence elementNames (divided by "/") that must be traversed to get
-from a Node to one of its descendents.
-
-Data is organized in an E57 format file (an ImageFile) hierarchically.
-Each ImageFile has a predefined root node that other nodes can be attached to as
-children (either directly or indirectly). A Node can exist temporarily without
-being attached to an ImageFile, however the state will not be saved in the
-associated file, and the state will be lost if the program exits.
-
-A handle to a generic Node may be safely be converted to and from a handle to
-the Node's true underlying type. Since an attempt to convert a generic Node to a
-incorrect handle type will fail with an exception, the true type should be
-interrogated beforehand.
-
-Due to the set-once design of the Foundation API, terminal nodes are immutable
-(i.e. their values and attributes can't change after creation). Once a
-parent-child relationship has been established, it cannot be changed.
-
-Only generic operations are available for a Node, to access more specific
-operations (e.g. StructureNode::childCount) the generic handle must be converted
-to the node type of the underlying object. This conversion is done in a
-type-safe way using "downcasting" (see discussion below).
-
-@section node_Downcasting Downcasting
-The conversion from a general handle type to a specific handle type is called
-"downcasting". Each of the 8 specific node types have a downcast function (see
-IntegerNode::IntegerNode(const Node&) for example). If a downcast is requested
-to an incorrect type (e.g. taking a Node handle that is actually a FloatNode and
-trying to downcast it to a IntegerNode), an E57Exception is thrown with an
-ErrorCode of ::ErrorBadNodeDowncast. Depending on the program design,
-throwing a bad downcast exception might be acceptable, if an element must be a
-specific type and no recovery is possible. If a standard requires an element be
-one several types, then Node::type() should be used to interrogate the type in
-an @c if or @c switch statement. Downcasting is "dangerous" (can fail with an
-exception) so the API requires the programmer to explicitly call the downcast
-functions rather than have the c++ compiler insert them automatically.
-
-@section node_Upcasting Upcasting
-The conversion of a specific node handle (e.g. IntegerNode) to a general Node
-handle is called "upcasting". Each of the 8 specific node types have an upcast
-function (see IntegerNode::operator Node() for example). Upcasting is "safe"
-(can't cause an exception) so the API allows the c++ compiler to insert them
-automatically. Upcasting is useful if you have a specific node handle and want
-to call a function that takes a generic Node handle argument. In this case, the
-function can be called with the specific handle and the compiler will
-automatically insert the upcast conversion. This implicit conversion allows one
-function, with an argument of type Node, to handle operations that apply to all
-8 types of nodes (e.g. StructureNode::set()).
-
-@section node_invariant Class Invariant
-A class invariant is a list of statements about an object that are always true
-before and after any operation on the object. An invariant is useful for testing
-correct operation of an implementation. Statements in an invariant can involve
-only externally visible state, or can refer to internal implementation-specific
-state that is not visible to the API user. The following C++ code checks
-externally visible state for consistency and throws an exception if the
-invariant is violated:
-@dontinclude Node.cpp
-@skip beginExample Node::checkInvariant
-@until endExample Node::checkInvariant
-
-@see StructureNode, VectorNode, CompressedVectorNode, IntegerNode,
-ScaledIntegerNode, FloatNode, StringNode, BlobNode
-*/
-
-/*!
-@brief   Return the NodeType of a generic Node.
-@details This function allows the actual node type to be interrogated before
-upcasting the handle to the actual node type (see Upcasting and Downcasting
-section in Node).
-@return  The NodeType of a generic Node, which may be one of the following NodeType enumeration values:
-::TypeStructure, ::TypeVector, ::TypeCompressedVector, ::TypeInteger, ::TypeScaledInteger, ::TypeFloat, ::TypeString,
-::TypeBlob.
-@post    No visible state is modified.
-@see     NodeType, upcast/downcast discussion in Node
-*/
-NodeType Node::type() const
-{
-   return impl_->type();
-}
-
-/*!
-@brief   Is this a root node.
-@details A root node has itself as a parent (it is not a child of any node).
-Newly constructed nodes (before they are inserted into an ImageFile tree) start
-out as root nodes. It is possible to temporarily create small trees that are
-unattached to any ImageFile. In these temporary trees, the top-most node will be
-a root node. After the tree is attached to the ImageFile tree, the only root
-node will be the pre-created one of the ImageTree (the one returned by
-ImageFile::root). The concept of @em attachment is slightly larger than that of
-the parent-child relationship (see Node::isAttached and
-CompressedVectorNode::CompressedVectorNode for more details).
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  true if this node is a root node.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     Node::parent, Node::isAttached, CompressedVectorNode::CompressedVectorNode
-*/
-bool Node::isRoot() const
-{
-   return impl_->isRoot();
-}
-
-/*!
-@brief   Return parent of node, or self if a root node.
-@details Nodes are organized into trees (acyclic graphs) with a distinguished
-node (the "top-most" node) called the root node. A parent-child relationship is
-established between nodes to form a tree. Nodes can have zero or one parent.
-Nodes with zero parents are called root nodes.
-In the API, if a node has zero parents it is represented by having itself as a
-parent. Due to the set-once design of the API, a parent-child relationship
-cannot be modified once established. A child node can be any of the 8 node
-types, but a parent node can only be one of the 3 container node types
-(::TypeStructure, ::TypeVector, and ::TypeCompressedVector). Each parent-child link
-has a string name (the elementName) associated with it (See Node::elementName
-for more details). More than one tree can be formed at any given time. Typically
-small trees are temporarily constructed before attachment to an ImageFile so
-that they will be written to the disk.
-
-@b Warning: user algorithms that use this function to walk the tree must take
-care to handle the case where a node is its own parent (it is a root node). Use
-Node::isRoot to avoid infinite loops or infinite recursion.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  A smart Node handle referencing the parent node or this node if is a
-root node.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     Node::isRoot, Node::isAttached, CompressedVectorNode::CompressedVectorNode, Node::elementName
-*/
-Node Node::parent() const
-{
-   return Node( impl_->parent() );
-}
-
-/*!
-@brief   Get absolute pathname of node.
-@details
-Nodes are organized into trees (acyclic graphs) by a parent-child relationship
-between nodes. Each parent-child relationship has an associated elementName
-string that is unique for a given parent. Any node in a given tree can be
-identified by a sequence of elementNames of how to get to the node from the root
-of the tree. An absolute pathname string that is formed by arranging this
-sequence of elementNames separated by the "/" character with a leading "/"
-prepended.
-
-Some example absolute pathNames: "/data3D/0/points/153/cartesianX",
-"/data3D/0/points",
-"/cameraImages/1/pose/rotation/w", and "/". These examples have probably been
-attached to an ImageFile. Here is an example absolute pathName of a node in a
-pose tree that has not yet been attached to an ImageFile: "/pose/rotation/w".
-
-A technical aside: the elementName of a root node does not appear in absolute
-pathnames, since the "path" is between the staring node (the root) and the
-ending node. By convention, in this API, a root node has the empty string ("")
-as its elementName.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The absolute path name of the node.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     Node::elementName, Node::parent, Node::isRoot
-*/
-ustring Node::pathName() const
-{
-   return impl_->pathName();
-}
-
-/*!
-@brief   Get element name of node.
-@details
-The elementName is a string associated with each parent-child link between
-nodes. For a given parent, the elementName uniquely identifies each of its
-children. Thus, any node in a tree can be identified by a sequence of
-elementNames that form a path from the tree's root node (see Node::pathName for
-more details).
-
-Three types of nodes (the container node types) can be parents: StructureNode,
-VectorNode, and CompressedVectorNode. The children of a StructureNode are
-explicitly given unique elementNames when they are attached to the parent (using
-StructureNode::set). The children of VectorNode and CompressedVectorNode are
-implicitly given elementNames based on their position in the list (starting at
-"0"). In a CompressedVectorNode, the elementName can become quite large:
-"1000000000" or more. However in a CompressedVectorNode, the elementName string
-is not stored in the file and is deduced by the position of the child.
-
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The element name of the node, or "" if a root node.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     Node::pathName, Node::parent, Node::isRoot
-*/
-ustring Node::elementName() const
-{
-   return impl_->elementName();
-}
-
-/*!
-@brief   Get the ImageFile that was declared as the destination for the node
-when it was created.
-@details The first argument of the constructors of each of the 8 types of nodes
-is an ImageFile that indicates which ImageFile the node will eventually be
-attached to. This function returns that constructor argument. It is an error to
-attempt to attach the node to a different ImageFile. However it is not an error
-to not attach the node to any ImageFile (it's just wasteful). Use
-Node::isAttached to check if the node actually did get attached.
-@post    No visible object state is modified.
-@return  The ImageFile that was declared as the destination for the node when it
-was created.
-@see     Node::isAttached,
-StructureNode::StructureNode(), VectorNode::VectorNode(),
-CompressedVectorNode::CompressedVectorNode(), IntegerNode::IntegerNode(),
-ScaledIntegerNode::ScaledIntegerNode(), FloatNode::FloatNode(),
-StringNode::StringNode(), BlobNode::BlobNode()
-*/
-ImageFile Node::destImageFile() const
-{
-   return ImageFile( impl_->destImageFile() );
-}
-
-/*!
-@brief   Has node been attached into the tree of an ImageFile.
-@details Nodes are attached into an ImageFile tree by inserting them as children
-(directly or indirectly) of the ImageFile's root node. Nodes can also be
-attached to an ImageFile if they are used in the @c codecs or @c prototype trees
-of an CompressedVectorNode that is attached. Attached nodes will be saved to
-disk when the ImageFile is closed, and restored when the ImageFile is read back
-in from disk. Unattached nodes will not be saved to disk. It is not recommended
-to create nodes that are not eventually attached to the ImageFile.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible object state is modified.
-@return  @c true if node is child of (or in codecs or prototype of a child
-CompressedVectorNode of) the root node of an ImageFile.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     Node::destImageFile, ImageFile::root
-*/
-bool Node::isAttached() const
-{
-   return impl_->isAttached();
-}
-
-/*!
-@brief   Diagnostic function to print internal state of object to output stream
-in an indented format.
-@param   [in] indent    Number of spaces to indent all the printed lines of this
-object.
-@param   [in] os        Output stream to print on.
-@details
-All objects in the E57 Foundation API (with exception of E57Exception) support a
-dump() function. These functions print out to the console a detailed listing of
-the internal state of objects. The content of these printouts is not documented,
-and is really of interest only to implementation developers/maintainers or the
-really adventurous users. In implementations of the API other than the Reference
-Implementation, the dump() functions may produce no output (although the
-functions should still be defined). The output format may change from version to
-version.
-@post    No visible object state is modified.
-@throw   No E57Exceptions
-*/
-#ifdef E57_DEBUG
-void Node::dump( int indent, std::ostream &os ) const
-{
-   impl_->dump( indent, os );
-}
-#else
-void Node::dump( int indent, std::ostream &os ) const
-{
-}
-#endif
-
+// Put this function first so we can reference the code in doxygen using @skip
 /*!
 @brief Check whether Node class invariant is true
-@param   [in] doRecurse     If true, also check invariants of all children or
-sub-objects recursively.
-@param   [in] doDowncast    If true, also check any invariants of the actual
-derived type in addition to the generic node invariants.
+
+@param [in] doRecurse If true, also check invariants of all children or sub-objects recursively.
+@param [in] doDowncast If true, also check any invariants of the actual derived type in addition to
+the generic node invariants.
+
 @details
-This function checks at least the assertions in the documented class invariant
-description (see class reference page for this object). Other internal
-invariants that are implementation-dependent may also be checked. If any
-invariant clause is violated, an E57Exception with errorCode of
+This function checks at least the assertions in the documented class invariant description (see
+class reference page for this object). Other internal invariants that are implementation-dependent
+may also be checked. If any invariant clause is violated, an E57Exception with errorCode of
 ErrorInvarianceViolation is thrown.
 
-Specifying doRecurse=true only makes sense if doDowncast=true is also specified
-(the generic Node has no way to access any children). Checking the invariant
-recursively may be expensive if the tree is large, so should be used
-judiciously, in debug versions of the application.
-@post    No visible state is modified.
-@throw   ::ErrorInvarianceViolation or any other E57 ErrorCode
-@see     Class Invariant section in Node,
-IntegerNode::checkInvariant, ScaledIntegerNode::checkInvariant,
-FloatNode::checkInvariant, BlobNode::checkInvariant,
-StructureNode::checkInvariant, VectorNode::checkInvariant,
-CompressedVectorNode::checkInvariant
+Specifying doRecurse=true only makes sense if doDowncast=true is also specified (the generic Node
+has no way to access any children). Checking the invariant recursively may be expensive if the tree
+is large, so should be used judiciously, in debug versions of the application.
+
+@post No visible state is modified.
+
+@throw ::ErrorInvarianceViolation or any other E57 ErrorCode
+
+@see Class Invariant section in Node, IntegerNode::checkInvariant,
+ScaledIntegerNode::checkInvariant, FloatNode::checkInvariant, BlobNode::checkInvariant,
+StructureNode::checkInvariant, VectorNode::checkInvariant, CompressedVectorNode::checkInvariant
 */
-// beginExample Node::checkInvariant
 void Node::checkInvariant( bool doRecurse, bool doDowncast )
 {
    ImageFile imf = destImageFile();
 
-   // If destImageFile not open, can't test invariant (almost every call would
-   // throw)
+   // If destImageFile not open, can't test invariant (almost every call would throw)
    if ( !imf.isOpen() )
    {
       return;
@@ -551,14 +260,319 @@ void Node::checkInvariant( bool doRecurse, bool doDowncast )
       }
    }
 }
-// endExample Node::checkInvariant
 
 /*!
-@brief   Test if two node handles refer to the same underlying node
-@param   [in] n2        The node to compare this node with
-@post    No visible object state is modified.
-@return  @c true if node handles refer to the same underlying node.
-@throw   No E57Exceptions
+@class e57::Node
+
+@brief Generic handle to any of the 8 types of E57 element objects.
+
+@details
+A Node is a generic handle to an underlying object that is any of the eight type of E57 element
+objects. Each of the eight node types support the all the functions of the Node class. A Node is a
+vertex in a tree (acyclic graph), which is a hierarchical organization of nodes. At the top of the
+hierarchy is a single root Node. If a Node is a container type (StructureNode, VectorNode,
+CompressedVectorNode) it may have child nodes. The following are non-container type nodes (also
+known as terminal nodes): IntegerNode, ScaledIntegerNode, FloatNode, StringNode, BlobNode. Terminal
+nodes store various types of values and cannot have children. Each Node has an elementName, which is
+a string that uniquely identifies it within the children of its parent. Children of a StructureNode
+have elementNames that are explicitly given by the API user. Children of a VectorNode or
+CompressedVectorNode have element names that are string reorientations of the Node's positional
+index, starting at "0". A path name is a sequence elementNames (divided by "/") that must be
+traversed to get from a Node to one of its descendents.
+
+Data is organized in an E57 format file (an ImageFile) hierarchically. Each ImageFile has a
+predefined root node that other nodes can be attached to as children (either directly or
+indirectly). A Node can exist temporarily without being attached to an ImageFile, however the state
+will not be saved in the associated file, and the state will be lost if the program exits.
+
+A handle to a generic Node may be safely be converted to and from a handle to the Node's true
+underlying type. Since an attempt to convert a generic Node to a incorrect handle type will fail
+with an exception, the true type should be interrogated beforehand.
+
+Due to the set-once design of the Foundation API, terminal nodes are immutable (i.e. their values
+and attributes can't change after creation). Once a parent-child relationship has been established,
+it cannot be changed.
+
+Only generic operations are available for a Node, to access more specific operations (e.g.
+StructureNode::childCount) the generic handle must be converted to the node type of the underlying
+object. This conversion is done in a type-safe way using "downcasting" (see discussion below).
+
+@section node_Downcasting Downcasting
+The conversion from a general handle type to a specific handle type is called "downcasting". Each of
+the 8 specific node types have a downcast function (see IntegerNode::IntegerNode(const Node&) for
+example). If a downcast is requested to an incorrect type (e.g. taking a Node handle that is
+actually a FloatNode and trying to downcast it to a IntegerNode), an E57Exception is thrown with an
+ErrorCode of ::ErrorBadNodeDowncast. Depending on the program design, throwing a bad downcast
+exception might be acceptable, if an element must be a specific type and no recovery is possible. If
+a standard requires an element be one several types, then Node::type() should be used to interrogate
+the type in an @c if or @c switch statement. Downcasting is "dangerous" (can fail with an exception)
+so the API requires the programmer to explicitly call the downcast functions rather than have the
+c++ compiler insert them automatically.
+
+@section node_Upcasting Upcasting
+The conversion of a specific node handle (e.g. IntegerNode) to a general Node handle is called
+"upcasting". Each of the 8 specific node types have an upcast function (see IntegerNode::operator
+Node() for example). Upcasting is "safe" (can't cause an exception) so the API allows the c++
+compiler to insert them automatically. Upcasting is useful if you have a specific node handle and
+want to call a function that takes a generic Node handle argument. In this case, the function can be
+called with the specific handle and the compiler will automatically insert the upcast conversion.
+This implicit conversion allows one function, with an argument of type Node, to handle operations
+that apply to all 8 types of nodes (e.g. StructureNode::set()).
+
+@section node_invariant Class Invariant
+A class invariant is a list of statements about an object that are always true before and after any
+operation on the object. An invariant is useful for testing correct operation of an implementation.
+Statements in an invariant can involve only externally visible state, or can refer to internal
+implementation-specific state that is not visible to the API user. The following C++ code checks
+externally visible state for consistency and throws an exception if the invariant is violated:
+
+@dontinclude Node.cpp
+@skip void Node::checkInvariant
+@until ^}
+
+@see StructureNode, VectorNode, CompressedVectorNode, IntegerNode, ScaledIntegerNode, FloatNode,
+StringNode, BlobNode
+*/
+
+/*!
+@brief Return the NodeType of a generic Node.
+
+@details
+This function allows the actual node type to be interrogated before upcasting the handle to the
+actual node type (see Upcasting and Downcasting section in Node).
+
+@post No visible state is modified.
+
+@return The NodeType of a generic Node, which may be one of the following NodeType enumeration
+values:
+::TypeStructure, ::TypeVector, ::TypeCompressedVector, ::TypeInteger, ::TypeScaledInteger,
+::TypeFloat, ::TypeString, ::TypeBlob.
+
+@see NodeType, upcast/downcast discussion in Node
+*/
+NodeType Node::type() const
+{
+   return impl_->type();
+}
+
+/*!
+@brief Is this a root node.
+
+@details
+A root node has itself as a parent (it is not a child of any node).
+Newly constructed nodes (before they are inserted into an ImageFile tree) start out as root nodes.
+It is possible to temporarily create small trees that are unattached to any ImageFile. In these
+temporary trees, the top-most node will be a root node. After the tree is attached to the ImageFile
+tree, the only root node will be the pre-created one of the ImageTree (the one returned by
+ImageFile::root). The concept of @em attachment is slightly larger than that of the parent-child
+relationship (see Node::isAttached and CompressedVectorNode::CompressedVectorNode for more details).
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return true if this node is a root node.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see Node::parent, Node::isAttached, CompressedVectorNode::CompressedVectorNode
+*/
+bool Node::isRoot() const
+{
+   return impl_->isRoot();
+}
+
+/*!
+@brief Return parent of node, or self if a root node.
+
+@details
+Nodes are organized into trees (acyclic graphs) with a distinguished node (the "top-most" node)
+called the root node. A parent-child relationship is established between nodes to form a tree. Nodes
+can have zero or one parent. Nodes with zero parents are called root nodes.
+
+In the API, if a node has zero parents it is represented by having itself as a parent. Due to the
+set-once design of the API, a parent-child relationship cannot be modified once established. A child
+node can be any of the 8 node types, but a parent node can only be one of the 3 container node types
+(::TypeStructure, ::TypeVector, and ::TypeCompressedVector). Each parent-child link has a string
+name (the elementName) associated with it (See Node::elementName for more details). More than one
+tree can be formed at any given time. Typically small trees are temporarily constructed before
+attachment to an ImageFile so that they will be written to the disk.
+
+@warning User algorithms that use this function to walk the tree must take care to handle the case
+where a node is its own parent (it is a root node). Use Node::isRoot to avoid infinite loops or
+infinite recursion.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return A smart Node handle referencing the parent node or this node if is a root node.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see Node::isRoot, Node::isAttached, CompressedVectorNode::CompressedVectorNode, Node::elementName
+*/
+Node Node::parent() const
+{
+   return Node( impl_->parent() );
+}
+
+/*!
+@brief Get absolute pathname of node.
+
+@details
+Nodes are organized into trees (acyclic graphs) by a parent-child relationship between nodes. Each
+parent-child relationship has an associated elementName string that is unique for a given parent.
+Any node in a given tree can be identified by a sequence of elementNames of how to get to the node
+from the root of the tree. An absolute pathname string that is formed by arranging this sequence of
+elementNames separated by the "/" character with a leading "/" prepended.
+
+Some example absolute pathNames: "/data3D/0/points/153/cartesianX", "/data3D/0/points",
+"/cameraImages/1/pose/rotation/w", and "/". These examples have probably been attached to an
+ImageFile. Here is an example absolute pathName of a node in a pose tree that has not yet been
+attached to an ImageFile: "/pose/rotation/w".
+
+A technical aside: the elementName of a root node does not appear in absolute pathnames, since the
+"path" is between the staring node (the root) and the ending node. By convention, in this API, a
+root node has the empty string ("") as its elementName.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return The absolute path name of the node.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see Node::elementName, Node::parent, Node::isRoot
+*/
+ustring Node::pathName() const
+{
+   return impl_->pathName();
+}
+
+/*!
+@brief Get element name of node.
+
+@details
+The elementName is a string associated with each parent-child link between nodes. For a given
+parent, the elementName uniquely identifies each of its children. Thus, any node in a tree can be
+identified by a sequence of elementNames that form a path from the tree's root node (see
+Node::pathName for more details).
+
+Three types of nodes (the container node types) can be parents: StructureNode, VectorNode, and
+CompressedVectorNode. The children of a StructureNode are explicitly given unique elementNames when
+they are attached to the parent (using StructureNode::set). The children of VectorNode and
+CompressedVectorNode are implicitly given elementNames based on their position in the list (starting
+at "0"). In a CompressedVectorNode, the elementName can become quite large: "1000000000" or more.
+However in a CompressedVectorNode, the elementName string is not stored in the file and is deduced
+by the position of the child.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return The element name of the node, or "" if a root node.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see Node::pathName, Node::parent, Node::isRoot
+*/
+ustring Node::elementName() const
+{
+   return impl_->elementName();
+}
+
+/*!
+@brief Get the ImageFile that was declared as the destination for the node when it was created.
+
+@details
+The first argument of the constructors of each of the 8 types of nodes is an ImageFile that
+indicates which ImageFile the node will eventually be attached to. This function returns that
+constructor argument. It is an error to attempt to attach the node to a different ImageFile. However
+it is not an error to not attach the node to any ImageFile (it's just wasteful). Use
+Node::isAttached to check if the node actually did get attached.
+
+@post No visible object state is modified.
+
+@return The ImageFile that was declared as the destination for the node when it was created.
+
+@see Node::isAttached, StructureNode::StructureNode(), VectorNode::VectorNode(),
+CompressedVectorNode::CompressedVectorNode(), IntegerNode::IntegerNode(),
+ScaledIntegerNode::ScaledIntegerNode(), FloatNode::FloatNode(), StringNode::StringNode(),
+BlobNode::BlobNode()
+*/
+ImageFile Node::destImageFile() const
+{
+   return ImageFile( impl_->destImageFile() );
+}
+
+/*!
+@brief Has node been attached into the tree of an ImageFile.
+
+@details
+Nodes are attached into an ImageFile tree by inserting them as children (directly or indirectly) of
+the ImageFile's root node. Nodes can also be attached to an ImageFile if they are used in the @c
+codecs or @c prototype trees of an CompressedVectorNode that is attached. Attached nodes will be
+saved to disk when the ImageFile is closed, and restored when the ImageFile is read back in from
+disk. Unattached nodes will not be saved to disk. It is not recommended to create nodes that are not
+eventually attached to the ImageFile.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible object state is modified.
+
+@return @c true if node is child of (or in codecs or prototype of a child CompressedVectorNode of)
+the root node of an ImageFile.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see Node::destImageFile, ImageFile::root
+*/
+bool Node::isAttached() const
+{
+   return impl_->isAttached();
+}
+
+/*!
+@brief Diagnostic function to print internal state of object to output stream in an indented format.
+
+@param [in] indent Number of spaces to indent all the printed lines of this object.
+@param [in] os Output stream to print on.
+
+@details
+All objects in the E57 Foundation API (with exception of E57Exception) support a dump() function.
+These functions print out to the console a detailed listing of the internal state of objects. The
+content of these printouts is not documented, and is really of interest only to implementation
+developers/maintainers or the really adventurous users. In implementations of the API other than the
+Reference Implementation, the dump() functions may produce no output (although the functions should
+still be defined). The output format may change from version to version.
+
+@post No visible object state is modified.
+
+@throw No E57Exceptions
+*/
+#ifdef E57_DEBUG
+void Node::dump( int indent, std::ostream &os ) const
+{
+   impl_->dump( indent, os );
+}
+#else
+void Node::dump( int indent, std::ostream &os ) const
+{
+}
+#endif
+
+/*!
+@brief Test if two node handles refer to the same underlying node
+
+@param [in] n2 The node to compare this node with
+
+@post No visible object state is modified.
+
+@return @c true if node handles refer to the same underlying node.
+
+@throw No E57Exceptions
 */
 bool Node::operator==( Node n2 ) const
 {
@@ -566,19 +580,23 @@ bool Node::operator==( Node n2 ) const
 }
 
 /*!
-@brief   Test if two node handles refer to different underlying nodes
-@param   [in] n2        The node to compare this node with
-@post    No visible object state is modified.
-@return  @c true if node handles refer to different underlying nodes.
-@throw   No E57Exceptions
+@brief Test if two node handles refer to different underlying nodes
+
+@param [in] n2 The node to compare this node with
+
+@post No visible object state is modified.
+
+@return @c true if node handles refer to different underlying nodes.
+
+@throw No E57Exceptions
 */
 bool Node::operator!=( Node n2 ) const
 {
    return ( impl_ != n2.impl_ );
 }
 
-//! @cond documentNonPublic   The following isn't part of the API, and isn't documented.
+/// @cond documentNonPublic The following isn't part of the API, and isn't documented.
 Node::Node( NodeImplSharedPtr ni ) : impl_( ni )
 {
 }
-//! @endcond
+/// @endcond

--- a/src/NodeImpl.cpp
+++ b/src/NodeImpl.cpp
@@ -33,20 +33,23 @@
 
 using namespace e57;
 
-NodeImpl::NodeImpl( ImageFileImplWeakPtr destImageFile ) : destImageFile_( destImageFile ), isAttached_( false )
+NodeImpl::NodeImpl( ImageFileImplWeakPtr destImageFile ) :
+   destImageFile_( destImageFile ), isAttached_( false )
 {
-   checkImageFileOpen( __FILE__, __LINE__,
-                       static_cast<const char *>( __FUNCTION__ ) ); // does checking for all node type ctors
+   checkImageFileOpen(
+      __FILE__, __LINE__,
+      static_cast<const char *>( __FUNCTION__ ) ); // does checking for all node type ctors
 }
 
-void NodeImpl::checkImageFileOpen( const char *srcFileName, int srcLineNumber, const char *srcFunctionName ) const
+void NodeImpl::checkImageFileOpen( const char *srcFileName, int srcLineNumber,
+                                   const char *srcFunctionName ) const
 {
-   /// Throw an exception if destImageFile (destImageFile_) isn't open
+   // Throw an exception if destImageFile (destImageFile_) isn't open
    ImageFileImplSharedPtr destImageFile( destImageFile_ );
    if ( !destImageFile->isOpen() )
    {
-      throw E57Exception( ErrorImageFileNotOpen, "fileName=" + destImageFile->fileName(), srcFileName, srcLineNumber,
-                          srcFunctionName );
+      throw E57Exception( ErrorImageFileNotOpen, "fileName=" + destImageFile->fileName(),
+                          srcFileName, srcLineNumber, srcFunctionName );
    }
 }
 
@@ -63,7 +66,7 @@ NodeImplSharedPtr NodeImpl::parent()
 
    if ( isRoot() )
    {
-      /// If is root, then has self as parent (by convention)
+      // If is root, then has self as parent (by convention)
       return shared_from_this();
    }
 
@@ -101,12 +104,12 @@ ustring NodeImpl::relativePathName( const NodeImplSharedPtr &origin, ustring chi
 
    if ( isRoot() )
    {
-      /// Got to top and didn't find origin, must be error
-      throw E57_EXCEPTION2( ErrorInternal,
-                            "this->elementName=" + this->elementName() + " childPathName=" + childPathName );
+      // Got to top and didn't find origin, must be error
+      throw E57_EXCEPTION2( ErrorInternal, "this->elementName=" + this->elementName() +
+                                              " childPathName=" + childPathName );
    }
 
-   /// Assemble relativePathName from right to left, recursively
+   // Assemble relativePathName from right to left, recursively
    NodeImplSharedPtr p( parent_ );
 
    if ( childPathName.empty() )
@@ -126,7 +129,7 @@ ustring NodeImpl::elementName() const
 
 ImageFileImplSharedPtr NodeImpl::destImageFile()
 {
-   /// don't checkImageFileOpen
+   // don't checkImageFileOpen
    return ImageFileImplSharedPtr( destImageFile_ );
 }
 
@@ -139,15 +142,14 @@ bool NodeImpl::isAttached() const
 
 void NodeImpl::setAttachedRecursive()
 {
-   /// Non-terminal node types (Structure, Vector, CompressedVector) will
-   /// override this virtual function, to mark their children, codecs,
-   /// prototypes
+   // Non-terminal node types (Structure, Vector, CompressedVector) will override this virtual
+   // function, to mark their children, codecs, prototypes
    isAttached_ = true;
 }
 
 ustring NodeImpl::imageFileName() const
 {
-   /// don't checkImageFileOpen
+   // don't checkImageFileOpen
    ImageFileImplSharedPtr imf( destImageFile_ );
 
    return imf->fileName();
@@ -155,27 +157,28 @@ ustring NodeImpl::imageFileName() const
 
 void NodeImpl::setParent( NodeImplSharedPtr parent, const ustring &elementName )
 {
-   /// don't checkImageFileOpen
+   // don't checkImageFileOpen
 
-   /// First check if our parent_ is already set, throw
-   /// ErrorAlreadyHasParent The isAttached_ condition is to catch two
-   /// errors:
-   ///    1) if user attempts to use the ImageFile root as a child (e.g.
-   ///    root.set("x", root)) 2) if user attempts to reuse codecs or prototype
-   ///    trees of a CompressedVectorNode
-   ///       ??? what if CV not attached yet?
+   // First check if our parent_ is already set, throw
+   // ErrorAlreadyHasParent The isAttached_ condition is to catch two
+   // errors:
+   //    1) if user attempts to use the ImageFile root as a child (e.g.
+   //    root.set("x", root)) 2) if user attempts to reuse codecs or prototype
+   //    trees of a CompressedVectorNode
+   //       ??? what if CV not attached yet?
    if ( !parent_.expired() || isAttached_ )
    {
-      /// ??? does caller do setParent first, so state is not messed up when
-      /// throw?
+      // ??? does caller do setParent first, so state is not messed up when
+      // throw?
       throw E57_EXCEPTION2( ErrorAlreadyHasParent,
-                            "this->pathName=" + this->pathName() + " newParent->pathName=" + parent->pathName() );
+                            "this->pathName=" + this->pathName() +
+                               " newParent->pathName=" + parent->pathName() );
    }
 
    parent_ = parent;
    elementName_ = elementName;
 
-   /// If parent is attached then we are attached (and all of our children)
+   // If parent is attached then we are attached (and all of our children)
    if ( parent->isAttached() )
    {
       setAttachedRecursive();
@@ -184,7 +187,7 @@ void NodeImpl::setParent( NodeImplSharedPtr parent, const ustring &elementName )
 
 NodeImplSharedPtr NodeImpl::getRoot()
 {
-   /// don't checkImageFileOpen
+   // don't checkImageFileOpen
    NodeImplSharedPtr p( shared_from_this() );
    while ( !p->isRoot() )
    {
@@ -197,25 +200,24 @@ NodeImplSharedPtr NodeImpl::getRoot()
 //??? use visitor?
 bool NodeImpl::isTypeConstrained()
 {
-   /// don't checkImageFileOpen
-   /// A node is type constrained if any of its parents is an homo VECTOR or
-   /// COMPRESSED_VECTOR with more than one child
+   // don't checkImageFileOpen
+   // A node is type constrained if any of its parents is an homo VECTOR or COMPRESSED_VECTOR with
+   // more than one child
    NodeImplSharedPtr p( shared_from_this() );
 
    while ( !p->isRoot() )
    {
-      /// We have a parent since we are not root
+      // We have a parent since we are not root
       p = NodeImplSharedPtr( p->parent_ ); //??? check if bad ptr?
 
       switch ( p->type() )
       {
          case TypeVector:
          {
-            /// Downcast to shared_ptr<VectorNodeImpl>
+            // Downcast to shared_ptr<VectorNodeImpl>
             std::shared_ptr<VectorNodeImpl> ai( std::static_pointer_cast<VectorNodeImpl>( p ) );
 
-            /// If homogeneous vector and have more than one child, then can't
-            /// change them
+            // If homogeneous vector and have more than one child, then can't change them
             if ( !ai->allowHeteroChildren() && ai->childCount() > 1 )
             {
                return ( true );
@@ -223,24 +225,23 @@ bool NodeImpl::isTypeConstrained()
          }
          break;
          case TypeCompressedVector:
-            /// Can't make any type changes to CompressedVector prototype.  ???
-            /// what if hasn't been written to yet
+            // Can't make any type changes to CompressedVector prototype.  ???
+            // what if hasn't been written to yet
             return ( true );
          default:
             break;
       }
    }
-   /// Didn't find any constraining VECTORs or COMPRESSED_VECTORs in path above
-   /// us, so our type is not constrained.
+   // Didn't find any constraining VECTORs or COMPRESSED_VECTORs in path above us, so our type is
+   // not constrained.
    return ( false );
 }
 
 NodeImplSharedPtr NodeImpl::get( const ustring &pathName )
 {
-   /// This is common virtual function for terminal E57 element types: Integer,
-   /// ScaledInteger, Float, Blob. The non-terminal types override this virtual
-   /// function. Only absolute pathNames make any sense here, because the
-   /// terminal types can't have children, so relative pathNames are illegal.
+   // This is common virtual function for terminal E57 element types: Integer, ScaledInteger, Float,
+   // Blob. The non-terminal types override this virtual function. Only absolute pathNames make any
+   // sense here, because the terminal types can't have children, so relative pathNames are illegal.
 
 #ifdef E57_DEBUG
    _verifyPathNameAbsolute( pathName );
@@ -248,16 +249,16 @@ NodeImplSharedPtr NodeImpl::get( const ustring &pathName )
 
    NodeImplSharedPtr root = _verifyAndGetRoot();
 
-   /// Forward call to the non-terminal root node
+   // Forward call to the non-terminal root node
    return root->get( pathName );
 }
 
 void NodeImpl::set( const ustring &pathName, NodeImplSharedPtr ni, bool autoPathCreate )
 {
-   /// This is common virtual function for terminal E57 element types: Integer,
-   /// ScaledInteger, Float, Blob. The non-terminal types override this virtual
-   /// function. Only absolute pathNames make any sense here, because the
-   /// terminal types can't have children, so relative pathNames are illegal.
+   // This is common virtual function for terminal E57 element types: Integer,  ScaledInteger,
+   // Float, Blob. The non-terminal types override this virtual function. Only absolute pathNames
+   // make any sense here, because the terminal types can't have children, so relative pathNames are
+   // illegal.
 
 #ifdef E57_DEBUG
    _verifyPathNameAbsolute( pathName );
@@ -265,24 +266,24 @@ void NodeImpl::set( const ustring &pathName, NodeImplSharedPtr ni, bool autoPath
 
    NodeImplSharedPtr root = _verifyAndGetRoot();
 
-   /// Forward call to the non-terminal root node
+   // Forward call to the non-terminal root node
    root->set( pathName, ni, autoPathCreate );
 }
 
 void NodeImpl::set( const StringList & /*fields*/, unsigned /*level*/, NodeImplSharedPtr /*ni*/,
                     bool /*autoPathCreate*/ )
 {
-   /// If get here, then tried to call set(fields...) on NodeImpl that wasn't a
-   /// StructureNodeImpl, so that's an error
+   // If get here, then tried to call set(fields...) on NodeImpl that wasn't a  StructureNodeImpl,
+   // so that's an error
    throw E57_EXCEPTION1( ErrorBadPathName ); //???
 }
 
 void NodeImpl::checkBuffers( const std::vector<SourceDestBuffer> &sdbufs,
                              bool allowMissing ) //??? convert sdbufs to vector of shared_ptr
 {
-   /// this node is prototype of CompressedVector
+   // this node is prototype of CompressedVector
 
-   /// don't checkImageFileOpen
+   // don't checkImageFileOpen
 
    StringSet pathNames;
 
@@ -290,42 +291,41 @@ void NodeImpl::checkBuffers( const std::vector<SourceDestBuffer> &sdbufs,
    {
       ustring pathName = sdbufs.at( i ).impl()->pathName();
 
-      /// Check that all buffers are same size
+      // Check that all buffers are same size
       if ( sdbufs.at( i ).impl()->capacity() != sdbufs.at( 0 ).impl()->capacity() )
       {
-         throw E57_EXCEPTION2( ErrorBufferSizeMismatch,
-                               "this->pathName=" + this->pathName() + " sdbuf.pathName=" + pathName +
-                                  " firstCapacity=" + toString( sdbufs.at( 0 ).impl()->capacity() ) +
-                                  " secondCapacity=" + toString( sdbufs.at( i ).impl()->capacity() ) );
+         throw E57_EXCEPTION2(
+            ErrorBufferSizeMismatch,
+            "this->pathName=" + this->pathName() + " sdbuf.pathName=" + pathName +
+               " firstCapacity=" + toString( sdbufs.at( 0 ).impl()->capacity() ) +
+               " secondCapacity=" + toString( sdbufs.at( i ).impl()->capacity() ) );
       }
 
-      /// Add each pathName to set, error if already in set (a duplicate
-      /// pathName in sdbufs)
+      // Add each pathName to set, error if already in set (a duplicate pathName in sdbufs)
       if ( !pathNames.insert( pathName ).second )
       {
-         throw E57_EXCEPTION2( ErrorBufferDuplicatePathName,
-                               "this->pathName=" + this->pathName() + " sdbuf.pathName=" + pathName );
+         throw E57_EXCEPTION2( ErrorBufferDuplicatePathName, "this->pathName=" + this->pathName() +
+                                                                " sdbuf.pathName=" + pathName );
       }
 
-      /// Check no bad fields in sdbufs
+      // Check no bad fields in sdbufs
       if ( !isDefined( pathName ) )
       {
-         throw E57_EXCEPTION2( ErrorPathUndefined,
-                               "this->pathName=" + this->pathName() + " sdbuf.pathName=" + pathName );
+         throw E57_EXCEPTION2( ErrorPathUndefined, "this->pathName=" + this->pathName() +
+                                                      " sdbuf.pathName=" + pathName );
       }
    }
 
    if ( !allowMissing )
    {
-      /// Traverse tree recursively, checking that all nodes are listed in
-      /// sdbufs
+      // Traverse tree recursively, checking that all nodes are listed in sdbufs
       checkLeavesInSet( pathNames, shared_from_this() );
    }
 }
 
 bool NodeImpl::findTerminalPosition( const NodeImplSharedPtr &target, uint64_t &countFromLeft )
 {
-   /// don't checkImageFileOpen
+   // don't checkImageFileOpen
 
    if ( this == &*target ) //??? ok?
    {
@@ -338,7 +338,7 @@ bool NodeImpl::findTerminalPosition( const NodeImplSharedPtr &target, uint64_t &
       {
          auto sni = static_cast<StructureNodeImpl *>( this );
 
-         /// Recursively visit child nodes
+         // Recursively visit child nodes
          int64_t childCount = sni->childCount();
          for ( int64_t i = 0; i < childCount; ++i )
          {
@@ -354,7 +354,7 @@ bool NodeImpl::findTerminalPosition( const NodeImplSharedPtr &target, uint64_t &
       {
          auto vni = static_cast<VectorNodeImpl *>( this );
 
-         /// Recursively visit child nodes
+         // Recursively visit child nodes
          int64_t childCount = vni->childCount();
          for ( int64_t i = 0; i < childCount; ++i )
          {
@@ -384,7 +384,7 @@ bool NodeImpl::findTerminalPosition( const NodeImplSharedPtr &target, uint64_t &
 #ifdef E57_DEBUG
 void NodeImpl::dump( int indent, std::ostream &os ) const
 {
-   /// don't checkImageFileOpen
+   // don't checkImageFileOpen
    os << space( indent ) << "elementName: " << elementName_ << std::endl;
    os << space( indent ) << "isAttached:  " << isAttached_ << std::endl;
    os << space( indent ) << "path:        " << pathName() << std::endl;
@@ -394,7 +394,7 @@ bool NodeImpl::_verifyPathNameAbsolute( const ustring &inPathName )
 {
    checkImageFileOpen( __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) );
 
-   /// Parse to determine if pathName is absolute
+   // Parse to determine if pathName is absolute
    bool isRelative = false;
    std::vector<ustring> fields;
    ImageFileImplSharedPtr imf( destImageFile_ );
@@ -402,10 +402,11 @@ bool NodeImpl::_verifyPathNameAbsolute( const ustring &inPathName )
    imf->pathNameParse( inPathName, isRelative,
                        fields ); // throws if bad pathName
 
-   /// If not an absolute path name, have error
+   // If not an absolute path name, have error
    if ( isRelative )
    {
-      throw E57_EXCEPTION2( ErrorBadPathName, "this->pathName=" + this->pathName() + " pathName=" + inPathName );
+      throw E57_EXCEPTION2( ErrorBadPathName,
+                            "this->pathName=" + this->pathName() + " pathName=" + inPathName );
    }
 
    return isRelative;
@@ -414,18 +415,18 @@ bool NodeImpl::_verifyPathNameAbsolute( const ustring &inPathName )
 
 NodeImplSharedPtr NodeImpl::_verifyAndGetRoot()
 {
-   /// Find root of the tree
+   // Find root of the tree
    NodeImplSharedPtr root( shared_from_this()->getRoot() );
 
-   /// Check to make sure root node is non-terminal type (otherwise have stack
-   /// overflow).
+   // Check to make sure root node is non-terminal type (otherwise have stack overflow).
    switch ( root->type() )
    {
       case TypeStructure:
       case TypeVector: //??? COMPRESSED_VECTOR?
          break;
       default:
-         throw E57_EXCEPTION2( ErrorInternal, "root invalid for this->pathName=" + this->pathName() );
+         throw E57_EXCEPTION2( ErrorInternal,
+                               "root invalid for this->pathName=" + this->pathName() );
    }
 
    return root;

--- a/src/NodeImpl.h
+++ b/src/NodeImpl.h
@@ -31,19 +31,21 @@
 
 namespace e57
 {
-
    class CheckedFile;
 
    class NodeImpl : public std::enable_shared_from_this<NodeImpl>
    {
    public:
       virtual NodeType type() const = 0;
-      void checkImageFileOpen( const char *srcFileName, int srcLineNumber, const char *srcFunctionName ) const;
+      void checkImageFileOpen( const char *srcFileName, int srcLineNumber,
+                               const char *srcFunctionName ) const;
       virtual bool isTypeEquivalent( NodeImplSharedPtr ni ) = 0;
+
       bool isRoot() const;
       NodeImplSharedPtr parent();
       ustring pathName() const;
-      ustring relativePathName( const NodeImplSharedPtr &origin, ustring childPathName = ustring() ) const;
+      ustring relativePathName( const NodeImplSharedPtr &origin,
+                                ustring childPathName = ustring() ) const;
       ustring elementName() const;
       ImageFileImplSharedPtr destImageFile();
 
@@ -56,8 +58,10 @@ namespace e57
       bool isTypeConstrained();
 
       virtual NodeImplSharedPtr get( const ustring &pathName );
-      virtual void set( const ustring &pathName, NodeImplSharedPtr ni, bool autoPathCreate = false );
-      virtual void set( const StringList &fields, unsigned level, NodeImplSharedPtr ni, bool autoPathCreate = false );
+      virtual void set( const ustring &pathName, NodeImplSharedPtr ni,
+                        bool autoPathCreate = false );
+      virtual void set( const StringList &fields, unsigned level, NodeImplSharedPtr ni,
+                        bool autoPathCreate = false );
 
       virtual void checkLeavesInSet( const StringSet &pathNames, NodeImplSharedPtr origin ) = 0;
       void checkBuffers( const std::vector<SourceDestBuffer> &sdbufs, bool allowMissing );

--- a/src/Packet.h
+++ b/src/Packet.h
@@ -37,7 +37,7 @@ namespace e57
    class CheckedFile;
    class PacketLock;
 
-   /// Packet types (in a compressed vector section)
+   // Packet types (in a compressed vector section)
    enum
    {
       INDEX_PACKET = 0,
@@ -45,7 +45,7 @@ namespace e57
       EMPTY_PACKET,
    };
 
-   /// maximum size of CompressedVector binary data packet
+   // Maximum size of CompressedVector binary data packet
    constexpr int DATA_PACKET_MAX = ( 64 * 1024 );
 
    class PacketReadCache
@@ -61,8 +61,9 @@ namespace e57
 #endif
 
    protected:
-      /// Only PacketLock can unlock the cache
       friend class PacketLock;
+
+      // Only PacketLock can unlock the cache
       void unlock( unsigned cacheIndex );
 
       void readPacket( unsigned oldestEntry, uint64_t packetLogicalOffset );
@@ -70,7 +71,7 @@ namespace e57
       struct CacheEntry
       {
          uint64_t logicalOffset_ = 0;
-         char buffer_[DATA_PACKET_MAX]; //! No need to init since it's a data buffer
+         char buffer_[DATA_PACKET_MAX]; // No need to init since it's a data buffer
          unsigned lastUsed_ = 0;
       };
 
@@ -86,13 +87,12 @@ namespace e57
    public:
       ~PacketLock();
 
-   private:
-      /// Can't be copied or assigned
-      PacketLock( const PacketLock &plock );
-      PacketLock &operator=( const PacketLock &plock );
+      PacketLock( const PacketLock &plock ) = delete;
+      PacketLock &operator=( const PacketLock &plock ) = delete;
 
    protected:
       friend class PacketReadCache;
+
       /// Only PacketReadCache can construct
       PacketLock( PacketReadCache *cache, unsigned cacheIndex );
 
@@ -112,6 +112,7 @@ namespace e57
 #ifdef E57_DEBUG
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
 #endif
+
       const uint8_t packetType = DATA_PACKET;
 
       uint8_t packetFlags = 0;
@@ -136,6 +137,6 @@ namespace e57
 
       DataPacketHeader header;
 
-      uint8_t payload[PayloadSize]; //! No need to init since it's a data buffer
+      uint8_t payload[PayloadSize]; // No need to init since it's a data buffer
    };
 }

--- a/src/ReaderImpl.cpp
+++ b/src/ReaderImpl.cpp
@@ -32,15 +32,19 @@
 
 namespace e57
 {
-   //! @brief Reads the data out of a given image node
-   //! @param [in] image 1 of 3 projects or the visual
-   //! @param [in] imageType identifies the image format desired.
-   //! @param [out] pBuffer pointer the buffer
-   //! @param [out] start position in the block to start reading
-   //! @param [out] count size of desired chunk or buffer size
-   //! @return number of bytes read
-   size_t _readImage2DNode( const StructureNode &image, Image2DType imageType, uint8_t *pBuffer, int64_t start,
-                            size_t count )
+   /*!
+   @brief Reads the data out of a given image node
+
+   @param [in] image 1 of 3 projects or the visual
+   @param [in] imageType identifies the image format desired.
+   @param [out] pBuffer pointer the buffer
+   @param [out] start position in the block to start reading
+   @param [out] count size of desired chunk or buffer size
+
+   @return number of bytes read
+   */
+   size_t _readImage2DNode( const StructureNode &image, Image2DType imageType, uint8_t *pBuffer,
+                            int64_t start, size_t count )
    {
       size_t transferred = 0;
 
@@ -80,16 +84,21 @@ namespace e57
       return transferred;
    }
 
-   //! @brief This function reads one of the image blobs
-   //! @param [in] image 1 of 3 projects or the visual
-   //! @param [out] imageType identifies the image format desired.
-   //! @param [out] imageWidth The image width (in pixels).
-   //! @param [out] imageHeight The image height (in pixels).
-   //! @param [out] imageSize This is the total number of bytes for the image blob.
-   //! @param [out] imageMaskType This is E57_PNG_IMAGE_MASK if "imageMask" is defined in the projection
-   //! @return Returns true if successful
-   static bool _getImage2DNodeSizes( const StructureNode &image, Image2DType &imageType, int64_t &imageWidth,
-                                     int64_t &imageHeight, int64_t &imageSize, Image2DType &imageMaskType )
+   /*!
+   @brief This function reads one of the image blobs
+
+   @param [in] image 1 of 3 projects or the visual
+   @param [out] imageType identifies the image format desired.
+   @param [out] imageWidth The image width (in pixels).
+   @param [out] imageHeight The image height (in pixels).
+   @param [out] imageSize This is the total number of bytes for the image blob.
+   @param [out] imageMaskType This is E57_PNG_IMAGE_MASK if "imageMask" is defined in the projection
+
+   @return Returns true if successful
+   */
+   static bool _getImage2DNodeSizes( const StructureNode &image, Image2DType &imageType,
+                                     int64_t &imageWidth, int64_t &imageHeight, int64_t &imageSize,
+                                     Image2DType &imageMaskType )
    {
       imageWidth = 0;
       imageHeight = 0;
@@ -140,9 +149,13 @@ namespace e57
       return true;
    }
 
-   void _readColourRanges( const std::string &protoName, const StructureNode &proto, double &colourMin,
-                           double &colourMax )
+   /// Possibly get min/max from the colour node itself instead of the colorLimits.
+   void _readColourRanges( const std::string &protoName, const StructureNode &proto,
+                           double &colourMin, double &colourMax )
    {
+      // IF the colorLimits are not set
+      // AND our colour node is
+      // THEN get our min/max from the colour node itself.
       if ( ( colourMax == 0.0 ) && proto.isDefined( protoName ) )
       {
          const auto colourProto = proto.get( protoName );
@@ -176,7 +189,8 @@ namespace e57
    }
 
    ReaderImpl::ReaderImpl( const ustring &filePath, const ReaderOptions &options ) :
-      imf_( filePath, "r", options.checksumPolicy ), root_( imf_.root() ), data3D_( root_.get( "/data3D" ) ),
+      imf_( filePath, "r", options.checksumPolicy ), root_( imf_.root() ),
+      data3D_( root_.get( "/data3D" ) ),
       images2D_( root_.isDefined( "/images2D" ) ? root_.get( "/images2D" ) : VectorNode( imf_ ) )
    {
    }
@@ -216,8 +230,10 @@ namespace e57
       fileHeader = {};
 
       fileHeader.formatName = StringNode( root_.get( "formatName" ) ).value();
-      fileHeader.versionMajor = static_cast<uint32_t>( IntegerNode( root_.get( "versionMajor" ) ).value() );
-      fileHeader.versionMinor = static_cast<uint32_t>( IntegerNode( root_.get( "versionMinor" ) ).value() );
+      fileHeader.versionMajor =
+         static_cast<uint32_t>( IntegerNode( root_.get( "versionMajor" ) ).value() );
+      fileHeader.versionMinor =
+         static_cast<uint32_t>( IntegerNode( root_.get( "versionMinor" ) ).value() );
       fileHeader.guid = StringNode( root_.get( "guid" ) ).value();
       if ( root_.isDefined( "e57LibraryVersion" ) )
       {
@@ -233,12 +249,13 @@ namespace e57
       {
          const StructureNode creationDateTime( root_.get( "creationDateTime" ) );
 
-         fileHeader.creationDateTime.dateTimeValue = FloatNode( creationDateTime.get( "dateTimeValue" ) ).value();
+         fileHeader.creationDateTime.dateTimeValue =
+            FloatNode( creationDateTime.get( "dateTimeValue" ) ).value();
 
          if ( creationDateTime.isDefined( "isAtomicClockReferenced" ) )
          {
-            fileHeader.creationDateTime.isAtomicClockReferenced =
-               static_cast<int32_t>( IntegerNode( creationDateTime.get( "isAtomicClockReferenced" ) ).value() );
+            fileHeader.creationDateTime.isAtomicClockReferenced = static_cast<int32_t>(
+               IntegerNode( creationDateTime.get( "isAtomicClockReferenced" ) ).value() );
          }
       }
 
@@ -296,7 +313,8 @@ namespace e57
 
       if ( image.isDefined( "associatedData3DGuid" ) )
       {
-         image2DHeader.associatedData3DGuid = StringNode( image.get( "associatedData3DGuid" ) ).value();
+         image2DHeader.associatedData3DGuid =
+            StringNode( image.get( "associatedData3DGuid" ) ).value();
       }
 
       if ( image.isDefined( "acquisitionDateTime" ) )
@@ -308,8 +326,8 @@ namespace e57
 
          if ( acquisitionDateTime.isDefined( "isAtomicClockReferenced" ) )
          {
-            image2DHeader.acquisitionDateTime.isAtomicClockReferenced =
-               static_cast<int32_t>( IntegerNode( acquisitionDateTime.get( "isAtomicClockReferenced" ) ).value() );
+            image2DHeader.acquisitionDateTime.isAtomicClockReferenced = static_cast<int32_t>(
+               IntegerNode( acquisitionDateTime.get( "isAtomicClockReferenced" ) ).value() );
          }
       }
 
@@ -339,7 +357,8 @@ namespace e57
 
       if ( image.isDefined( "visualReferenceRepresentation" ) )
       {
-         const StructureNode visualReferenceRepresentation( image.get( "visualReferenceRepresentation" ) );
+         const StructureNode visualReferenceRepresentation(
+            image.get( "visualReferenceRepresentation" ) );
 
          if ( visualReferenceRepresentation.isDefined( "jpegImage" ) )
          {
@@ -357,10 +376,10 @@ namespace e57
                BlobNode( visualReferenceRepresentation.get( "imageMask" ) ).byteCount();
          }
 
-         image2DHeader.visualReferenceRepresentation.imageHeight =
-            static_cast<int32_t>( IntegerNode( visualReferenceRepresentation.get( "imageHeight" ) ).value() );
-         image2DHeader.visualReferenceRepresentation.imageWidth =
-            static_cast<int32_t>( IntegerNode( visualReferenceRepresentation.get( "imageWidth" ) ).value() );
+         image2DHeader.visualReferenceRepresentation.imageHeight = static_cast<int32_t>(
+            IntegerNode( visualReferenceRepresentation.get( "imageHeight" ) ).value() );
+         image2DHeader.visualReferenceRepresentation.imageWidth = static_cast<int32_t>(
+            IntegerNode( visualReferenceRepresentation.get( "imageWidth" ) ).value() );
       }
 
       if ( image.isDefined( "pinholeRepresentation" ) )
@@ -385,10 +404,10 @@ namespace e57
 
          image2DHeader.pinholeRepresentation.focalLength =
             FloatNode( pinholeRepresentation.get( "focalLength" ) ).value();
-         image2DHeader.pinholeRepresentation.imageHeight =
-            static_cast<int32_t>( IntegerNode( pinholeRepresentation.get( "imageHeight" ) ).value() );
-         image2DHeader.pinholeRepresentation.imageWidth =
-            static_cast<int32_t>( IntegerNode( pinholeRepresentation.get( "imageWidth" ) ).value() );
+         image2DHeader.pinholeRepresentation.imageHeight = static_cast<int32_t>(
+            IntegerNode( pinholeRepresentation.get( "imageHeight" ) ).value() );
+         image2DHeader.pinholeRepresentation.imageWidth = static_cast<int32_t>(
+            IntegerNode( pinholeRepresentation.get( "imageWidth" ) ).value() );
 
          image2DHeader.pinholeRepresentation.pixelHeight =
             FloatNode( pinholeRepresentation.get( "pixelHeight" ) ).value();
@@ -419,10 +438,10 @@ namespace e57
                BlobNode( sphericalRepresentation.get( "imageMask" ) ).byteCount();
          }
 
-         image2DHeader.sphericalRepresentation.imageHeight =
-            static_cast<int32_t>( IntegerNode( sphericalRepresentation.get( "imageHeight" ) ).value() );
-         image2DHeader.sphericalRepresentation.imageWidth =
-            static_cast<int32_t>( IntegerNode( sphericalRepresentation.get( "imageWidth" ) ).value() );
+         image2DHeader.sphericalRepresentation.imageHeight = static_cast<int32_t>(
+            IntegerNode( sphericalRepresentation.get( "imageHeight" ) ).value() );
+         image2DHeader.sphericalRepresentation.imageWidth = static_cast<int32_t>(
+            IntegerNode( sphericalRepresentation.get( "imageWidth" ) ).value() );
 
          image2DHeader.sphericalRepresentation.pixelHeight =
             FloatNode( sphericalRepresentation.get( "pixelHeight" ) ).value();
@@ -449,10 +468,10 @@ namespace e57
                BlobNode( cylindricalRepresentation.get( "imageMask" ) ).byteCount();
          }
 
-         image2DHeader.cylindricalRepresentation.imageHeight =
-            static_cast<int32_t>( IntegerNode( cylindricalRepresentation.get( "imageHeight" ) ).value() );
-         image2DHeader.cylindricalRepresentation.imageWidth =
-            static_cast<int32_t>( IntegerNode( cylindricalRepresentation.get( "imageWidth" ) ).value() );
+         image2DHeader.cylindricalRepresentation.imageHeight = static_cast<int32_t>(
+            IntegerNode( cylindricalRepresentation.get( "imageHeight" ) ).value() );
+         image2DHeader.cylindricalRepresentation.imageWidth = static_cast<int32_t>(
+            IntegerNode( cylindricalRepresentation.get( "imageWidth" ) ).value() );
 
          image2DHeader.cylindricalRepresentation.pixelHeight =
             FloatNode( cylindricalRepresentation.get( "pixelHeight" ) ).value();
@@ -468,9 +487,11 @@ namespace e57
    }
 
    // Returns the image sizes
-   bool ReaderImpl::GetImage2DSizes( int64_t imageIndex, Image2DProjection &imageProjection, Image2DType &imageType,
-                                     int64_t &imageWidth, int64_t &imageHeight, int64_t &imageSize,
-                                     Image2DType &imageMaskType, Image2DType &imageVisualType ) const
+   bool ReaderImpl::GetImage2DSizes( int64_t imageIndex, Image2DProjection &imageProjection,
+                                     Image2DType &imageType, int64_t &imageWidth,
+                                     int64_t &imageHeight, int64_t &imageSize,
+                                     Image2DType &imageMaskType,
+                                     Image2DType &imageVisualType ) const
    {
       if ( ( imageIndex < 0 ) || ( imageIndex >= images2D_.childCount() ) )
       {
@@ -486,10 +507,11 @@ namespace e57
 
       if ( image.isDefined( "visualReferenceRepresentation" ) )
       {
-         const StructureNode visualReferenceRepresentation( image.get( "visualReferenceRepresentation" ) );
+         const StructureNode visualReferenceRepresentation(
+            image.get( "visualReferenceRepresentation" ) );
 
-         bool ret = _getImage2DNodeSizes( visualReferenceRepresentation, imageType, imageWidth, imageHeight, imageSize,
-                                          imageMaskType );
+         bool ret = _getImage2DNodeSizes( visualReferenceRepresentation, imageType, imageWidth,
+                                          imageHeight, imageSize, imageMaskType );
          imageProjection = ProjectionVisual;
          imageVisualType = imageType;
 
@@ -502,8 +524,8 @@ namespace e57
 
          imageProjection = ProjectionPinhole;
 
-         return _getImage2DNodeSizes( pinholeRepresentation, imageType, imageWidth, imageHeight, imageSize,
-                                      imageMaskType );
+         return _getImage2DNodeSizes( pinholeRepresentation, imageType, imageWidth, imageHeight,
+                                      imageSize, imageMaskType );
       }
 
       if ( image.isDefined( "sphericalRepresentation" ) )
@@ -512,8 +534,8 @@ namespace e57
 
          imageProjection = ProjectionSpherical;
 
-         return _getImage2DNodeSizes( sphericalRepresentation, imageType, imageWidth, imageHeight, imageSize,
-                                      imageMaskType );
+         return _getImage2DNodeSizes( sphericalRepresentation, imageType, imageWidth, imageHeight,
+                                      imageSize, imageMaskType );
       }
 
       if ( image.isDefined( "cylindricalRepresentation" ) )
@@ -522,16 +544,17 @@ namespace e57
 
          imageProjection = ProjectionCylindrical;
 
-         return _getImage2DNodeSizes( cylindricalRepresentation, imageType, imageWidth, imageHeight, imageSize,
-                                      imageMaskType );
+         return _getImage2DNodeSizes( cylindricalRepresentation, imageType, imageWidth, imageHeight,
+                                      imageSize, imageMaskType );
       }
 
       return false;
    }
 
    // Reads the image data block
-   size_t ReaderImpl::ReadImage2DData( int64_t imageIndex, Image2DProjection imageProjection, Image2DType imageType,
-                                       uint8_t *pBuffer, int64_t start, size_t count ) const
+   size_t ReaderImpl::ReadImage2DData( int64_t imageIndex, Image2DProjection imageProjection,
+                                       Image2DType imageType, uint8_t *pBuffer, int64_t start,
+                                       size_t count ) const
    {
       if ( ( imageIndex < 0 ) || ( imageIndex >= images2D_.childCount() ) )
       {
@@ -548,9 +571,11 @@ namespace e57
          case ProjectionVisual:
             if ( image.isDefined( "visualReferenceRepresentation" ) )
             {
-               const StructureNode visualReferenceRepresentation( image.get( "visualReferenceRepresentation" ) );
+               const StructureNode visualReferenceRepresentation(
+                  image.get( "visualReferenceRepresentation" ) );
 
-               return _readImage2DNode( visualReferenceRepresentation, imageType, pBuffer, start, count );
+               return _readImage2DNode( visualReferenceRepresentation, imageType, pBuffer, start,
+                                        count );
             }
             break;
 
@@ -566,7 +591,8 @@ namespace e57
          case ProjectionSpherical:
             if ( image.isDefined( "sphericalRepresentation" ) )
             {
-               const StructureNode sphericalRepresentation( image.get( "sphericalRepresentation" ) );
+               const StructureNode sphericalRepresentation(
+                  image.get( "sphericalRepresentation" ) );
 
                return _readImage2DNode( sphericalRepresentation, imageType, pBuffer, start, count );
             }
@@ -575,9 +601,11 @@ namespace e57
          case ProjectionCylindrical:
             if ( image.isDefined( "cylindricalRepresentation" ) )
             {
-               const StructureNode cylindricalRepresentation( image.get( "cylindricalRepresentation" ) );
+               const StructureNode cylindricalRepresentation(
+                  image.get( "cylindricalRepresentation" ) );
 
-               return _readImage2DNode( cylindricalRepresentation, imageType, pBuffer, start, count );
+               return _readImage2DNode( cylindricalRepresentation, imageType, pBuffer, start,
+                                        count );
             }
             break;
       }
@@ -642,25 +670,30 @@ namespace e57
       }
       if ( scan.isDefined( "sensorHardwareVersion" ) )
       {
-         data3DHeader.sensorHardwareVersion = StringNode( scan.get( "sensorHardwareVersion" ) ).value();
+         data3DHeader.sensorHardwareVersion =
+            StringNode( scan.get( "sensorHardwareVersion" ) ).value();
       }
       if ( scan.isDefined( "sensorSoftwareVersion" ) )
       {
-         data3DHeader.sensorSoftwareVersion = StringNode( scan.get( "sensorSoftwareVersion" ) ).value();
+         data3DHeader.sensorSoftwareVersion =
+            StringNode( scan.get( "sensorSoftwareVersion" ) ).value();
       }
       if ( scan.isDefined( "sensorFirmwareVersion" ) )
       {
-         data3DHeader.sensorFirmwareVersion = StringNode( scan.get( "sensorFirmwareVersion" ) ).value();
+         data3DHeader.sensorFirmwareVersion =
+            StringNode( scan.get( "sensorFirmwareVersion" ) ).value();
       }
 
       // Get temp/humidity from scan.
       if ( scan.isDefined( "temperature" ) )
       {
-         data3DHeader.temperature = static_cast<float>( FloatNode( scan.get( "temperature" ) ).value() );
+         data3DHeader.temperature =
+            static_cast<float>( FloatNode( scan.get( "temperature" ) ).value() );
       }
       if ( scan.isDefined( "relativeHumidity" ) )
       {
-         data3DHeader.relativeHumidity = static_cast<float>( FloatNode( scan.get( "relativeHumidity" ) ).value() );
+         data3DHeader.relativeHumidity =
+            static_cast<float>( FloatNode( scan.get( "relativeHumidity" ) ).value() );
       }
       if ( scan.isDefined( "atmosphericPressure" ) )
       {
@@ -679,13 +712,17 @@ namespace e57
          }
          if ( ibox.isDefined( "columnMaximum" ) )
          {
-            data3DHeader.indexBounds.columnMinimum = IntegerNode( ibox.get( "columnMinimum" ) ).value();
-            data3DHeader.indexBounds.columnMaximum = IntegerNode( ibox.get( "columnMaximum" ) ).value();
+            data3DHeader.indexBounds.columnMinimum =
+               IntegerNode( ibox.get( "columnMinimum" ) ).value();
+            data3DHeader.indexBounds.columnMaximum =
+               IntegerNode( ibox.get( "columnMaximum" ) ).value();
          }
          if ( ibox.isDefined( "returnMaximum" ) )
          {
-            data3DHeader.indexBounds.returnMinimum = IntegerNode( ibox.get( "returnMinimum" ) ).value();
-            data3DHeader.indexBounds.returnMaximum = IntegerNode( ibox.get( "returnMaximum" ) ).value();
+            data3DHeader.indexBounds.returnMinimum =
+               IntegerNode( ibox.get( "returnMinimum" ) ).value();
+            data3DHeader.indexBounds.returnMaximum =
+               IntegerNode( ibox.get( "returnMaximum" ) ).value();
          }
       }
 
@@ -720,12 +757,18 @@ namespace e57
 
          if ( bbox.get( "xMinimum" ).type() == TypeScaledInteger )
          {
-            data3DHeader.cartesianBounds.xMinimum = ScaledIntegerNode( bbox.get( "xMinimum" ) ).scaledValue();
-            data3DHeader.cartesianBounds.xMaximum = ScaledIntegerNode( bbox.get( "xMaximum" ) ).scaledValue();
-            data3DHeader.cartesianBounds.yMinimum = ScaledIntegerNode( bbox.get( "yMinimum" ) ).scaledValue();
-            data3DHeader.cartesianBounds.yMaximum = ScaledIntegerNode( bbox.get( "yMaximum" ) ).scaledValue();
-            data3DHeader.cartesianBounds.zMinimum = ScaledIntegerNode( bbox.get( "zMinimum" ) ).scaledValue();
-            data3DHeader.cartesianBounds.zMaximum = ScaledIntegerNode( bbox.get( "zMaximum" ) ).scaledValue();
+            data3DHeader.cartesianBounds.xMinimum =
+               ScaledIntegerNode( bbox.get( "xMinimum" ) ).scaledValue();
+            data3DHeader.cartesianBounds.xMaximum =
+               ScaledIntegerNode( bbox.get( "xMaximum" ) ).scaledValue();
+            data3DHeader.cartesianBounds.yMinimum =
+               ScaledIntegerNode( bbox.get( "yMinimum" ) ).scaledValue();
+            data3DHeader.cartesianBounds.yMaximum =
+               ScaledIntegerNode( bbox.get( "yMaximum" ) ).scaledValue();
+            data3DHeader.cartesianBounds.zMinimum =
+               ScaledIntegerNode( bbox.get( "zMinimum" ) ).scaledValue();
+            data3DHeader.cartesianBounds.zMaximum =
+               ScaledIntegerNode( bbox.get( "zMaximum" ) ).scaledValue();
          }
          else if ( bbox.get( "xMinimum" ).type() == TypeFloat )
          {
@@ -744,13 +787,17 @@ namespace e57
 
          if ( sbox.get( "rangeMinimum" ).type() == TypeScaledInteger )
          {
-            data3DHeader.sphericalBounds.rangeMinimum = ScaledIntegerNode( sbox.get( "rangeMinimum" ) ).scaledValue();
-            data3DHeader.sphericalBounds.rangeMaximum = ScaledIntegerNode( sbox.get( "rangeMaximum" ) ).scaledValue();
+            data3DHeader.sphericalBounds.rangeMinimum =
+               ScaledIntegerNode( sbox.get( "rangeMinimum" ) ).scaledValue();
+            data3DHeader.sphericalBounds.rangeMaximum =
+               ScaledIntegerNode( sbox.get( "rangeMaximum" ) ).scaledValue();
          }
          else if ( sbox.get( "rangeMinimum" ).type() == TypeFloat )
          {
-            data3DHeader.sphericalBounds.rangeMinimum = FloatNode( sbox.get( "rangeMinimum" ) ).value();
-            data3DHeader.sphericalBounds.rangeMaximum = FloatNode( sbox.get( "rangeMaximum" ) ).value();
+            data3DHeader.sphericalBounds.rangeMinimum =
+               FloatNode( sbox.get( "rangeMinimum" ) ).value();
+            data3DHeader.sphericalBounds.rangeMaximum =
+               FloatNode( sbox.get( "rangeMaximum" ) ).value();
          }
 
          if ( sbox.get( "elevationMinimum" ).type() == TypeScaledInteger )
@@ -762,18 +809,23 @@ namespace e57
          }
          else if ( sbox.get( "elevationMinimum" ).type() == TypeFloat )
          {
-            data3DHeader.sphericalBounds.elevationMinimum = FloatNode( sbox.get( "elevationMinimum" ) ).value();
-            data3DHeader.sphericalBounds.elevationMaximum = FloatNode( sbox.get( "elevationMaximum" ) ).value();
+            data3DHeader.sphericalBounds.elevationMinimum =
+               FloatNode( sbox.get( "elevationMinimum" ) ).value();
+            data3DHeader.sphericalBounds.elevationMaximum =
+               FloatNode( sbox.get( "elevationMaximum" ) ).value();
          }
 
          if ( sbox.get( "azimuthStart" ).type() == TypeScaledInteger )
          {
-            data3DHeader.sphericalBounds.azimuthStart = ScaledIntegerNode( sbox.get( "azimuthStart" ) ).scaledValue();
-            data3DHeader.sphericalBounds.azimuthEnd = ScaledIntegerNode( sbox.get( "azimuthEnd" ) ).scaledValue();
+            data3DHeader.sphericalBounds.azimuthStart =
+               ScaledIntegerNode( sbox.get( "azimuthStart" ) ).scaledValue();
+            data3DHeader.sphericalBounds.azimuthEnd =
+               ScaledIntegerNode( sbox.get( "azimuthEnd" ) ).scaledValue();
          }
          else if ( sbox.get( "azimuthStart" ).type() == TypeFloat )
          {
-            data3DHeader.sphericalBounds.azimuthStart = FloatNode( sbox.get( "azimuthStart" ) ).value();
+            data3DHeader.sphericalBounds.azimuthStart =
+               FloatNode( sbox.get( "azimuthStart" ) ).value();
             data3DHeader.sphericalBounds.azimuthEnd = FloatNode( sbox.get( "azimuthEnd" ) ).value();
          }
       }
@@ -808,12 +860,13 @@ namespace e57
       {
          const StructureNode acquisitionStart( scan.get( "acquisitionStart" ) );
 
-         data3DHeader.acquisitionStart.dateTimeValue = FloatNode( acquisitionStart.get( "dateTimeValue" ) ).value();
+         data3DHeader.acquisitionStart.dateTimeValue =
+            FloatNode( acquisitionStart.get( "dateTimeValue" ) ).value();
 
          if ( acquisitionStart.isDefined( "isAtomicClockReferenced" ) )
          {
-            data3DHeader.acquisitionStart.isAtomicClockReferenced =
-               static_cast<int32_t>( IntegerNode( acquisitionStart.get( "isAtomicClockReferenced" ) ).value() );
+            data3DHeader.acquisitionStart.isAtomicClockReferenced = static_cast<int32_t>(
+               IntegerNode( acquisitionStart.get( "isAtomicClockReferenced" ) ).value() );
          }
       }
 
@@ -821,12 +874,13 @@ namespace e57
       {
          const StructureNode acquisitionEnd( scan.get( "acquisitionEnd" ) );
 
-         data3DHeader.acquisitionEnd.dateTimeValue = FloatNode( acquisitionEnd.get( "dateTimeValue" ) ).value();
+         data3DHeader.acquisitionEnd.dateTimeValue =
+            FloatNode( acquisitionEnd.get( "dateTimeValue" ) ).value();
 
          if ( acquisitionEnd.isDefined( "isAtomicClockReferenced" ) )
          {
-            data3DHeader.acquisitionEnd.isAtomicClockReferenced =
-               static_cast<int32_t>( IntegerNode( acquisitionEnd.get( "isAtomicClockReferenced" ) ).value() );
+            data3DHeader.acquisitionEnd.isAtomicClockReferenced = static_cast<int32_t>(
+               IntegerNode( acquisitionEnd.get( "isAtomicClockReferenced" ) ).value() );
          }
       }
 
@@ -834,7 +888,8 @@ namespace e57
       data3DHeader.pointFields.cartesianXField = proto.isDefined( "cartesianX" );
       data3DHeader.pointFields.cartesianYField = proto.isDefined( "cartesianY" );
       data3DHeader.pointFields.cartesianZField = proto.isDefined( "cartesianZ" );
-      data3DHeader.pointFields.cartesianInvalidStateField = proto.isDefined( "cartesianInvalidState" );
+      data3DHeader.pointFields.cartesianInvalidStateField =
+         proto.isDefined( "cartesianInvalidState" );
 
       data3DHeader.pointFields.pointRangeMinimum = 0.0;
       data3DHeader.pointFields.pointRangeMaximum = 0.0;
@@ -847,7 +902,8 @@ namespace e57
          {
             case TypeInteger:
             {
-               // Should be a warning that we don't handle this type, but we don't have a mechanism for warnings.
+               // Should be a warning that we don't handle this type, but we don't have a mechanism
+               // for warnings.
                break;
             }
 
@@ -859,8 +915,10 @@ namespace e57
                const int64_t minimum = scaledCartesianX.minimum();
                const int64_t maximum = scaledCartesianX.maximum();
 
-               data3DHeader.pointFields.pointRangeMinimum = static_cast<double>( minimum ) * scale + offset;
-               data3DHeader.pointFields.pointRangeMaximum = static_cast<double>( maximum ) * scale + offset;
+               data3DHeader.pointFields.pointRangeMinimum =
+                  static_cast<double>( minimum ) * scale + offset;
+               data3DHeader.pointFields.pointRangeMaximum =
+                  static_cast<double>( maximum ) * scale + offset;
 
                data3DHeader.pointFields.pointRangeNodeType = NumericalNodeType::ScaledInteger;
                data3DHeader.pointFields.pointRangeScale = scale;
@@ -888,8 +946,9 @@ namespace e57
             }
 
             default:
-               throw E57_EXCEPTION2( ErrorInvalidNodeType, "invalid node type reading cartesianX field: " +
-                                                              toString( cartesianXProto.type() ) );
+               throw E57_EXCEPTION2( ErrorInvalidNodeType,
+                                     "invalid node type reading cartesianX field: " +
+                                        toString( cartesianXProto.type() ) );
                break;
          }
       }
@@ -901,7 +960,8 @@ namespace e57
          {
             case TypeInteger:
             {
-               // Should be a warning that we don't handle this type, but we don't have a mechanism for warnings.
+               // Should be a warning that we don't handle this type, but we don't have a mechanism
+               // for warnings.
                break;
             }
 
@@ -913,8 +973,10 @@ namespace e57
                const int64_t minimum = scaledSphericalRange.minimum();
                const int64_t maximum = scaledSphericalRange.maximum();
 
-               data3DHeader.pointFields.pointRangeMinimum = static_cast<double>( minimum ) * scale + offset;
-               data3DHeader.pointFields.pointRangeMaximum = static_cast<double>( maximum ) * scale + offset;
+               data3DHeader.pointFields.pointRangeMinimum =
+                  static_cast<double>( minimum ) * scale + offset;
+               data3DHeader.pointFields.pointRangeMaximum =
+                  static_cast<double>( maximum ) * scale + offset;
 
                data3DHeader.pointFields.pointRangeNodeType = NumericalNodeType::ScaledInteger;
                data3DHeader.pointFields.pointRangeScale = scale;
@@ -942,8 +1004,9 @@ namespace e57
             }
 
             default:
-               throw E57_EXCEPTION2( ErrorInvalidNodeType, "invalid node type reading sphericalRange field: " +
-                                                              toString( sphericalRangeProto.type() ) );
+               throw E57_EXCEPTION2( ErrorInvalidNodeType,
+                                     "invalid node type reading sphericalRange field: " +
+                                        toString( sphericalRangeProto.type() ) );
                break;
          }
       }
@@ -951,7 +1014,8 @@ namespace e57
       data3DHeader.pointFields.sphericalRangeField = proto.isDefined( "sphericalRange" );
       data3DHeader.pointFields.sphericalAzimuthField = proto.isDefined( "sphericalAzimuth" );
       data3DHeader.pointFields.sphericalElevationField = proto.isDefined( "sphericalElevation" );
-      data3DHeader.pointFields.sphericalInvalidStateField = proto.isDefined( "sphericalInvalidState" );
+      data3DHeader.pointFields.sphericalInvalidStateField =
+         proto.isDefined( "sphericalInvalidState" );
 
       data3DHeader.pointFields.angleMinimum = 0.0;
       data3DHeader.pointFields.angleMaximum = 0.0;
@@ -970,8 +1034,10 @@ namespace e57
                const int64_t minimum = scaledSphericalAzimuth.minimum();
                const int64_t maximum = scaledSphericalAzimuth.maximum();
 
-               data3DHeader.pointFields.angleMinimum = static_cast<double>( minimum ) * scale + offset;
-               data3DHeader.pointFields.angleMaximum = static_cast<double>( maximum ) * scale + offset;
+               data3DHeader.pointFields.angleMinimum =
+                  static_cast<double>( minimum ) * scale + offset;
+               data3DHeader.pointFields.angleMaximum =
+                  static_cast<double>( maximum ) * scale + offset;
 
                data3DHeader.pointFields.angleNodeType = NumericalNodeType::ScaledInteger;
                data3DHeader.pointFields.angleScale = scale;
@@ -999,8 +1065,9 @@ namespace e57
             }
 
             default:
-               throw E57_EXCEPTION2( ErrorInvalidNodeType, "invalid node type reading sphericalAzimuth field: " +
-                                                              toString( sphericalAzimuthProto.type() ) );
+               throw E57_EXCEPTION2( ErrorInvalidNodeType,
+                                     "invalid node type reading sphericalAzimuth field: " +
+                                        toString( sphericalAzimuthProto.type() ) );
                break;
          }
       }
@@ -1047,8 +1114,10 @@ namespace e57
             {
                const IntegerNode integerTimeStamp( timeStampProto );
 
-               data3DHeader.pointFields.timeMaximum = static_cast<double>( integerTimeStamp.maximum() );
-               data3DHeader.pointFields.timeMinimum = static_cast<double>( integerTimeStamp.minimum() );
+               data3DHeader.pointFields.timeMaximum =
+                  static_cast<double>( integerTimeStamp.maximum() );
+               data3DHeader.pointFields.timeMinimum =
+                  static_cast<double>( integerTimeStamp.minimum() );
 
                data3DHeader.pointFields.timeNodeType = NumericalNodeType::Integer;
 
@@ -1064,8 +1133,10 @@ namespace e57
                const int64_t minimum = scaledTimeStamp.minimum();
                const int64_t maximum = scaledTimeStamp.maximum();
 
-               data3DHeader.pointFields.timeMinimum = static_cast<double>( minimum ) * scale + offset;
-               data3DHeader.pointFields.timeMaximum = static_cast<double>( maximum ) * scale + offset;
+               data3DHeader.pointFields.timeMinimum =
+                  static_cast<double>( minimum ) * scale + offset;
+               data3DHeader.pointFields.timeMaximum =
+                  static_cast<double>( maximum ) * scale + offset;
 
                data3DHeader.pointFields.timeNodeType = NumericalNodeType::ScaledInteger;
                data3DHeader.pointFields.timeScale = scale;
@@ -1093,8 +1164,9 @@ namespace e57
             }
 
             default:
-               throw E57_EXCEPTION2( ErrorInvalidNodeType, "invalid node type reading timeStamp field: " +
-                                                              toString( timeStampProto.type() ) );
+               throw E57_EXCEPTION2( ErrorInvalidNodeType,
+                                     "invalid node type reading timeStamp field: " +
+                                        toString( timeStampProto.type() ) );
                break;
          }
       }
@@ -1112,13 +1184,17 @@ namespace e57
 
          if ( intensityMaximumProto.type() == TypeScaledInteger )
          {
-            data3DHeader.intensityLimits.intensityMaximum = ScaledIntegerNode( intensityMaximumProto ).scaledValue();
-            data3DHeader.intensityLimits.intensityMinimum = ScaledIntegerNode( intensityMinimumProto ).scaledValue();
+            data3DHeader.intensityLimits.intensityMaximum =
+               ScaledIntegerNode( intensityMaximumProto ).scaledValue();
+            data3DHeader.intensityLimits.intensityMinimum =
+               ScaledIntegerNode( intensityMinimumProto ).scaledValue();
          }
          else if ( intensityMaximumProto.type() == TypeFloat )
          {
-            data3DHeader.intensityLimits.intensityMaximum = FloatNode( intensityMaximumProto ).value();
-            data3DHeader.intensityLimits.intensityMinimum = FloatNode( intensityMinimumProto ).value();
+            data3DHeader.intensityLimits.intensityMaximum =
+               FloatNode( intensityMaximumProto ).value();
+            data3DHeader.intensityLimits.intensityMinimum =
+               FloatNode( intensityMinimumProto ).value();
          }
          else if ( intensityMaximumProto.type() == TypeInteger )
          {
@@ -1141,8 +1217,10 @@ namespace e57
 
                if ( data3DHeader.intensityLimits.intensityMaximum == 0.0 )
                {
-                  data3DHeader.intensityLimits.intensityMinimum = static_cast<double>( integerIntensity.minimum() );
-                  data3DHeader.intensityLimits.intensityMaximum = static_cast<double>( integerIntensity.maximum() );
+                  data3DHeader.intensityLimits.intensityMinimum =
+                     static_cast<double>( integerIntensity.minimum() );
+                  data3DHeader.intensityLimits.intensityMaximum =
+                     static_cast<double>( integerIntensity.maximum() );
                }
 
                data3DHeader.pointFields.intensityNodeType = NumericalNodeType::Integer;
@@ -1161,8 +1239,10 @@ namespace e57
                   const int64_t minimum = scaledIntensity.minimum();
                   const int64_t maximum = scaledIntensity.maximum();
 
-                  data3DHeader.intensityLimits.intensityMinimum = static_cast<double>( minimum ) * scale + offset;
-                  data3DHeader.intensityLimits.intensityMaximum = static_cast<double>( maximum ) * scale + offset;
+                  data3DHeader.intensityLimits.intensityMinimum =
+                     static_cast<double>( minimum ) * scale + offset;
+                  data3DHeader.intensityLimits.intensityMaximum =
+                     static_cast<double>( maximum ) * scale + offset;
                }
 
                data3DHeader.pointFields.intensityNodeType = NumericalNodeType::ScaledInteger;
@@ -1191,8 +1271,9 @@ namespace e57
             }
 
             default:
-               throw E57_EXCEPTION2( ErrorInvalidNodeType, "invalid node type reading intensity field: " +
-                                                              toString( intensityProto.type() ) );
+               throw E57_EXCEPTION2( ErrorInvalidNodeType,
+                                     "invalid node type reading intensity field: " +
+                                        toString( intensityProto.type() ) );
                break;
          }
       }
@@ -1230,12 +1311,18 @@ namespace e57
          }
          else if ( colorbox.get( "colorRedMaximum" ).type() == TypeFloat )
          {
-            data3DHeader.colorLimits.colorRedMaximum = FloatNode( colorbox.get( "colorRedMaximum" ) ).value();
-            data3DHeader.colorLimits.colorRedMinimum = FloatNode( colorbox.get( "colorRedMinimum" ) ).value();
-            data3DHeader.colorLimits.colorGreenMaximum = FloatNode( colorbox.get( "colorGreenMaximum" ) ).value();
-            data3DHeader.colorLimits.colorGreenMinimum = FloatNode( colorbox.get( "colorGreenMinimum" ) ).value();
-            data3DHeader.colorLimits.colorBlueMaximum = FloatNode( colorbox.get( "colorBlueMaximum" ) ).value();
-            data3DHeader.colorLimits.colorBlueMinimum = FloatNode( colorbox.get( "colorBlueMinimum" ) ).value();
+            data3DHeader.colorLimits.colorRedMaximum =
+               FloatNode( colorbox.get( "colorRedMaximum" ) ).value();
+            data3DHeader.colorLimits.colorRedMinimum =
+               FloatNode( colorbox.get( "colorRedMinimum" ) ).value();
+            data3DHeader.colorLimits.colorGreenMaximum =
+               FloatNode( colorbox.get( "colorGreenMaximum" ) ).value();
+            data3DHeader.colorLimits.colorGreenMinimum =
+               FloatNode( colorbox.get( "colorGreenMinimum" ) ).value();
+            data3DHeader.colorLimits.colorBlueMaximum =
+               FloatNode( colorbox.get( "colorBlueMaximum" ) ).value();
+            data3DHeader.colorLimits.colorBlueMinimum =
+               FloatNode( colorbox.get( "colorBlueMinimum" ) ).value();
          }
          else if ( colorbox.get( "colorRedMaximum" ).type() == TypeInteger )
          {
@@ -1274,8 +1361,9 @@ namespace e57
    }
 
    // This function returns the size of the point data
-   bool ReaderImpl::GetData3DSizes( int64_t dataIndex, int64_t &row, int64_t &column, int64_t &pointsSize,
-                                    int64_t &groupsSize, int64_t &countSize, bool &bColumnIndex ) const
+   bool ReaderImpl::GetData3DSizes( int64_t dataIndex, int64_t &row, int64_t &column,
+                                    int64_t &pointsSize, int64_t &groupsSize, int64_t &countSize,
+                                    bool &bColumnIndex ) const
    {
       int64_t elementSize = 0;
 
@@ -1390,8 +1478,9 @@ namespace e57
    }
 
    // Reads the group data
-   bool ReaderImpl::ReadData3DGroupsData( int64_t dataIndex, int64_t groupCount, int64_t *idElementValue,
-                                          int64_t *startPointIndex, int64_t *pointCount ) const
+   bool ReaderImpl::ReadData3DGroupsData( int64_t dataIndex, int64_t groupCount,
+                                          int64_t *idElementValue, int64_t *startPointIndex,
+                                          int64_t *pointCount ) const
    {
       if ( ( dataIndex < 0 ) || ( dataIndex >= data3D_.childCount() ) )
       {
@@ -1432,10 +1521,12 @@ namespace e57
          if ( ( name == "startPointIndex" ) && lineGroupRecord.isDefined( "startPointIndex" ) &&
               ( startPointIndex != nullptr ) )
          {
-            groupSDBuffers.emplace_back( imf_, "startPointIndex", startPointIndex, groupCount, true );
+            groupSDBuffers.emplace_back( imf_, "startPointIndex", startPointIndex, groupCount,
+                                         true );
          }
 
-         if ( ( name == "pointCount" ) && lineGroupRecord.isDefined( "pointCount" ) && ( pointCount != nullptr ) )
+         if ( ( name == "pointCount" ) && lineGroupRecord.isDefined( "pointCount" ) &&
+              ( pointCount != nullptr ) )
          {
             groupSDBuffers.emplace_back( imf_, "pointCount", pointCount, groupCount, true );
          }
@@ -1450,8 +1541,8 @@ namespace e57
    }
 
    template <typename COORDTYPE>
-   CompressedVectorReader ReaderImpl::SetUpData3DPointsData( int64_t dataIndex, size_t count,
-                                                             const Data3DPointsData_t<COORDTYPE> &buffers ) const
+   CompressedVectorReader ReaderImpl::SetUpData3DPointsData(
+      int64_t dataIndex, size_t count, const Data3DPointsData_t<COORDTYPE> &buffers ) const
    {
       static_assert( std::is_floating_point<COORDTYPE>::value, "Floating point type required." );
 
@@ -1471,86 +1562,107 @@ namespace e57
          ustring norExtUri;
          const bool haveNormalsExt = imf_.extensionsLookupPrefix( "nor", norExtUri );
 
-         if ( ( name == "cartesianX" ) && proto.isDefined( "cartesianX" ) && ( buffers.cartesianX != nullptr ) )
+         if ( ( name == "cartesianX" ) && proto.isDefined( "cartesianX" ) &&
+              ( buffers.cartesianX != nullptr ) )
          {
             destBuffers.emplace_back( imf_, "cartesianX", buffers.cartesianX, count, true, scaled );
          }
-         else if ( ( name == "cartesianY" ) && proto.isDefined( "cartesianY" ) && ( buffers.cartesianY != nullptr ) )
+         else if ( ( name == "cartesianY" ) && proto.isDefined( "cartesianY" ) &&
+                   ( buffers.cartesianY != nullptr ) )
          {
             destBuffers.emplace_back( imf_, "cartesianY", buffers.cartesianY, count, true, scaled );
          }
-         else if ( ( name == "cartesianZ" ) && proto.isDefined( "cartesianZ" ) && ( buffers.cartesianZ != nullptr ) )
+         else if ( ( name == "cartesianZ" ) && proto.isDefined( "cartesianZ" ) &&
+                   ( buffers.cartesianZ != nullptr ) )
          {
             destBuffers.emplace_back( imf_, "cartesianZ", buffers.cartesianZ, count, true, scaled );
          }
-         else if ( ( name == "cartesianInvalidState" ) && proto.isDefined( "cartesianInvalidState" ) &&
+         else if ( ( name == "cartesianInvalidState" ) &&
+                   proto.isDefined( "cartesianInvalidState" ) &&
                    ( buffers.cartesianInvalidState != nullptr ) )
          {
-            destBuffers.emplace_back( imf_, "cartesianInvalidState", buffers.cartesianInvalidState, count, true );
+            destBuffers.emplace_back( imf_, "cartesianInvalidState", buffers.cartesianInvalidState,
+                                      count, true );
          }
          else if ( ( name == "sphericalRange" ) && proto.isDefined( "sphericalRange" ) &&
                    ( buffers.sphericalRange != nullptr ) )
          {
-            destBuffers.emplace_back( imf_, "sphericalRange", buffers.sphericalRange, count, true, scaled );
+            destBuffers.emplace_back( imf_, "sphericalRange", buffers.sphericalRange, count, true,
+                                      scaled );
          }
          else if ( ( name == "sphericalAzimuth" ) && proto.isDefined( "sphericalAzimuth" ) &&
                    ( buffers.sphericalAzimuth != nullptr ) )
          {
-            destBuffers.emplace_back( imf_, "sphericalAzimuth", buffers.sphericalAzimuth, count, true, scaled );
+            destBuffers.emplace_back( imf_, "sphericalAzimuth", buffers.sphericalAzimuth, count,
+                                      true, scaled );
          }
          else if ( ( name == "sphericalElevation" ) && proto.isDefined( "sphericalElevation" ) &&
                    ( buffers.sphericalElevation != nullptr ) )
          {
-            destBuffers.emplace_back( imf_, "sphericalElevation", buffers.sphericalElevation, count, true, scaled );
+            destBuffers.emplace_back( imf_, "sphericalElevation", buffers.sphericalElevation, count,
+                                      true, scaled );
          }
-         else if ( ( name == "sphericalInvalidState" ) && proto.isDefined( "sphericalInvalidState" ) &&
+         else if ( ( name == "sphericalInvalidState" ) &&
+                   proto.isDefined( "sphericalInvalidState" ) &&
                    ( buffers.sphericalInvalidState != nullptr ) )
          {
-            destBuffers.emplace_back( imf_, "sphericalInvalidState", buffers.sphericalInvalidState, count, true );
+            destBuffers.emplace_back( imf_, "sphericalInvalidState", buffers.sphericalInvalidState,
+                                      count, true );
          }
-         else if ( ( name == "rowIndex" ) && proto.isDefined( "rowIndex" ) && ( buffers.rowIndex != nullptr ) )
+         else if ( ( name == "rowIndex" ) && proto.isDefined( "rowIndex" ) &&
+                   ( buffers.rowIndex != nullptr ) )
          {
             destBuffers.emplace_back( imf_, "rowIndex", buffers.rowIndex, count, true );
          }
-         else if ( ( name == "columnIndex" ) && proto.isDefined( "columnIndex" ) && ( buffers.columnIndex != nullptr ) )
+         else if ( ( name == "columnIndex" ) && proto.isDefined( "columnIndex" ) &&
+                   ( buffers.columnIndex != nullptr ) )
          {
             destBuffers.emplace_back( imf_, "columnIndex", buffers.columnIndex, count, true );
          }
-         else if ( ( name == "returnIndex" ) && proto.isDefined( "returnIndex" ) && ( buffers.returnIndex != nullptr ) )
+         else if ( ( name == "returnIndex" ) && proto.isDefined( "returnIndex" ) &&
+                   ( buffers.returnIndex != nullptr ) )
          {
             destBuffers.emplace_back( imf_, "returnIndex", buffers.returnIndex, count, true );
          }
-         else if ( ( name == "returnCount" ) && proto.isDefined( "returnCount" ) && ( buffers.returnCount != nullptr ) )
+         else if ( ( name == "returnCount" ) && proto.isDefined( "returnCount" ) &&
+                   ( buffers.returnCount != nullptr ) )
          {
             destBuffers.emplace_back( imf_, "returnCount", buffers.returnCount, count, true );
          }
-         else if ( ( name == "timeStamp" ) && proto.isDefined( "timeStamp" ) && ( buffers.timeStamp != nullptr ) )
+         else if ( ( name == "timeStamp" ) && proto.isDefined( "timeStamp" ) &&
+                   ( buffers.timeStamp != nullptr ) )
          {
             destBuffers.emplace_back( imf_, "timeStamp", buffers.timeStamp, count, true, scaled );
          }
          else if ( ( name == "isTimeStampInvalid" ) && proto.isDefined( "isTimeStampInvalid" ) &&
                    ( buffers.isTimeStampInvalid != nullptr ) )
          {
-            destBuffers.emplace_back( imf_, "isTimeStampInvalid", buffers.isTimeStampInvalid, count, true );
+            destBuffers.emplace_back( imf_, "isTimeStampInvalid", buffers.isTimeStampInvalid, count,
+                                      true );
          }
-         else if ( ( name == "intensity" ) && proto.isDefined( "intensity" ) && ( buffers.intensity != nullptr ) )
+         else if ( ( name == "intensity" ) && proto.isDefined( "intensity" ) &&
+                   ( buffers.intensity != nullptr ) )
          {
             destBuffers.emplace_back( imf_, "intensity", buffers.intensity, count, true, scaled );
          }
          else if ( ( name == "isIntensityInvalid" ) && proto.isDefined( "isIntensityInvalid" ) &&
                    ( buffers.isIntensityInvalid != nullptr ) )
          {
-            destBuffers.emplace_back( imf_, "isIntensityInvalid", buffers.isIntensityInvalid, count, true );
+            destBuffers.emplace_back( imf_, "isIntensityInvalid", buffers.isIntensityInvalid, count,
+                                      true );
          }
-         else if ( ( name == "colorRed" ) && proto.isDefined( "colorRed" ) && ( buffers.colorRed != nullptr ) )
+         else if ( ( name == "colorRed" ) && proto.isDefined( "colorRed" ) &&
+                   ( buffers.colorRed != nullptr ) )
          {
             destBuffers.emplace_back( imf_, "colorRed", buffers.colorRed, count, true, scaled );
          }
-         else if ( ( name == "colorGreen" ) && proto.isDefined( "colorGreen" ) && ( buffers.colorGreen != nullptr ) )
+         else if ( ( name == "colorGreen" ) && proto.isDefined( "colorGreen" ) &&
+                   ( buffers.colorGreen != nullptr ) )
          {
             destBuffers.emplace_back( imf_, "colorGreen", buffers.colorGreen, count, true, scaled );
          }
-         else if ( ( name == "colorBlue" ) && proto.isDefined( "colorBlue" ) && ( buffers.colorBlue != nullptr ) )
+         else if ( ( name == "colorBlue" ) && proto.isDefined( "colorBlue" ) &&
+                   ( buffers.colorBlue != nullptr ) )
          {
             destBuffers.emplace_back( imf_, "colorBlue", buffers.colorBlue, count, true, scaled );
          }
@@ -1559,18 +1671,18 @@ namespace e57
          {
             destBuffers.emplace_back( imf_, "isColorInvalid", buffers.isColorInvalid, count, true );
          }
-         else if ( haveNormalsExt && ( name == "nor:normalX" ) && proto.isDefined( "nor:normalX" ) &&
-                   ( buffers.normalX != nullptr ) )
+         else if ( haveNormalsExt && ( name == "nor:normalX" ) &&
+                   proto.isDefined( "nor:normalX" ) && ( buffers.normalX != nullptr ) )
          {
             destBuffers.emplace_back( imf_, "nor:normalX", buffers.normalX, count, true, scaled );
          }
-         else if ( haveNormalsExt && ( name == "nor:normalY" ) && proto.isDefined( "nor:normalY" ) &&
-                   ( buffers.normalY != nullptr ) )
+         else if ( haveNormalsExt && ( name == "nor:normalY" ) &&
+                   proto.isDefined( "nor:normalY" ) && ( buffers.normalY != nullptr ) )
          {
             destBuffers.emplace_back( imf_, "nor:normalY", buffers.normalY, count, true, scaled );
          }
-         else if ( haveNormalsExt && ( name == "nor:normalZ" ) && proto.isDefined( "nor:normalZ" ) &&
-                   ( buffers.normalZ != nullptr ) )
+         else if ( haveNormalsExt && ( name == "nor:normalZ" ) &&
+                   proto.isDefined( "nor:normalZ" ) && ( buffers.normalZ != nullptr ) )
          {
             destBuffers.emplace_back( imf_, "nor:normalZ", buffers.normalZ, count, true, scaled );
          }
@@ -1607,10 +1719,10 @@ namespace e57
    }
 
    // Explicit template instantiation
-   template CompressedVectorReader ReaderImpl::SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
-                                                                      const Data3DPointsData_t<float> &buffers ) const;
+   template CompressedVectorReader ReaderImpl::SetUpData3DPointsData(
+      int64_t dataIndex, size_t pointCount, const Data3DPointsData_t<float> &buffers ) const;
 
-   template CompressedVectorReader ReaderImpl::SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
-                                                                      const Data3DPointsData_t<double> &buffers ) const;
+   template CompressedVectorReader ReaderImpl::SetUpData3DPointsData(
+      int64_t dataIndex, size_t pointCount, const Data3DPointsData_t<double> &buffers ) const;
 
 } // end namespace e57

--- a/src/ReaderImpl.h
+++ b/src/ReaderImpl.h
@@ -33,7 +33,6 @@
 
 namespace e57
 {
-   //! most of the functions follows Reader
    class ReaderImpl
    {
    public:
@@ -56,26 +55,29 @@ namespace e57
 
       bool ReadImage2D( int64_t imageIndex, Image2D &Image2DHeader ) const;
 
-      bool GetImage2DSizes( int64_t imageIndex, Image2DProjection &imageProjection, Image2DType &imageType,
-                            int64_t &imageWidth, int64_t &imageHeight, int64_t &imageSize, Image2DType &imageMaskType,
+      bool GetImage2DSizes( int64_t imageIndex, Image2DProjection &imageProjection,
+                            Image2DType &imageType, int64_t &imageWidth, int64_t &imageHeight,
+                            int64_t &imageSize, Image2DType &imageMaskType,
                             Image2DType &imageVisualType ) const;
 
-      size_t ReadImage2DData( int64_t imageIndex, Image2DProjection imageProjection, Image2DType imageType,
-                              uint8_t *pBuffer, int64_t start, size_t count ) const;
+      size_t ReadImage2DData( int64_t imageIndex, Image2DProjection imageProjection,
+                              Image2DType imageType, uint8_t *pBuffer, int64_t start,
+                              size_t count ) const;
 
       int64_t GetData3DCount() const;
 
       bool ReadData3D( int64_t dataIndex, Data3D &data3DHeader ) const;
 
-      bool GetData3DSizes( int64_t dataIndex, int64_t &rowMax, int64_t &columnMax, int64_t &pointsSize,
-                           int64_t &groupsSize, int64_t &countSize, bool &bColumnIndex ) const;
+      bool GetData3DSizes( int64_t dataIndex, int64_t &rowMax, int64_t &columnMax,
+                           int64_t &pointsSize, int64_t &groupsSize, int64_t &countSize,
+                           bool &bColumnIndex ) const;
 
       bool ReadData3DGroupsData( int64_t dataIndex, int64_t groupCount, int64_t *idElementValue,
                                  int64_t *startPointIndex, int64_t *pointCount ) const;
 
       template <typename COORDTYPE>
-      CompressedVectorReader SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
-                                                    const Data3DPointsData_t<COORDTYPE> &buffers ) const;
+      CompressedVectorReader SetUpData3DPointsData(
+         int64_t dataIndex, size_t pointCount, const Data3DPointsData_t<COORDTYPE> &buffers ) const;
 
       StructureNode GetRawE57Root() const;
 

--- a/src/ScaledIntegerNode.cpp
+++ b/src/ScaledIntegerNode.cpp
@@ -27,329 +27,21 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-//! @file ScaledIntegerNode.cpp
+/// @file ScaledIntegerNode.cpp
 
 #include "ScaledIntegerNodeImpl.h"
 #include "StringFunctions.h"
 
 using namespace e57;
 
+// Put this function first so we can reference the code in doxygen using @skip
 /*!
-@class e57::ScaledIntegerNode
-@brief An E57 element encoding a fixed point number.
-@details
-An ScaledIntegerNode is a terminal node (i.e. having no children) that holds a
-fixed point number encoded by an integer @c rawValue, a double precision
-floating point @c scale, an double precision floating point @c offset, and
-integer minimum/maximum bounds.
-
-The @c minimum attribute may be a number in the interval [-2^63, 2^63).
-The @c maximum attribute may be a number in the interval [minimum, 2^63).
-The @c rawValue may be a number in the interval [minimum, maximum].
-The @c scaledValue is a calculated double precision floating point number
-derived from: scaledValue = rawValue*scale + offset.
-
-See Node class discussion for discussion of the common functions that
-StructureNode supports.
-
-@section ScaledIntegerNode_invariant Class Invariant
-A class invariant is a list of statements about an object that are always true
-before and after any operation on the object. An invariant is useful for testing
-correct operation of an implementation. Statements in an invariant can involve
-only externally visible state, or can refer to internal implementation-specific
-state that is not visible to the API user. The following C++ code checks
-externally visible state for consistency and throws an exception if the
-invariant is violated:
-@dontinclude ScaledIntegerNode.cpp
-@skip beginExample ScaledIntegerNode::checkInvariant
-@until endExample ScaledIntegerNode::checkInvariant
-
-@see     Node
+@brief Check whether ScaledIntegerNode class invariant is true
+@copydetails IntegerNode::checkInvariant()
 */
-
-/*!
-@brief Create an E57 element for storing a fixed point number.
-@param [in] destImageFile   The ImageFile where the new node will eventually
-be stored.
-@param [in] rawValue  The raw integer value of the element.
-@param [in] minimum   The smallest rawValue that the element may take.
-@param [in] maximum   The largest rawValue that the element may take.
-@param [in] scale     The scaling factor used to compute scaledValue from
-rawValue.
-@param [in] offset    The offset factor used to compute scaledValue from
-rawValue.
-@details
-A ScaledIntegerNode stores an integer value, a lower and upper bound, and two
-conversion factors. The ScaledIntegerNode class corresponds to the ASTM E57
-standard ScaledInteger element. See the class discussion at bottom of
-ScaledIntegerNode page for more details.
-
-The @a destImageFile indicates which ImageFile the ScaledIntegerNode will
-eventually be attached to. A node is attached to an ImageFile by adding it
-underneath the predefined root of the ImageFile (gotten from ImageFile::root).
-It is not an error to fail to attach the ScaledIntegerNode to the @a
-destImageFile. It is an error to attempt to attach the ScaledIntegerNode to a
-different ImageFile.
-
-@b Warning: it is an error to give an @a rawValue outside the @a minimum / @a
-maximum bounds, even if the ScaledIntegerNode is destined to be used in a
-CompressedVectorNode prototype (where the @a rawValue will be ignored). If the
-ScaledIntegerNode is to be used in a prototype, it is recommended to specify a
-@a rawValue = 0 if 0 is within bounds, or a @a rawValue = @a minimum if 0 is not
-within bounds.
-@pre     The @a destImageFile must be open (i.e. destImageFile.isOpen() must be
-true).
-@pre     The @a destImageFile must have been opened in write mode (i.e.
-destImageFile.isWritable() must be true).
-@pre     minimum <= rawValue <= maximum
-@pre     scale != 0
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorFileReadOnly
-@throw   ::ErrorValueOutOfBounds
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ScaledIntegerNode::rawValue, Node, CompressedVectorNode, CompressedVectorNode::prototype
-*/
-ScaledIntegerNode::ScaledIntegerNode( ImageFile destImageFile, int64_t rawValue, int64_t minimum, int64_t maximum,
-                                      double scale, double offset ) :
-   impl_( new ScaledIntegerNodeImpl( destImageFile.impl(), rawValue, minimum, maximum, scale, offset ) )
-{
-}
-
-ScaledIntegerNode::ScaledIntegerNode( ImageFile destImageFile, int rawValue, int64_t minimum, int64_t maximum,
-                                      double scale, double offset ) :
-   impl_( new ScaledIntegerNodeImpl( destImageFile.impl(), static_cast<int64_t>( rawValue ), minimum, maximum, scale,
-                                     offset ) )
-{
-}
-
-ScaledIntegerNode::ScaledIntegerNode( ImageFile destImageFile, int rawValue, int minimum, int maximum, double scale,
-                                      double offset ) :
-   impl_( new ScaledIntegerNodeImpl( destImageFile.impl(), static_cast<int64_t>( rawValue ),
-                                     static_cast<int64_t>( minimum ), static_cast<int64_t>( maximum ), scale, offset ) )
-{
-}
-
-/*!
-@brief This second constructor creates an E57 element for storing a fixed point
-number but does the scaling for you.
-@param [in] destImageFile   The ImageFile where the new node will eventually
-be stored.
-@param [in] scaledValue     The scaled integer value of the element.
-@param [in] scaledMinimum   The smallest scaledValue that the element may
-take.
-@param [in] scaledMaximum   The largest scaledValue that the element may take.
-@param [in] scale     The scaling factor used to compute scaledValue from
-rawValue.
-@param [in] offset    The offset factor used to compute scaledValue from
-rawValue.
-@details
-A ScaledIntegerNode stores an integer value, a lower and upper bound, and two
-conversion factors. This ScaledIntegerNode constructor calculates the rawValue,
-minimum, and maximum by doing the floor((scaledValue - offset)/scale + .5) on
-each scaled parameters.
-@b Warning: it is an error to give an @a rawValue outside the @a minimum / @a
-maximum bounds, even if the ScaledIntegerNode is destined to be used in a
-CompressedVectorNode prototype (where the @a rawValue will be ignored). If the
-ScaledIntegerNode is to be used in a prototype, it is recommended to specify a
-@a rawValue = 0 if 0 is within bounds, or a @a rawValue = @a minimum if 0 is not
-within bounds.
-@pre     The @a destImageFile must be open (i.e. destImageFile.isOpen() must be
-true).
-@pre     The @a destImageFile must have been opened in write mode (i.e.
-destImageFile.isWritable() must be true).
-@pre     scaledMinimum <= scaledValue <= scaledMaximum
-@pre     scale != 0
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorFileReadOnly
-@throw   ::ErrorValueOutOfBounds
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ScaledIntegerNode::scaledValue, Node, CompressedVectorNode, CompressedVectorNode::prototype
-*/
-ScaledIntegerNode::ScaledIntegerNode( ImageFile destImageFile, double scaledValue, double scaledMinimum,
-                                      double scaledMaximum, double scale, double offset ) :
-   impl_( new ScaledIntegerNodeImpl( destImageFile.impl(), scaledValue, scaledMinimum, scaledMaximum, scale, offset ) )
-{
-}
-
-//! @brief   Is this a root node.
-//! @copydetails Node::isRoot()
-bool ScaledIntegerNode::isRoot() const
-{
-   return impl_->isRoot();
-}
-
-//! @brief   Return parent of node, or self if a root node.
-//! @copydetails Node::parent()
-Node ScaledIntegerNode::parent() const
-{
-   return Node( impl_->parent() );
-}
-
-//! @brief   Get absolute pathname of node.
-//! @copydetails Node::pathName()
-ustring ScaledIntegerNode::pathName() const
-{
-   return impl_->pathName();
-}
-
-//! @brief   Get elementName string, that identifies the node in its parent..
-//! @copydetails Node::elementName()
-ustring ScaledIntegerNode::elementName() const
-{
-   return impl_->elementName();
-}
-
-//! @brief   Get the ImageFile that was declared as the destination for the node
-//! when it was created.
-//! @copydetails Node::destImageFile()
-ImageFile ScaledIntegerNode::destImageFile() const
-{
-   return ImageFile( impl_->destImageFile() );
-}
-
-//! @brief   Has node been attached into the tree of an ImageFile.
-//! @copydetails Node::isAttached()
-bool ScaledIntegerNode::isAttached() const
-{
-   return impl_->isAttached();
-}
-
-/*!
-@brief   Get raw unscaled integer value of element.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The raw unscaled integer value stored.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ScaledIntegerNode::scaledValue, ScaledIntegerNode::minimum, ScaledIntegerNode::maximum
-*/
-int64_t ScaledIntegerNode::rawValue() const
-{
-   return impl_->rawValue();
-}
-
-/*!
-@brief   Get scaled value of element.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The scaled value (rawValue*scale + offset) calculated from the rawValue
-stored.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ScaledIntegerNode::rawValue
-*/
-double ScaledIntegerNode::scaledValue() const
-{
-   return impl_->scaledValue();
-}
-
-/*!
-@brief   Get the declared minimum that the raw value may take.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The declared minimum that the rawValue may take.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ScaledIntegerNode::maximum, ScaledIntegerNode::rawValue
-*/
-int64_t ScaledIntegerNode::minimum() const
-{
-   return impl_->minimum();
-}
-
-/*!
-@brief   Get the declared scaled minimum that the scaled value may take.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The declared minimum that the rawValue may take.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ScaledIntegerNode::scaledMaximum, ScaledIntegerNode::scaledValue
-*/
-double ScaledIntegerNode::scaledMinimum() const
-{
-   return impl_->scaledMinimum();
-}
-
-/*!
-@brief   Get the declared maximum that the raw value may take.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The declared maximum that the rawValue may take.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ScaledIntegerNode::minimum, ScaledIntegerNode::rawValue
-*/
-int64_t ScaledIntegerNode::maximum() const
-{
-   return impl_->maximum();
-}
-
-/*!
-@brief   Get the declared scaled maximum that the scaled value may take.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The declared maximum that the rawValue may take.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ScaledIntegerNode::scaledMinimum, ScaledIntegerNode::scaledValue
-*/
-double ScaledIntegerNode::scaledMaximum() const // Added by SC
-{
-   return impl_->scaledMaximum();
-}
-
-/*!
-@brief   Get declared scaling factor.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The scaling factor used to compute scaledValue from rawValue.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ScaledIntegerNode::scaledValue
-*/
-double ScaledIntegerNode::scale() const
-{
-   return impl_->scale();
-}
-
-/*!
-@brief   Get declared offset.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The offset used to compute scaledValue from rawValue.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ScaledIntegerNode::scaledValue
-*/
-double ScaledIntegerNode::offset() const
-{
-   return impl_->offset();
-}
-
-//! @brief   Diagnostic function to print internal state of object to output
-//! stream in an indented format.
-//! @copydetails Node::dump()
-#ifdef E57_DEBUG
-void ScaledIntegerNode::dump( int indent, std::ostream &os ) const
-{
-   impl_->dump( indent, os );
-}
-#else
-void ScaledIntegerNode::dump( int indent, std::ostream &os ) const
-{
-}
-#endif
-
-//! @brief Check whether ScaledIntegerNode class invariant is true
-//! @copydetails IntegerNode::checkInvariant()
-// beginExample ScaledIntegerNode::checkInvariant
 void ScaledIntegerNode::checkInvariant( bool /*doRecurse*/, bool doUpcast )
 {
-   // If destImageFile not open, can't test invariant (almost every call would
-   // throw)
+   // If destImageFile not open, can't test invariant (almost every call would throw)
    if ( !destImageFile().isOpen() )
    {
       return;
@@ -379,33 +71,394 @@ void ScaledIntegerNode::checkInvariant( bool /*doRecurse*/, bool doUpcast )
       throw E57_EXCEPTION1( ErrorInvarianceViolation );
    }
 }
-// endExample ScaledIntegerNode::checkInvariant
 
 /*!
-@brief   Upcast a ScaledIntegerNode handle to a generic Node handle.
-@details An upcast is always safe, and the compiler can automatically insert it
-for initializations of Node variables and Node function arguments.
-@return  A smart Node handle referencing the underlying object.
-@throw   No E57Exceptions.
-@see     Explanation in Node, Node::type(), ScaledIntegerNode(const Node&)
+@class e57::ScaledIntegerNode
+
+@brief An E57 element encoding a fixed point number.
+
+@details
+An ScaledIntegerNode is a terminal node (i.e. having no children) that holds a fixed point number
+encoded by an integer @c rawValue, a double precision floating point @c scale, an double precision
+floating point @c offset, and integer minimum/maximum bounds.
+
+The @c minimum attribute may be a number in the interval [-2^63, 2^63).
+
+The @c maximum attribute may be a number in the interval [minimum, 2^63).
+
+The @c rawValue may be a number in the interval [minimum, maximum].
+
+The @c scaledValue is a calculated double precision floating point number derived from: scaledValue
+= rawValue*scale + offset.
+
+See Node class discussion for discussion of the common functions that StructureNode supports.
+
+@section ScaledIntegerNode_invariant Class Invariant
+A class invariant is a list of statements about an object that are always true before and after any
+operation on the object. An invariant is useful for testing correct operation of an implementation.
+Statements in an invariant can involve only externally visible state, or can refer to internal
+implementation-specific state that is not visible to the API user. The following C++ code checks
+externally visible state for consistency and throws an exception if the invariant is violated:
+
+@dontinclude ScaledIntegerNode.cpp
+@skip void ScaledIntegerNode::checkInvariant
+@until ^}
+
+@see Node
+*/
+
+/*!
+@brief Create an E57 element for storing a fixed point number.
+
+@param [in] destImageFile The ImageFile where the new node will eventually be stored.
+@param [in] rawValue The raw integer value of the element.
+@param [in] minimum The smallest rawValue that the element may take.
+@param [in] maximum The largest rawValue that the element may take.
+@param [in] scale The scaling factor used to compute scaledValue from rawValue.
+@param [in] offset The offset factor used to compute scaledValue from rawValue.
+
+@details
+A ScaledIntegerNode stores an integer value, a lower and upper bound, and two conversion factors.
+The ScaledIntegerNode class corresponds to the ASTM E57 standard ScaledInteger element. See the
+class discussion at bottom of ScaledIntegerNode page for more details.
+
+The @a destImageFile indicates which ImageFile the ScaledIntegerNode will eventually be attached to.
+A node is attached to an ImageFile by adding it underneath the predefined root of the ImageFile
+(gotten from ImageFile::root). It is not an error to fail to attach the ScaledIntegerNode to the @a
+destImageFile. It is an error to attempt to attach the ScaledIntegerNode to a different ImageFile.
+
+@warning It is an error to give an @a rawValue outside the @a minimum / @a maximum bounds, even if
+the ScaledIntegerNode is destined to be used in a CompressedVectorNode prototype (where the @a
+rawValue will be ignored). If the ScaledIntegerNode is to be used in a prototype, it is recommended
+to specify a @a rawValue = 0 if 0 is within bounds, or a @a rawValue = @a minimum if 0 is not within
+bounds.
+
+@pre The @a destImageFile must be open (i.e. destImageFile.isOpen() must be true).
+@pre The @a destImageFile must have been opened in write mode (i.e. destImageFile.isWritable() must
+be true).
+@pre minimum <= rawValue <= maximum
+@pre scale != 0
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorFileReadOnly
+@throw ::ErrorValueOutOfBounds
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ScaledIntegerNode::rawValue, Node, CompressedVectorNode, CompressedVectorNode::prototype
+*/
+ScaledIntegerNode::ScaledIntegerNode( ImageFile destImageFile, int64_t rawValue, int64_t minimum,
+                                      int64_t maximum, double scale, double offset ) :
+   impl_(
+      new ScaledIntegerNodeImpl( destImageFile.impl(), rawValue, minimum, maximum, scale, offset ) )
+{
+}
+
+ScaledIntegerNode::ScaledIntegerNode( ImageFile destImageFile, int rawValue, int64_t minimum,
+                                      int64_t maximum, double scale, double offset ) :
+   impl_( new ScaledIntegerNodeImpl( destImageFile.impl(), static_cast<int64_t>( rawValue ),
+                                     minimum, maximum, scale, offset ) )
+{
+}
+
+ScaledIntegerNode::ScaledIntegerNode( ImageFile destImageFile, int rawValue, int minimum,
+                                      int maximum, double scale, double offset ) :
+   impl_( new ScaledIntegerNodeImpl( destImageFile.impl(), static_cast<int64_t>( rawValue ),
+                                     static_cast<int64_t>( minimum ),
+                                     static_cast<int64_t>( maximum ), scale, offset ) )
+{
+}
+
+/*!
+@brief This second constructor creates an E57 element for storing a fixed point number but does the
+scaling for you.
+
+@param [in] destImageFile The ImageFile where the new node will eventually be stored.
+@param [in] scaledValue The scaled integer value of the element.
+@param [in] scaledMinimum The smallest scaledValue that the element may take.
+@param [in] scaledMaximum The largest scaledValue that the element may take.
+@param [in] scale The scaling factor used to compute scaledValue from rawValue.
+@param [in] offset The offset factor used to compute scaledValue from rawValue.
+
+@details
+A ScaledIntegerNode stores an integer value, a lower and upper bound, and two conversion factors.
+This ScaledIntegerNode constructor calculates the rawValue, minimum, and maximum by doing the
+floor((scaledValue - offset)/scale + .5) on each scaled parameters.
+
+@warning It is an error to give an @a rawValue outside the @a minimum / @a maximum bounds, even if
+the ScaledIntegerNode is destined to be used in a CompressedVectorNode prototype (where the @a
+rawValue will be ignored). If the ScaledIntegerNode is to be used in a prototype, it is recommended
+to specify a @a rawValue = 0 if 0 is within bounds, or a @a rawValue = @a minimum if 0 is not within
+bounds.
+
+@pre The @a destImageFile must be open (i.e. destImageFile.isOpen() must be true).
+@pre The @a destImageFile must have been opened in write mode (i.e. destImageFile.isWritable() must
+be true).
+@pre scaledMinimum <= scaledValue <= scaledMaximum
+@pre scale != 0
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorFileReadOnly
+@throw ::ErrorValueOutOfBounds
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ScaledIntegerNode::scaledValue, Node, CompressedVectorNode, CompressedVectorNode::prototype
+*/
+ScaledIntegerNode::ScaledIntegerNode( ImageFile destImageFile, double scaledValue,
+                                      double scaledMinimum, double scaledMaximum, double scale,
+                                      double offset ) :
+   impl_( new ScaledIntegerNodeImpl( destImageFile.impl(), scaledValue, scaledMinimum,
+                                     scaledMaximum, scale, offset ) )
+{
+}
+
+/*!
+@brief Is this a root node.
+@copydetails Node::isRoot()
+*/
+bool ScaledIntegerNode::isRoot() const
+{
+   return impl_->isRoot();
+}
+
+/*!
+@brief Return parent of node, or self if a root node.
+@copydetails Node::parent()
+*/
+Node ScaledIntegerNode::parent() const
+{
+   return Node( impl_->parent() );
+}
+
+/*!
+@brief Get absolute pathname of node.
+@copydetails Node::pathName()
+*/
+ustring ScaledIntegerNode::pathName() const
+{
+   return impl_->pathName();
+}
+
+/*!
+@brief Get elementName string, that identifies the node in its parent.
+@copydetails Node::elementName()
+*/
+ustring ScaledIntegerNode::elementName() const
+{
+   return impl_->elementName();
+}
+
+/*!
+@brief Get the ImageFile that was declared as the destination for the node when it was created.
+@copydetails Node::destImageFile()
+*/
+ImageFile ScaledIntegerNode::destImageFile() const
+{
+   return ImageFile( impl_->destImageFile() );
+}
+
+/*!
+@brief Has node been attached into the tree of an ImageFile.
+@copydetails Node::isAttached()
+*/
+bool ScaledIntegerNode::isAttached() const
+{
+   return impl_->isAttached();
+}
+
+/*!
+@brief Get raw unscaled integer value of element.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return The raw unscaled integer value stored.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ScaledIntegerNode::scaledValue, ScaledIntegerNode::minimum, ScaledIntegerNode::maximum
+*/
+int64_t ScaledIntegerNode::rawValue() const
+{
+   return impl_->rawValue();
+}
+
+/*!
+@brief Get scaled value of element.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return The scaled value (rawValue*scale + offset) calculated from the rawValue stored.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ScaledIntegerNode::rawValue
+*/
+double ScaledIntegerNode::scaledValue() const
+{
+   return impl_->scaledValue();
+}
+
+/*!
+@brief Get the declared minimum that the raw value may take.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return The declared minimum that the rawValue may take.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ScaledIntegerNode::maximum, ScaledIntegerNode::rawValue
+*/
+int64_t ScaledIntegerNode::minimum() const
+{
+   return impl_->minimum();
+}
+
+/*!
+@brief Get the declared scaled minimum that the scaled value may take.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return The declared minimum that the rawValue may take.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ScaledIntegerNode::scaledMaximum, ScaledIntegerNode::scaledValue
+*/
+double ScaledIntegerNode::scaledMinimum() const
+{
+   return impl_->scaledMinimum();
+}
+
+/*!
+@brief Get the declared maximum that the raw value may take.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return The declared maximum that the rawValue may take.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ScaledIntegerNode::minimum, ScaledIntegerNode::rawValue
+*/
+int64_t ScaledIntegerNode::maximum() const
+{
+   return impl_->maximum();
+}
+
+/*!
+@brief Get the declared scaled maximum that the scaled value may take.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return The declared maximum that the rawValue may take.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ScaledIntegerNode::scaledMinimum, ScaledIntegerNode::scaledValue
+*/
+double ScaledIntegerNode::scaledMaximum() const // Added by SC
+{
+   return impl_->scaledMaximum();
+}
+
+/*!
+@brief Get declared scaling factor.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return The scaling factor used to compute scaledValue from rawValue.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ScaledIntegerNode::scaledValue
+*/
+double ScaledIntegerNode::scale() const
+{
+   return impl_->scale();
+}
+
+/*!
+@brief Get declared offset.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return The offset used to compute scaledValue from rawValue.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ScaledIntegerNode::scaledValue
+*/
+double ScaledIntegerNode::offset() const
+{
+   return impl_->offset();
+}
+
+/*!
+@brief Diagnostic function to print internal state of object to output stream in an indented format.
+@copydetails Node::dump()
+*/
+#ifdef E57_DEBUG
+void ScaledIntegerNode::dump( int indent, std::ostream &os ) const
+{
+   impl_->dump( indent, os );
+}
+#else
+void ScaledIntegerNode::dump( int indent, std::ostream &os ) const
+{
+}
+#endif
+
+/*!
+@brief Upcast a ScaledIntegerNode handle to a generic Node handle.
+
+@details
+An upcast is always safe, and the compiler can automatically insert it for initializations of Node
+variables and Node function arguments.
+
+@return A smart Node handle referencing the underlying object.
+
+@throw No E57Exceptions.
+
+@see Explanation in Node, Node::type(), ScaledIntegerNode(const Node&)
 */
 ScaledIntegerNode::operator Node() const
 {
-   /// Upcast from shared_ptr<ScaledIntegerNodeImpl> to SharedNodeImplPtr and
-   /// construct a Node object
+   // Upcast from shared_ptr<ScaledIntegerNodeImpl> to SharedNodeImplPtr and construct a Node object
    return Node( impl_ );
 }
 
 /*!
-@brief   Downcast a generic Node handle to an ScaledIntegerNode handle.
-@param   [in] n The generic handle to downcast.
-@details The handle @a n must be for an underlying ScaledIntegerNode, otherwise
-an exception is thrown. In designs that need to avoid the exception, use
-Node::type() to determine the actual type of the @a n before downcasting. This
-function must be explicitly called (c++ compiler cannot insert it
+@brief Downcast a generic Node handle to an ScaledIntegerNode handle.
+
+@param [in] n The generic handle to downcast.
+
+@details
+The handle @a n must be for an underlying ScaledIntegerNode, otherwise an exception is thrown. In
+designs that need to avoid the exception, use Node::type() to determine the actual type of the @a n
+before downcasting. This function must be explicitly called (c++ compiler cannot insert it
 automatically).
-@throw   ::ErrorBadNodeDowncast
-@see     Node::type(), ScaledIntegerNode::operator, Node()
+
+@throw ::ErrorBadNodeDowncast
+
+@see Node::type(), ScaledIntegerNode::operator, Node()
 */
 ScaledIntegerNode::ScaledIntegerNode( const Node &n )
 {
@@ -414,13 +467,12 @@ ScaledIntegerNode::ScaledIntegerNode( const Node &n )
       throw E57_EXCEPTION2( ErrorBadNodeDowncast, "nodeType=" + toString( n.type() ) );
    }
 
-   /// Set our shared_ptr to the downcast shared_ptr
+   // Set our shared_ptr to the downcast shared_ptr
    impl_ = std::static_pointer_cast<ScaledIntegerNodeImpl>( n.impl() );
 }
 
-//! @cond documentNonPublic   The following isn't part of the API, and isn't
-//! documented.
+/// @cond documentNonPublic The following isn't part of the API, and isn't documented.
 ScaledIntegerNode::ScaledIntegerNode( std::shared_ptr<ScaledIntegerNodeImpl> ni ) : impl_( ni )
 {
 }
-//! @endcond
+/// @endcond

--- a/src/ScaledIntegerNodeImpl.cpp
+++ b/src/ScaledIntegerNodeImpl.cpp
@@ -33,40 +33,45 @@
 
 namespace e57
 {
-   ScaledIntegerNodeImpl::ScaledIntegerNodeImpl( ImageFileImplWeakPtr destImageFile, int64_t rawValue, int64_t minimum,
-                                                 int64_t maximum, double scale, double offset ) :
+   ScaledIntegerNodeImpl::ScaledIntegerNodeImpl( ImageFileImplWeakPtr destImageFile,
+                                                 int64_t rawValue, int64_t minimum, int64_t maximum,
+                                                 double scale, double offset ) :
       NodeImpl( destImageFile ),
-      value_( rawValue ), minimum_( minimum ), maximum_( maximum ), scale_( scale ), offset_( offset )
-   {
-      // don't checkImageFileOpen, NodeImpl() will do it
-
-      /// Enforce the given bounds on raw value
-      if ( rawValue < minimum || maximum < rawValue )
-      {
-         throw E57_EXCEPTION2( ErrorValueOutOfBounds,
-                               "this->pathName=" + this->pathName() + " rawValue=" + toString( rawValue ) +
-                                  " minimum=" + toString( minimum ) + " maximum=" + toString( maximum ) );
-      }
-   }
-
-   ScaledIntegerNodeImpl::ScaledIntegerNodeImpl( ImageFileImplWeakPtr destImageFile, double scaledValue,
-                                                 double scaledMinimum, double scaledMaximum, double scale,
-                                                 double offset ) :
-      NodeImpl( destImageFile ),
-      value_( static_cast<int64_t>( std::floor( ( scaledValue - offset ) / scale + .5 ) ) ),
-      minimum_( static_cast<int64_t>( std::floor( ( scaledMinimum - offset ) / scale + .5 ) ) ),
-      maximum_( static_cast<int64_t>( std::floor( ( scaledMaximum - offset ) / scale + .5 ) ) ), scale_( scale ),
+      value_( rawValue ), minimum_( minimum ), maximum_( maximum ), scale_( scale ),
       offset_( offset )
    {
       // don't checkImageFileOpen, NodeImpl() will do it
 
-      /// Enforce the given bounds on raw value
-      if ( scaledValue < scaledMinimum || scaledMaximum < scaledValue )
+      // Enforce the given bounds on raw value
+      if ( rawValue < minimum || maximum < rawValue )
       {
          throw E57_EXCEPTION2( ErrorValueOutOfBounds, "this->pathName=" + this->pathName() +
-                                                         " scaledValue=" + toString( scaledValue ) +
-                                                         " scaledMinimum=" + toString( scaledMinimum ) +
-                                                         " scaledMaximum=" + toString( scaledMaximum ) );
+                                                         " rawValue=" + toString( rawValue ) +
+                                                         " minimum=" + toString( minimum ) +
+                                                         " maximum=" + toString( maximum ) );
+      }
+   }
+
+   ScaledIntegerNodeImpl::ScaledIntegerNodeImpl( ImageFileImplWeakPtr destImageFile,
+                                                 double scaledValue, double scaledMinimum,
+                                                 double scaledMaximum, double scale,
+                                                 double offset ) :
+      NodeImpl( destImageFile ),
+      value_( static_cast<int64_t>( std::floor( ( scaledValue - offset ) / scale + .5 ) ) ),
+      minimum_( static_cast<int64_t>( std::floor( ( scaledMinimum - offset ) / scale + .5 ) ) ),
+      maximum_( static_cast<int64_t>( std::floor( ( scaledMaximum - offset ) / scale + .5 ) ) ),
+      scale_( scale ), offset_( offset )
+   {
+      // don't checkImageFileOpen, NodeImpl() will do it
+
+      // Enforce the given bounds on raw value
+      if ( scaledValue < scaledMinimum || scaledMaximum < scaledValue )
+      {
+         throw E57_EXCEPTION2( ErrorValueOutOfBounds,
+                               "this->pathName=" + this->pathName() +
+                                  " scaledValue=" + toString( scaledValue ) +
+                                  " scaledMinimum=" + toString( scaledMinimum ) +
+                                  " scaledMaximum=" + toString( scaledMaximum ) );
       }
    }
 
@@ -74,42 +79,43 @@ namespace e57
    {
       // don't checkImageFileOpen
 
-      /// Same node type?
+      // Same node type?
       if ( ni->type() != TypeScaledInteger )
       {
          return ( false );
       }
 
-      /// Downcast to shared_ptr<ScaledIntegerNodeImpl>
-      std::shared_ptr<ScaledIntegerNodeImpl> ii( std::static_pointer_cast<ScaledIntegerNodeImpl>( ni ) );
+      // Downcast to shared_ptr<ScaledIntegerNodeImpl>
+      std::shared_ptr<ScaledIntegerNodeImpl> ii(
+         std::static_pointer_cast<ScaledIntegerNodeImpl>( ni ) );
 
-      /// minimum must match
+      // minimum must match
       if ( minimum_ != ii->minimum_ )
       {
          return ( false );
       }
 
-      /// maximum must match
+      // maximum must match
       if ( maximum_ != ii->maximum_ )
       {
          return ( false );
       }
 
-      /// scale must match
+      // scale must match
       if ( scale_ != ii->scale_ )
       {
          return ( false );
       }
 
-      /// offset must match
+      // offset must match
       if ( offset_ != ii->offset_ )
       {
          return ( false );
       }
 
-      /// ignore value_, doesn't have to match
+      // ignore value_, doesn't have to match
 
-      /// Types match
+      // Types match
       return ( true );
    }
 
@@ -117,7 +123,7 @@ namespace e57
    {
       // don't checkImageFileOpen
 
-      /// We have no sub-structure, so if path not empty return false
+      // We have no sub-structure, so if path not empty return false
       return pathName.empty();
    }
 
@@ -169,19 +175,20 @@ namespace e57
       return ( offset_ );
    }
 
-   void ScaledIntegerNodeImpl::checkLeavesInSet( const StringSet &pathNames, NodeImplSharedPtr origin )
+   void ScaledIntegerNodeImpl::checkLeavesInSet( const StringSet &pathNames,
+                                                 NodeImplSharedPtr origin )
    {
       // don't checkImageFileOpen
 
-      /// We are a leaf node, so verify that we are listed in set.
+      // We are a leaf node, so verify that we are listed in set.
       if ( pathNames.find( relativePathName( origin ) ) == pathNames.end() )
       {
          throw E57_EXCEPTION2( ErrorNoBufferForElement, "this->pathName=" + this->pathName() );
       }
    }
 
-   void ScaledIntegerNodeImpl::writeXml( ImageFileImplSharedPtr /*imf*/, CheckedFile &cf, int indent,
-                                         const char *forcedFieldName )
+   void ScaledIntegerNodeImpl::writeXml( ImageFileImplSharedPtr /*imf*/, CheckedFile &cf,
+                                         int indent, const char *forcedFieldName )
    {
       // don't checkImageFileOpen
 
@@ -197,7 +204,7 @@ namespace e57
 
       cf << space( indent ) << "<" << fieldName << " type=\"ScaledInteger\"";
 
-      /// Don't need to write if are default values
+      // Don't need to write if are default values
       if ( minimum_ != INT64_MIN )
       {
          cf << " minimum=\"" << minimum_ << "\"";
@@ -215,7 +222,7 @@ namespace e57
          cf << " offset=\"" << offset_ << "\"";
       }
 
-      /// Write value as child text, unless it is the default value
+      // Write value as child text, unless it is the default value
       if ( value_ != 0 )
       {
          cf << ">" << value_ << "</" << fieldName << ">\n";

--- a/src/ScaledIntegerNodeImpl.h
+++ b/src/ScaledIntegerNodeImpl.h
@@ -33,12 +33,13 @@ namespace e57
    class ScaledIntegerNodeImpl : public NodeImpl
    {
    public:
-      explicit ScaledIntegerNodeImpl( ImageFileImplWeakPtr destImageFile, int64_t value = 0, int64_t minimum = 0,
-                                      int64_t maximum = 0, double scale = 1.0, double offset = 0.0 );
+      explicit ScaledIntegerNodeImpl( ImageFileImplWeakPtr destImageFile, int64_t value = 0,
+                                      int64_t minimum = 0, int64_t maximum = 0, double scale = 1.0,
+                                      double offset = 0.0 );
 
       explicit ScaledIntegerNodeImpl( ImageFileImplWeakPtr destImageFile, double scaledValue = 0.,
-                                      double scaledMinimum = 0., double scaledMaximum = 0., double scale = 1.0,
-                                      double offset = 0.0 );
+                                      double scaledMinimum = 0., double scaledMaximum = 0.,
+                                      double scale = 1.0, double offset = 0.0 );
 
       ~ScaledIntegerNodeImpl() override = default;
 

--- a/src/SectionHeaders.cpp
+++ b/src/SectionHeaders.cpp
@@ -40,55 +40,60 @@ namespace e57
 
    CompressedVectorSectionHeader::CompressedVectorSectionHeader()
    {
-      /// Double check that header is correct length.  Watch out for RTTI
-      /// increasing the size.
+      // Double check that header is correct length.  Watch out for RTTI increasing the size.
       static_assert( sizeof( CompressedVectorSectionHeader ) == 32,
                      "Unexpected size of CompressedVectorSectionHeader" );
    }
 
    void CompressedVectorSectionHeader::verify( uint64_t filePhysicalSize )
    {
-      /// Verify reserved fields are zero. ???  if fileversion==1.0 ???
+      // Verify reserved fields are zero. ???  if fileversion==1.0 ???
       for ( unsigned i = 0; i < sizeof( reserved1 ); i++ )
       {
          if ( reserved1[i] != 0 )
          {
-            throw E57_EXCEPTION2( ErrorBadCVHeader, "i=" + toString( i ) + " reserved=" + toString( reserved1[i] ) );
+            throw E57_EXCEPTION2( ErrorBadCVHeader,
+                                  "i=" + toString( i ) + " reserved=" + toString( reserved1[i] ) );
          }
       }
 
-      /// Check section length is multiple of 4
+      // Check section length is multiple of 4
       if ( sectionLogicalLength % 4 )
       {
-         throw E57_EXCEPTION2( ErrorBadCVHeader, "sectionLogicalLength=" + toString( sectionLogicalLength ) );
+         throw E57_EXCEPTION2( ErrorBadCVHeader,
+                               "sectionLogicalLength=" + toString( sectionLogicalLength ) );
       }
 
-      /// Check sectionLogicalLength is in bounds
+      // Check sectionLogicalLength is in bounds
       if ( filePhysicalSize > 0 && sectionLogicalLength >= filePhysicalSize )
       {
-         throw E57_EXCEPTION2( ErrorBadCVHeader, "sectionLogicalLength=" + toString( sectionLogicalLength ) +
-                                                    " filePhysicalSize=" + toString( filePhysicalSize ) );
+         throw E57_EXCEPTION2( ErrorBadCVHeader,
+                               "sectionLogicalLength=" + toString( sectionLogicalLength ) +
+                                  " filePhysicalSize=" + toString( filePhysicalSize ) );
       }
 
-      /// Check dataPhysicalOffset is in bounds
+      // Check dataPhysicalOffset is in bounds
       if ( filePhysicalSize > 0 && dataPhysicalOffset >= filePhysicalSize )
       {
-         throw E57_EXCEPTION2( ErrorBadCVHeader, "dataPhysicalOffset=" + toString( dataPhysicalOffset ) +
-                                                    " filePhysicalSize=" + toString( filePhysicalSize ) );
+         throw E57_EXCEPTION2( ErrorBadCVHeader,
+                               "dataPhysicalOffset=" + toString( dataPhysicalOffset ) +
+                                  " filePhysicalSize=" + toString( filePhysicalSize ) );
       }
 
-      /// Check indexPhysicalOffset is in bounds
+      // Check indexPhysicalOffset is in bounds
       if ( filePhysicalSize > 0 && indexPhysicalOffset >= filePhysicalSize )
       {
-         throw E57_EXCEPTION2( ErrorBadCVHeader, "indexPhysicalOffset=" + toString( indexPhysicalOffset ) +
-                                                    " filePhysicalSize=" + toString( filePhysicalSize ) );
+         throw E57_EXCEPTION2( ErrorBadCVHeader,
+                               "indexPhysicalOffset=" + toString( indexPhysicalOffset ) +
+                                  " filePhysicalSize=" + toString( filePhysicalSize ) );
       }
    }
 
 #ifdef E57_DEBUG
    void CompressedVectorSectionHeader::dump( int indent, std::ostream &os ) const
    {
-      os << space( indent ) << "sectionId:            " << static_cast<unsigned>( sectionId ) << std::endl;
+      os << space( indent ) << "sectionId:            " << static_cast<unsigned>( sectionId )
+         << std::endl;
       os << space( indent ) << "sectionLogicalLength: " << sectionLogicalLength << std::endl;
       os << space( indent ) << "dataPhysicalOffset:   " << dataPhysicalOffset << std::endl;
       os << space( indent ) << "indexPhysicalOffset:  " << indexPhysicalOffset << std::endl;

--- a/src/SectionHeaders.h
+++ b/src/SectionHeaders.h
@@ -58,6 +58,7 @@ namespace e57
       uint64_t indexPhysicalOffset = 0;  // offset of first index packet
 
       CompressedVectorSectionHeader();
+
       void verify( uint64_t filePhysicalSize = 0 );
 
 #ifdef E57_DEBUG

--- a/src/SourceDestBuffer.cpp
+++ b/src/SourceDestBuffer.cpp
@@ -27,250 +27,311 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-//! @file SourceDestBuffer.cpp
+/// @file SourceDestBuffer.cpp
 
 #include "SourceDestBufferImpl.h"
 
 using namespace e57;
 
+// Put this function first so we can reference the code in doxygen using @skip
+/// @brief Check whether SourceDestBuffer class invariant is true
+void SourceDestBuffer::checkInvariant( bool /*doRecurse*/ ) const
+{
+   // Stride must be >= a memory type dependent value
+   size_t min_stride = 0;
+
+   switch ( memoryRepresentation() )
+   {
+      case Int8:
+         min_stride = 1;
+         break;
+      case UInt8:
+         min_stride = 1;
+         break;
+      case Int16:
+         min_stride = 2;
+         break;
+      case UInt16:
+         min_stride = 2;
+         break;
+      case Int32:
+         min_stride = 4;
+         break;
+      case UInt32:
+         min_stride = 4;
+         break;
+      case Int64:
+         min_stride = 8;
+         break;
+      case Bool:
+         min_stride = 1;
+         break;
+      case Real32:
+         min_stride = 4;
+         break;
+      case Real64:
+         min_stride = 8;
+         break;
+      case UString:
+         min_stride = sizeof( ustring );
+         break;
+      default:
+         throw E57_EXCEPTION1( ErrorInvarianceViolation );
+   }
+
+   if ( stride() < min_stride )
+   {
+      throw E57_EXCEPTION1( ErrorInvarianceViolation );
+   }
+}
+
 /*!
 @class e57::SourceDestBuffer
-@brief   A memory buffer to transfer data to/from a CompressedVectorNode in a
-block.
+
+@brief A memory buffer to transfer data to/from a CompressedVectorNode in a block.
+
 @details
-The SourceDestBuffer is an encapsulation of a buffer in memory that will
-transfer data to/from a field in a CompressedVectorNode. The API user is
-responsible for creating the actual memory buffer, describing it correctly to
-the API, making sure it exists during the transfer period, and destroying it
-after the transfer is complete. Additionally, the SourceDestBuffer has
-information that specifies the connection to the CompressedVectorNode field
-(i.e. the field's path name in the prototype).
+The SourceDestBuffer is an encapsulation of a buffer in memory that will transfer data to/from a
+field in a CompressedVectorNode. The API user is responsible for creating the actual memory buffer,
+describing it correctly to the API, making sure it exists during the transfer period, and destroying
+it after the transfer is complete. Additionally, the SourceDestBuffer has information that specifies
+the connection to the CompressedVectorNode field (i.e. the field's path name in the prototype).
 
-The type of buffer element may be an assortment of built-in C++ memory types.
-There are all combinations of signed/unsigned and 8/16/32/64 bit integers
-(except unsigned 64bit integer, which is not supported in the ASTM standard),
-bool, float, double, as well as a vector of variable length unicode strings. The
-compiler selects the appropriate constructor automatically based on the type of
-the buffer array. However, the API user is responsible for reporting the correct
-length and stride options (otherwise unspecified behavior can occur).
+The type of buffer element may be an assortment of built-in C++ memory types. There are all
+combinations of signed/unsigned and 8/16/32/64 bit integers (except unsigned 64bit integer, which is
+not supported in the ASTM standard), bool, float, double, as well as a vector of variable length
+unicode strings. The compiler selects the appropriate constructor automatically based on the type of
+the buffer array. However, the API user is responsible for reporting the correct length and stride
+options (otherwise unspecified behavior can occur).
 
-The connection of the SourceDestBuffer to a CompressedVectorNode field is
-established by specifying the pathName. There are several options to this
-connection: doConversion and doScaling, which are described in the constructor
-documentation.
+The connection of the SourceDestBuffer to a CompressedVectorNode field is established by specifying
+the pathName. There are several options to this connection: doConversion and doScaling, which are
+described in the constructor documentation.
 
 @section sourcedestbuffer_invariant Class Invariant
-A class invariant is a list of statements about an object that are always true
-before and after any operation on the object. An invariant is useful for testing
-correct operation of an implementation. Statements in an invariant can involve
-only externally visible state, or can refer to internal implementation-specific
-state that is not visible to the API user. The following C++ code checks
-externally visible state for consistency and throws an exception if the
-invariant is violated:
-@dontinclude SourceDestBuffer.cpp
-@skip beginExample SourceDestBuffer::checkInvariant
-@until endExample SourceDestBuffer::checkInvariant
+A class invariant is a list of statements about an object that are always true before and after any
+operation on the object. An invariant is useful for testing correct operation of an implementation.
+Statements in an invariant can involve only externally visible state, or can refer to internal
+implementation-specific state that is not visible to the API user. The following C++ code checks
+externally visible state for consistency and throws an exception if the invariant is violated:
 
-@see     Node
+@dontinclude SourceDestBuffer.cpp
+@skip void SourceDestBuffer::checkInvariant
+@until ^}
+
+@see Node
 */
 
 /*!
-@brief   Designate buffers to transfer data to/from a CompressedVectorNode in a
-block.
-@param   [in] destImageFile The ImageFile where the new node will eventually be
-stored.
-@param   [in] pathName      The pathname of the field in CompressedVectorNode
-that will transfer data to/from.
-@param   [in] b             The caller allocated memory buffer.
-@param   [in] capacity      The total number of memory elements in buffer @a b.
-@param   [in] doConversion  Will a conversion be attempted between memory and
-ImageFile representations.
-@param   [in] doScaling     In a ScaledInteger field, do memory elements hold
-scaled values, if false they hold raw values.
-@param   [in] stride        The number of bytes between memory elements.  If
-zero, defaults to sizeof memory element.
+@brief Designate buffers to transfer data to/from a CompressedVectorNode in a block.
+
+@param [in] destImageFile The ImageFile where the new node will eventually be stored.
+@param [in] pathName The pathname of the field in CompressedVectorNode that will transfer data
+to/from.
+@param [in] b The caller allocated memory buffer.
+@param [in] capacity The total number of memory elements in buffer @a b.
+@param [in] doConversion Will a conversion be attempted between memory and ImageFile
+representations.
+@param [in] doScaling In a ScaledInteger field, do memory elements hold scaled values, if false they
+hold raw values.
+@param [in] stride The number of bytes between memory elements.  If zero, defaults to sizeof memory
+element.
+
 @details
-This overloaded form of the SourceDestBuffer constructor declares a buffer @a b
-to be the source/destination of a transfer of values stored in a
-CompressedVectorNode.\n\n
+This overloaded form of the SourceDestBuffer constructor declares a buffer @a b to be the
+source/destination of a transfer of values stored in a CompressedVectorNode.
 
-The @a pathName will be used to identify a Node in the prototype that will
-get/receive data from this buffer. The @a pathName may be an absolute path name
-(e.g. "/cartesianX") or a path name relative to the root of the prototype (i.e.
-the absolute path name without the leading "/", for example: "cartesianX").\n\n
+The @a pathName will be used to identify a Node in the prototype that will get/receive data from
+this buffer. The @a pathName may be an absolute path name (e.g. "/cartesianX") or a path name
+relative to the root of the prototype (i.e. the absolute path name without the leading "/", for
+example: "cartesianX").
 
-The type of @a b is used to determine the MemoryRepresentation of the
-SourceDestBuffer. The buffer @a b may be used for multiple block transfers. See
-discussions of operation of SourceDestBuffer attributes in
-SourceDestBuffer::memoryRepresentation, SourceDestBuffer::capacity,
-SourceDestBuffer::doConversion, and SourceDestBuffer::doScaling, and
-SourceDestBuffer::stride.\n\n
+The type of @a b is used to determine the MemoryRepresentation of the SourceDestBuffer. The buffer
+@a b may be used for multiple block transfers. See discussions of operation of SourceDestBuffer
+attributes in SourceDestBuffer::memoryRepresentation, SourceDestBuffer::capacity,
+SourceDestBuffer::doConversion, and SourceDestBuffer::doScaling, and SourceDestBuffer::stride.
 
-The API user is responsible for ensuring that the lifetime of the @a b memory
-buffer exceeds the time that it is used in transfers (i.e. the E57 Foundation
-Implementation cannot detect that the buffer been destroyed).\n\n
+The API user is responsible for ensuring that the lifetime of the @a b memory buffer exceeds the
+time that it is used in transfers (i.e. the E57 Foundation Implementation cannot detect that the
+buffer been destroyed).
 
-The @a capacity must match the capacity of all other SourceDestBuffers that will
-participate in a transfer with a CompressedVectorNode.
+The @a capacity must match the capacity of all other SourceDestBuffers that will participate in a
+transfer with a CompressedVectorNode.
 
-@pre     The @a destImageFile must be open (i.e. destImageFile.isOpen() must be
-true).
-@pre     The stride must be >= sizeof(*b)
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorBadPathName
-@throw   ::ErrorBadBuffer
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ImageFile::reader, ImageFile::writer,
+@pre The @a destImageFile must be open (i.e. destImageFile.isOpen() must be true).
+@pre The stride must be >= sizeof(*b)
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorBadPathName
+@throw ::ErrorBadBuffer
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ImageFile::reader, ImageFile::writer,
 CompressedVectorReader::read(std::vector<SourceDestBuffer>&),
 CompressedVectorWriter::write(std::vector<SourceDestBuffer>&)
 */
-SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, int8_t *b, const size_t capacity,
-                                    bool doConversion, bool doScaling, size_t stride ) :
-   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion, doScaling ) )
+SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, int8_t *b,
+                                    const size_t capacity, bool doConversion, bool doScaling,
+                                    size_t stride ) :
+   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion,
+                                    doScaling ) )
 {
    impl_->setTypeInfo<int8_t>( b, stride );
 }
 
-//! @brief   Designate buffers to transfer data to/from a CompressedVectorNode in a block.
-//! @copydetails SourceDestBuffer::SourceDestBuffer(ImageFile,const ustring&,int8_t*,size_t,bool,bool,size_t)
-SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, uint8_t *b, const size_t capacity,
-                                    bool doConversion, bool doScaling, size_t stride ) :
-   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion, doScaling ) )
+/// @overload
+SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, uint8_t *b,
+                                    const size_t capacity, bool doConversion, bool doScaling,
+                                    size_t stride ) :
+   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion,
+                                    doScaling ) )
 {
    impl_->setTypeInfo<uint8_t>( b, stride );
 }
 
-//! @brief   Designate buffers to transfer data to/from a CompressedVectorNode in a block.
-//! @copydetails SourceDestBuffer::SourceDestBuffer(ImageFile,const ustring&,int8_t*,size_t,bool,bool,size_t)
-SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, int16_t *b, const size_t capacity,
-                                    bool doConversion, bool doScaling, size_t stride ) :
-   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion, doScaling ) )
+/// @overload
+SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, int16_t *b,
+                                    const size_t capacity, bool doConversion, bool doScaling,
+                                    size_t stride ) :
+   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion,
+                                    doScaling ) )
 {
    impl_->setTypeInfo<int16_t>( b, stride );
 }
 
-//! @brief   Designate buffers to transfer data to/from a CompressedVectorNode in a block.
-//! @copydetails SourceDestBuffer::SourceDestBuffer(ImageFile,const ustring&,int8_t*,size_t,bool,bool,size_t)
+/// @overload
 SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, uint16_t *b,
-                                    const size_t capacity, bool doConversion, bool doScaling, size_t stride ) :
-   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion, doScaling ) )
+                                    const size_t capacity, bool doConversion, bool doScaling,
+                                    size_t stride ) :
+   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion,
+                                    doScaling ) )
 {
    impl_->setTypeInfo<uint16_t>( b, stride );
 }
 
-//! @brief   Designate buffers to transfer data to/from a CompressedVectorNode in a block.
-//! @copydetails SourceDestBuffer::SourceDestBuffer(ImageFile,const ustring&,int8_t*,size_t,bool,bool,size_t)
-SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, int32_t *b, const size_t capacity,
-                                    bool doConversion, bool doScaling, size_t stride ) :
-   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion, doScaling ) )
+/// @overload
+SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, int32_t *b,
+                                    const size_t capacity, bool doConversion, bool doScaling,
+                                    size_t stride ) :
+   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion,
+                                    doScaling ) )
 {
    impl_->setTypeInfo<int32_t>( b, stride );
 }
 
-//! @brief   Designate buffers to transfer data to/from a CompressedVectorNode in a block.
-//! @copydetails SourceDestBuffer::SourceDestBuffer(ImageFile,const ustring&,int8_t*,size_t,bool,bool,size_t)
+/// @overload
 SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, uint32_t *b,
-                                    const size_t capacity, bool doConversion, bool doScaling, size_t stride ) :
-   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion, doScaling ) )
+                                    const size_t capacity, bool doConversion, bool doScaling,
+                                    size_t stride ) :
+   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion,
+                                    doScaling ) )
 {
    impl_->setTypeInfo<uint32_t>( b, stride );
 }
 
-//! @brief   Designate buffers to transfer data to/from a CompressedVectorNode in a block.
-//! @copydetails SourceDestBuffer::SourceDestBuffer(ImageFile,const ustring&,int8_t*,size_t,bool,bool,size_t)
-SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, int64_t *b, const size_t capacity,
-                                    bool doConversion, bool doScaling, size_t stride ) :
-   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion, doScaling ) )
+/// @overload
+SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, int64_t *b,
+                                    const size_t capacity, bool doConversion, bool doScaling,
+                                    size_t stride ) :
+   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion,
+                                    doScaling ) )
 {
    impl_->setTypeInfo<int64_t>( b, stride );
 }
 
-//! @brief   Designate buffers to transfer data to/from a CompressedVectorNode in a block.
-//! @copydetails SourceDestBuffer::SourceDestBuffer(ImageFile,const ustring&,int8_t*,size_t,bool,bool,size_t)
-SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, bool *b, const size_t capacity,
-                                    bool doConversion, bool doScaling, size_t stride ) :
-   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion, doScaling ) )
+/// @overload
+SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, bool *b,
+                                    const size_t capacity, bool doConversion, bool doScaling,
+                                    size_t stride ) :
+   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion,
+                                    doScaling ) )
 {
    impl_->setTypeInfo<bool>( b, stride );
 }
 
-//! @brief   Designate buffers to transfer data to/from a CompressedVectorNode in a block.
-//! @copydetails SourceDestBuffer::SourceDestBuffer(ImageFile,const ustring&,int8_t*,size_t,bool,bool,size_t)
-SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, float *b, const size_t capacity,
-                                    bool doConversion, bool doScaling, size_t stride ) :
-   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion, doScaling ) )
+/// @overload
+SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, float *b,
+                                    const size_t capacity, bool doConversion, bool doScaling,
+                                    size_t stride ) :
+   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion,
+                                    doScaling ) )
 {
    impl_->setTypeInfo<float>( b, stride );
 }
 
-//! @brief   Designate buffers to transfer data to/from a CompressedVectorNode in a block.
-//! @copydetails SourceDestBuffer::SourceDestBuffer(ImageFile,const ustring&,int8_t*,size_t,bool,bool,size_t)
-SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, double *b, const size_t capacity,
-                                    bool doConversion, bool doScaling, size_t stride ) :
-   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion, doScaling ) )
+/// @overload
+SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, double *b,
+                                    const size_t capacity, bool doConversion, bool doScaling,
+                                    size_t stride ) :
+   impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, capacity, doConversion,
+                                    doScaling ) )
 {
    impl_->setTypeInfo<double>( b, stride );
 }
 
 /*!
-@brief   Designate vector of strings to transfer data to/from a CompressedVector as a block.
-@param   [in] destImageFile The ImageFile where the new node will eventually be stored.
-@param   [in] pathName      The pathname of the field in CompressedVectorNode that will transfer data to/from.
-@param   [in] b             The caller created vector of ustrings to transfer from/to.
+@brief Designate vector of strings to transfer data to/from a CompressedVector as a block.
+
+@param [in] destImageFile The ImageFile where the new node will eventually be stored.
+@param [in] pathName The pathname of the field in CompressedVectorNode that will transfer data
+to/from.
+@param [in] b The caller created vector of ustrings to transfer from/to.
+
 @details
-This overloaded form of the SourceDestBuffer constructor declares a
-vector<ustring> to be the source/destination of a transfer of StringNode values
-stored in a CompressedVectorNode.
+This overloaded form of the SourceDestBuffer constructor declares a vector<ustring> to be the
+source/destination of a transfer of StringNode values stored in a CompressedVectorNode.
 
-The @a pathName will be used to identify a Node in the prototype that will
-get/receive data from this buffer. The @a pathName may be an absolute path name
-(e.g. "/cartesianX") or a path name relative to the root of the prototype (i.e.
-the absolute path name without the leading "/", for example: "cartesianX").
+The @a pathName will be used to identify a Node in the prototype that will get/receive data from
+this buffer. The @a pathName may be an absolute path name (e.g. "/cartesianX") or a path name
+relative to the root of the prototype (i.e. the absolute path name without the leading "/", for
+example: "cartesianX").
 
-The @a b->size() must match capacity of all other SourceDestBuffers that will
-participate in a transfer with a CompressedVectorNode (string or any other type
-of buffer). In a read into the SourceDestBuffer, the previous contents of the
-strings in the vector are lost, and the memory space is potentially freed. The
-@a b->size() of the vector will not be changed. It is an error to request a
-read/write of more records that @a b->size() (just as it would be for buffers of
-integer types). The API user is responsible for ensuring that the lifetime of
-the @a b vector exceeds the time that it is used in transfers (i.e. the E57
-Foundation Implementation cannot detect that the buffer been destroyed).
+The @a b->size() must match capacity of all other SourceDestBuffers that will participate in a
+transfer with a CompressedVectorNode (string or any other type of buffer). In a read into the
+SourceDestBuffer, the previous contents of the strings in the vector are lost, and the memory space
+is potentially freed. The @a b->size() of the vector will not be changed. It is an error to request
+a read/write of more records that @a b->size() (just as it would be for buffers of integer types).
+The API user is responsible for ensuring that the lifetime of the @a b vector exceeds the time that
+it is used in transfers (i.e. the E57 Foundation Implementation cannot detect that the buffer been
+destroyed).
 
-@pre     b.size() must be > 0.
-@pre     The @a destImageFile must be open (i.e. destImageFile.isOpen() must be
-true).
-@throw   ::ErrorBadAPIArgument
-@throw   ::ErrorBadPathName
-@throw   ::ErrorBadBuffer
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     SourceDestBuffer::doConversion for discussion on representations compatible with string SourceDestBuffers.
+@pre b.size() must be > 0.
+@pre The @a destImageFile must be open (i.e. destImageFile.isOpen() must be true).
+
+@throw ::ErrorBadAPIArgument
+@throw ::ErrorBadPathName
+@throw ::ErrorBadBuffer
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see SourceDestBuffer::doConversion for discussion on representations compatible with string
+SourceDestBuffers.
 */
-SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName, std::vector<ustring> *b ) :
+SourceDestBuffer::SourceDestBuffer( ImageFile destImageFile, const ustring &pathName,
+                                    std::vector<ustring> *b ) :
    impl_( new SourceDestBufferImpl( destImageFile.impl(), pathName, b ) )
 {
 }
 
 /*!
-@brief   Get path name in prototype that this SourceDestBuffer will transfer
-data to/from.
-@details
-The prototype of a CompressedVectorNode describes the fields that are in each
-record. This function returns the path name of the node in the prototype tree
-that this SourceDestBuffer will write/read. The correctness of this path name is
-checked when this SourceDestBuffer is associated with a CompressedVectorNode
-(either in CompressedVectorNode::writer,
-CompressedVectorWriter::write(std::vector<SourceDestBuffer>&, unsigned),
-CompressedVectorNode::reader,
-CompressedVectorReader::read(std::vector<SourceDestBuffer>&)).
+@brief Get path name in prototype that this SourceDestBuffer will transfer data to/from.
 
-@post    No visible state is modified.
-@return  Path name in prototype that this SourceDestBuffer will transfer data
-to/from.
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     CompressedVector, CompressedVectorNode::prototype
+@details
+The prototype of a CompressedVectorNode describes the fields that are in each record. This function
+returns the path name of the node in the prototype tree that this SourceDestBuffer will write/read.
+The correctness of this path name is checked when this SourceDestBuffer is associated with a
+CompressedVectorNode (either in CompressedVectorNode::writer,
+CompressedVectorWriter::write(std::vector<SourceDestBuffer>&, unsigned),
+CompressedVectorNode::reader, CompressedVectorReader::read(std::vector<SourceDestBuffer>&)).
+
+@post No visible state is modified.
+
+@return Path name in prototype that this SourceDestBuffer will transfer data to/from.
+
+@throw ::ErrorInternal All objects in undocumented state
+
+@see CompressedVector, CompressedVectorNode::prototype
 */
 ustring SourceDestBuffer::pathName() const
 {
@@ -278,24 +339,27 @@ ustring SourceDestBuffer::pathName() const
 }
 
 /*!
-@brief   Get memory representation of the elements in this SourceDestBuffer.
-@details
-The memory representation is deduced from which overloaded SourceDestBuffer
-constructor was used. The memory representation is independent of the type and
-minimum/maximum bounds of the node in the prototype that the SourceDestBuffer
-will transfer to/from. However, some combinations will result in an error if
-doConversion is not requested (e.g. ::Int16 and FloatNode).
+@brief Get memory representation of the elements in this SourceDestBuffer.
 
-Some combinations risk an error occurring during a write, if a value is too
-large (e.g. writing an ::Int16 memory representation to an IntegerNode with
-minimum=-1024 maximum=1023). Some combinations risk an error occurring during a
-read, if a value is too large (e.g. reading an IntegerNode with minimum=-1024
-maximum=1023 int an ::Int8 memory representation). Some combinations are never
+@details
+The memory representation is deduced from which overloaded SourceDestBuffer constructor was used.
+The memory representation is independent of the type and minimum/maximum bounds of the node in the
+prototype that the SourceDestBuffer will transfer to/from. However, some combinations will result in
+an error if doConversion is not requested (e.g. ::Int16 and FloatNode).
+
+Some combinations risk an error occurring during a write, if a value is too large (e.g. writing an
+::Int16 memory representation to an IntegerNode with minimum=-1024 maximum=1023). Some combinations
+risk an error occurring during a read, if a value is too large (e.g. reading an IntegerNode with
+minimum=-1024 maximum=1023 int an ::Int8 memory representation). Some combinations are never
 possible (e.g. ::Int16 and StringNode).
-@post    No visible state is modified.
-@return  Memory representation of the elements in buffer.
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     MemoryRepresentation, NodeType
+
+@post No visible state is modified.
+
+@return Memory representation of the elements in buffer.
+
+@throw ::ErrorInternal All objects in undocumented state
+
+@see MemoryRepresentation, NodeType
 */
 MemoryRepresentation SourceDestBuffer::memoryRepresentation() const
 {
@@ -303,14 +367,18 @@ MemoryRepresentation SourceDestBuffer::memoryRepresentation() const
 }
 
 /*!
-@brief   Get total capacity of buffer.
+@brief Get total capacity of buffer.
+
 @details
-The API programmer is responsible for correctly specifying the length of a
-buffer. This function returns that declared length. If the length is incorrect
-(in particular, too long) memory may be corrupted or erroneous values written.
-@post    No visible state is modified.
-@return  Total capacity of buffer.
-@throw   ::ErrorInternal           All objects in undocumented state
+The API programmer is responsible for correctly specifying the length of a buffer. This function
+returns that declared length. If the length is incorrect (in particular, too long) memory may be
+corrupted or erroneous values written.
+
+@post No visible state is modified.
+
+@return Total capacity of buffer.
+
+@throw ::ErrorInternal All objects in undocumented state
 */
 size_t SourceDestBuffer::capacity() const
 {
@@ -318,33 +386,31 @@ size_t SourceDestBuffer::capacity() const
 }
 
 /*!
-@brief   Get whether conversions will be performed to match the memory type of
-buffer.
+@brief Get whether conversions will be performed to match the memory type of buffer.
+
 @details
-The API user must explicitly request conversion between basic representation
-groups in memory and on the disk. The four basic representation groups are:
-integer, boolean, floating point, and string. There is no distinction between
-integer and boolean groups on the disk (they both use IntegerNode). A explicit
-request for conversion between single and double precision floating point
-representations is not required.
+The API user must explicitly request conversion between basic representation groups in memory and on
+the disk. The four basic representation groups are: integer, boolean, floating point, and string.
+There is no distinction between integer and boolean groups on the disk (they both use IntegerNode).
+A explicit request for conversion between single and double precision floating point representations
+is not required.
 
-The most useful conversion is between integer and floating point representation
-groups. Conversion from integer to floating point representations cannot result
-in an overflow, and is usually loss-less (except for extremely large integers).
-Conversion from floating point to integer representations can result in an
-overflow, and can be lossy.
+The most useful conversion is between integer and floating point representation groups. Conversion
+from integer to floating point representations cannot result in an overflow, and is usually
+loss-less (except for extremely large integers). Conversion from floating point to integer
+representations can result in an overflow, and can be lossy.
 
-Conversion between any of the integer, boolean, and floating point
-representation groups is supported. No conversion from the string to any other
-representation group is possible. Missing or unsupported conversions are
-detected when the first transfer is attempted (i.e. not when the
+Conversion between any of the integer, boolean, and floating point representation groups is
+supported. No conversion from the string to any other representation group is possible. Missing or
+unsupported conversions are detected when the first transfer is attempted (i.e. not when the
 CompressedVectorReader or CompressedVectorWriter is created).
 
-@post    No visible state is modified.
-@return  true if conversions will be performed to match the memory type of
-buffer.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
+@post No visible state is modified.
+
+@return true if conversions will be performed to match the memory type of buffer.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
 */
 bool SourceDestBuffer::doConversion() const
 {
@@ -352,36 +418,36 @@ bool SourceDestBuffer::doConversion() const
 }
 
 /*!
-@brief   Get whether scaling will be performed for ScaledIntegerNode transfers.
+@brief Get whether scaling will be performed for ScaledIntegerNode transfers.
+
 @details
-The doScaling option only applies to ScaledIntegerNodes stored in a
-CompressedVectorNode on the disk (it is ignored if a ScaledIntegerNode is not
-involved).
+The doScaling option only applies to ScaledIntegerNodes stored in a CompressedVectorNode on the disk
+(it is ignored if a ScaledIntegerNode is not involved).
 
-As a convenience, an E57 Foundation Implementation can perform scaling of data
-so that the API user can manipulate scaledValues rather than rawValues. For a
-reader, the scaling process is: scaledValue = (rawValue * scale) + offset. For a
-writer, the scaling process is reversed: rawValue = (scaledValue - offset) /
-scale. The result performing a scaling in a reader (or "unscaling" in a writer)
-is always a floating point number. This floating point number may have to be
-converted to be compatible with the destination representation. If the
-destination representation is not floating point, there is a risk of violating
-declared min/max bounds. Because of this risk, it is recommended that scaling
-only be requested for reading scaledValues from ScaledIntegerNodes into floating
-point numbers in memory.
+As a convenience, an E57 Foundation Implementation can perform scaling of data so that the API user
+can manipulate scaledValues rather than rawValues. For a reader, the scaling process is: scaledValue
+= (rawValue * scale) + offset. For a writer, the scaling process is reversed: rawValue =
+(scaledValue - offset) / scale. The result performing a scaling in a reader (or "unscaling" in a
+writer) is always a floating point number. This floating point number may have to be converted to be
+compatible with the destination representation. If the destination representation is not floating
+point, there is a risk of violating declared min/max bounds. Because of this risk, it is recommended
+that scaling only be requested for reading scaledValues from ScaledIntegerNodes into floating point
+numbers in memory.
 
-It is also possible (and perhaps safest of all) to never request that scaling be
-performed, and always deal with rawValues outside the API. Note this does not
-mean that ScaledIntegerNodes should be avoided. ScaledIntgerNodes are essential
-for encoding numeric data with fractional parts in CompressedVectorNodes.
-Because the ASTM E57 format recommends that SI units without prefix be used
-(i.e. meters, not milli-meters or micro-furlongs), almost every measured value
-will have a fractional part.
+It is also possible (and perhaps safest of all) to never request that scaling be performed, and
+always deal with rawValues outside the API. Note this does not mean that ScaledIntegerNodes should
+be avoided. ScaledIntgerNodes are essential for encoding numeric data with fractional parts in
+CompressedVectorNodes. Because the ASTM E57 format recommends that SI units without prefix be used
+(i.e. meters, not milli-meters or micro-furlongs), almost every measured value will have a
+fractional part.
 
-@post    No visible state is modified.
-@return  true if scaling will be performed for ScaledInteger transfers.
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ScaledIntegerNode
+@post No visible state is modified.
+
+@return true if scaling will be performed for ScaledInteger transfers.
+
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ScaledIntegerNode
 */
 bool SourceDestBuffer::doScaling() const
 {
@@ -389,25 +455,27 @@ bool SourceDestBuffer::doScaling() const
 }
 
 /*!
-@brief   Get number of bytes between consecutive memory elements in buffer
+@brief Get number of bytes between consecutive memory elements in buffer
+
 @details
-Elements in a memory buffer do not have to be consecutive.
-They can also be spaced at regular intervals.
-This allows a value to be picked out of an array of C++ structures (the stride
-would be the size of the structure). In the case that the element values are
-stored consecutively in memory, the stride equals the size of the memory
-representation of the element.
-@post    No visible state is modified.
-@return  Number of bytes between consecutive memory elements in buffer
+Elements in a memory buffer do not have to be consecutive. They can also be spaced at regular
+intervals. This allows a value to be picked out of an array of C++ structures (the stride would be
+the size of the structure). In the case that the element values are stored consecutively in memory,
+the stride equals the size of the memory representation of the element.
+
+@post No visible state is modified.
+
+@return Number of bytes between consecutive memory elements in buffer
 */
 size_t SourceDestBuffer::stride() const
 {
    return impl_->stride();
 }
 
-//! @brief   Diagnostic function to print internal state of object to output
-//! stream in an indented format.
-//! @copydetails Node::dump()
+/*!
+@brief Diagnostic function to print internal state of object to output stream in an indented format.
+@copydetails Node::dump()
+*/
 #ifdef E57_DEBUG
 void SourceDestBuffer::dump( int indent, std::ostream &os ) const
 {

--- a/src/SourceDestBufferImpl.cpp
+++ b/src/SourceDestBufferImpl.cpp
@@ -33,11 +33,12 @@
 
 using namespace e57;
 
-SourceDestBufferImpl::SourceDestBufferImpl( ImageFileImplWeakPtr destImageFile, const ustring &pathName,
-                                            const size_t capacity, bool doConversion, bool doScaling ) :
+SourceDestBufferImpl::SourceDestBufferImpl( ImageFileImplWeakPtr destImageFile,
+                                            const ustring &pathName, const size_t capacity,
+                                            bool doConversion, bool doScaling ) :
    destImageFile_( destImageFile ),
-   pathName_( pathName ), memoryRepresentation_( Int32 ), capacity_( capacity ), doConversion_( doConversion ),
-   doScaling_( doScaling )
+   pathName_( pathName ), memoryRepresentation_( Int32 ), capacity_( capacity ),
+   doConversion_( doConversion ), doScaling_( doScaling )
 {
 }
 
@@ -106,8 +107,8 @@ template void SourceDestBufferImpl::setTypeInfo<bool>( bool *base, size_t stride
 template void SourceDestBufferImpl::setTypeInfo<float>( float *base, size_t stride );
 template void SourceDestBufferImpl::setTypeInfo<double>( double *base, size_t stride );
 
-SourceDestBufferImpl::SourceDestBufferImpl( ImageFileImplWeakPtr destImageFile, const ustring &pathName,
-                                            std::vector<ustring> *b ) :
+SourceDestBufferImpl::SourceDestBufferImpl( ImageFileImplWeakPtr destImageFile,
+                                            const ustring &pathName, std::vector<ustring> *b ) :
    destImageFile_( destImageFile ),
    pathName_( pathName ), memoryRepresentation_( UString ), ustrings_( b )
 {
@@ -256,7 +257,8 @@ template <typename T> void SourceDestBufferImpl::_setNextReal( T inValue )
          else
          {
 #ifdef _MSC_VER
-            // MSVC is not smart enough to realize 'inValue' cannot be a double here, so disable warning
+            // MSVC is not smart enough to realize 'inValue' cannot be a double here, so disable
+            // warning
 #pragma warning( disable : 4244 )
             *reinterpret_cast<float *>( p ) = inValue;
 #pragma warning( default : 4244 )
@@ -588,7 +590,8 @@ float SourceDestBufferImpl::getNextFloat()
          ///??? silently limit here?
          if ( d < DOUBLE_MIN || DOUBLE_MAX < d )
          {
-            throw E57_EXCEPTION2( ErrorReal64TooLarge, "pathName=" + pathName_ + " value=" + toString( d ) );
+            throw E57_EXCEPTION2( ErrorReal64TooLarge,
+                                  "pathName=" + pathName_ + " value=" + toString( d ) );
          }
          value = static_cast<float>( d );
          break;
@@ -729,42 +732,48 @@ void SourceDestBufferImpl::setNextInt64( int64_t value )
       case Int8:
          if ( value < INT8_MIN || INT8_MAX < value )
          {
-            throw E57_EXCEPTION2( ErrorValueNotRepresentable, "pathName=" + pathName_ + " value=" + toString( value ) );
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable,
+                                  "pathName=" + pathName_ + " value=" + toString( value ) );
          }
          *reinterpret_cast<int8_t *>( p ) = static_cast<int8_t>( value );
          break;
       case UInt8:
          if ( value < UINT8_MIN || UINT8_MAX < value )
          {
-            throw E57_EXCEPTION2( ErrorValueNotRepresentable, "pathName=" + pathName_ + " value=" + toString( value ) );
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable,
+                                  "pathName=" + pathName_ + " value=" + toString( value ) );
          }
          *reinterpret_cast<uint8_t *>( p ) = static_cast<uint8_t>( value );
          break;
       case Int16:
          if ( value < INT16_MIN || INT16_MAX < value )
          {
-            throw E57_EXCEPTION2( ErrorValueNotRepresentable, "pathName=" + pathName_ + " value=" + toString( value ) );
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable,
+                                  "pathName=" + pathName_ + " value=" + toString( value ) );
          }
          *reinterpret_cast<int16_t *>( p ) = static_cast<int16_t>( value );
          break;
       case UInt16:
          if ( value < UINT16_MIN || UINT16_MAX < value )
          {
-            throw E57_EXCEPTION2( ErrorValueNotRepresentable, "pathName=" + pathName_ + " value=" + toString( value ) );
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable,
+                                  "pathName=" + pathName_ + " value=" + toString( value ) );
          }
          *reinterpret_cast<uint16_t *>( p ) = static_cast<uint16_t>( value );
          break;
       case Int32:
          if ( value < INT32_MIN || INT32_MAX < value )
          {
-            throw E57_EXCEPTION2( ErrorValueNotRepresentable, "pathName=" + pathName_ + " value=" + toString( value ) );
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable,
+                                  "pathName=" + pathName_ + " value=" + toString( value ) );
          }
          *reinterpret_cast<int32_t *>( p ) = static_cast<int32_t>( value );
          break;
       case UInt32:
          if ( value < UINT32_MIN || UINT32_MAX < value )
          {
-            throw E57_EXCEPTION2( ErrorValueNotRepresentable, "pathName=" + pathName_ + " value=" + toString( value ) );
+            throw E57_EXCEPTION2( ErrorValueNotRepresentable,
+                                  "pathName=" + pathName_ + " value=" + toString( value ) );
          }
          *reinterpret_cast<uint32_t *>( p ) = static_cast<uint32_t>( value );
          break;
@@ -845,7 +854,8 @@ void SourceDestBufferImpl::setNextInt64( int64_t value, double scale, double off
          if ( scaledValue < INT8_MIN || INT8_MAX < scaledValue )
          {
             throw E57_EXCEPTION2( ErrorScaledValueNotRepresentable,
-                                  "pathName=" + pathName_ + " scaledValue=" + toString( scaledValue ) );
+                                  "pathName=" + pathName_ +
+                                     " scaledValue=" + toString( scaledValue ) );
          }
          *reinterpret_cast<int8_t *>( p ) = static_cast<int8_t>( scaledValue );
          break;
@@ -853,7 +863,8 @@ void SourceDestBufferImpl::setNextInt64( int64_t value, double scale, double off
          if ( scaledValue < UINT8_MIN || UINT8_MAX < scaledValue )
          {
             throw E57_EXCEPTION2( ErrorScaledValueNotRepresentable,
-                                  "pathName=" + pathName_ + " scaledValue=" + toString( scaledValue ) );
+                                  "pathName=" + pathName_ +
+                                     " scaledValue=" + toString( scaledValue ) );
          }
          *reinterpret_cast<uint8_t *>( p ) = static_cast<uint8_t>( scaledValue );
          break;
@@ -861,7 +872,8 @@ void SourceDestBufferImpl::setNextInt64( int64_t value, double scale, double off
          if ( scaledValue < INT16_MIN || INT16_MAX < scaledValue )
          {
             throw E57_EXCEPTION2( ErrorScaledValueNotRepresentable,
-                                  "pathName=" + pathName_ + " scaledValue=" + toString( scaledValue ) );
+                                  "pathName=" + pathName_ +
+                                     " scaledValue=" + toString( scaledValue ) );
          }
          *reinterpret_cast<int16_t *>( p ) = static_cast<int16_t>( scaledValue );
          break;
@@ -869,7 +881,8 @@ void SourceDestBufferImpl::setNextInt64( int64_t value, double scale, double off
          if ( scaledValue < UINT16_MIN || UINT16_MAX < scaledValue )
          {
             throw E57_EXCEPTION2( ErrorScaledValueNotRepresentable,
-                                  "pathName=" + pathName_ + " scaledValue=" + toString( scaledValue ) );
+                                  "pathName=" + pathName_ +
+                                     " scaledValue=" + toString( scaledValue ) );
          }
          *reinterpret_cast<uint16_t *>( p ) = static_cast<uint16_t>( scaledValue );
          break;
@@ -877,7 +890,8 @@ void SourceDestBufferImpl::setNextInt64( int64_t value, double scale, double off
          if ( scaledValue < INT32_MIN || INT32_MAX < scaledValue )
          {
             throw E57_EXCEPTION2( ErrorScaledValueNotRepresentable,
-                                  "pathName=" + pathName_ + " scaledValue=" + toString( scaledValue ) );
+                                  "pathName=" + pathName_ +
+                                     " scaledValue=" + toString( scaledValue ) );
          }
          *reinterpret_cast<int32_t *>( p ) = static_cast<int32_t>( scaledValue );
          break;
@@ -885,7 +899,8 @@ void SourceDestBufferImpl::setNextInt64( int64_t value, double scale, double off
          if ( scaledValue < UINT32_MIN || UINT32_MAX < scaledValue )
          {
             throw E57_EXCEPTION2( ErrorScaledValueNotRepresentable,
-                                  "pathName=" + pathName_ + " scaledValue=" + toString( scaledValue ) );
+                                  "pathName=" + pathName_ +
+                                     " scaledValue=" + toString( scaledValue ) );
          }
          *reinterpret_cast<uint32_t *>( p ) = static_cast<uint32_t>( scaledValue );
          break;
@@ -905,7 +920,8 @@ void SourceDestBufferImpl::setNextInt64( int64_t value, double scale, double off
          if ( scaledValue < DOUBLE_MIN || DOUBLE_MAX < scaledValue )
          {
             throw E57_EXCEPTION2( ErrorScaledValueNotRepresentable,
-                                  "pathName=" + pathName_ + " scaledValue=" + toString( scaledValue ) );
+                                  "pathName=" + pathName_ +
+                                     " scaledValue=" + toString( scaledValue ) );
          }
          *reinterpret_cast<float *>( p ) = static_cast<float>( scaledValue );
          break;
@@ -953,11 +969,13 @@ void SourceDestBufferImpl::setNextString( const ustring &value )
    nextIndex_++;
 }
 
-void SourceDestBufferImpl::checkCompatible( const std::shared_ptr<SourceDestBufferImpl> &newBuf ) const
+void SourceDestBufferImpl::checkCompatible(
+   const std::shared_ptr<SourceDestBufferImpl> &newBuf ) const
 {
    if ( pathName_ != newBuf->pathName() )
    {
-      throw E57_EXCEPTION2( ErrorBuffersNotCompatible, "pathName=" + pathName_ + " newPathName=" + newBuf->pathName() );
+      throw E57_EXCEPTION2( ErrorBuffersNotCompatible,
+                            "pathName=" + pathName_ + " newPathName=" + newBuf->pathName() );
    }
    if ( memoryRepresentation_ != newBuf->memoryRepresentation() )
    {
@@ -968,17 +986,20 @@ void SourceDestBufferImpl::checkCompatible( const std::shared_ptr<SourceDestBuff
    if ( capacity_ != newBuf->capacity() )
    {
       throw E57_EXCEPTION2( ErrorBuffersNotCompatible,
-                            "capacity=" + toString( capacity_ ) + " newCapacity=" + toString( newBuf->capacity() ) );
+                            "capacity=" + toString( capacity_ ) +
+                               " newCapacity=" + toString( newBuf->capacity() ) );
    }
    if ( doConversion_ != newBuf->doConversion() )
    {
-      throw E57_EXCEPTION2( ErrorBuffersNotCompatible, "doConversion=" + toString( doConversion_ ) +
-                                                          "newDoConversion=" + toString( newBuf->doConversion() ) );
+      throw E57_EXCEPTION2( ErrorBuffersNotCompatible,
+                            "doConversion=" + toString( doConversion_ ) +
+                               "newDoConversion=" + toString( newBuf->doConversion() ) );
    }
    if ( stride_ != newBuf->stride() )
    {
       throw E57_EXCEPTION2( ErrorBuffersNotCompatible,
-                            "stride=" + toString( stride_ ) + " newStride=" + toString( newBuf->stride() ) );
+                            "stride=" + toString( stride_ ) +
+                               " newStride=" + toString( newBuf->stride() ) );
    }
 }
 
@@ -1028,8 +1049,10 @@ void SourceDestBufferImpl::dump( int indent, std::ostream &os )
          os << "<unknown>" << std::endl;
          break;
    }
-   os << space( indent ) << "base:                 " << static_cast<const void *>( base_ ) << std::endl;
-   os << space( indent ) << "ustrings:             " << static_cast<const void *>( ustrings_ ) << std::endl;
+   os << space( indent ) << "base:                 " << static_cast<const void *>( base_ )
+      << std::endl;
+   os << space( indent ) << "ustrings:             " << static_cast<const void *>( ustrings_ )
+      << std::endl;
    os << space( indent ) << "capacity:             " << capacity_ << std::endl;
    os << space( indent ) << "doConversion:         " << doConversion_ << std::endl;
    os << space( indent ) << "doScaling:            " << doScaling_ << std::endl;

--- a/src/SourceDestBufferImpl.h
+++ b/src/SourceDestBufferImpl.h
@@ -36,12 +36,13 @@ namespace e57
    class SourceDestBufferImpl : public std::enable_shared_from_this<SourceDestBufferImpl>
    {
    public:
-      SourceDestBufferImpl( ImageFileImplWeakPtr destImageFile, const ustring &pathName, size_t capacity,
-                            bool doConversion = false, bool doScaling = false );
+      SourceDestBufferImpl( ImageFileImplWeakPtr destImageFile, const ustring &pathName,
+                            size_t capacity, bool doConversion = false, bool doScaling = false );
 
       template <typename T> void setTypeInfo( T *base, size_t stride = sizeof( T ) );
 
-      SourceDestBufferImpl( ImageFileImplWeakPtr destImageFile, const ustring &pathName, StringList *b );
+      SourceDestBufferImpl( ImageFileImplWeakPtr destImageFile, const ustring &pathName,
+                            StringList *b );
 
       ImageFileImplWeakPtr destImageFile() const
       {
@@ -118,23 +119,37 @@ namespace e57
    private:
       template <typename T> void _setNextReal( T inValue );
 
-      void checkState_() const; /// Common routine to check that constructor
-                                /// arguments were ok, throws if not
+      /// Common routine to check that constructor arguments were ok, throws if not
+      void checkState_() const;
 
-      //??? verify alignment
       ImageFileImplWeakPtr destImageFile_;
-      ustring pathName_;                          /// Pathname from CompressedVectorNode to source/dest
-                                                  /// object, e.g. "Indices/0"
-      MemoryRepresentation memoryRepresentation_; /// Type of element (e.g. ::Int8, ::UIin64, ::Real64...)
-      char *base_ = nullptr;                      /// Address of first element, for non-ustring buffers
-      size_t capacity_ = 0;                       /// Total number of elements in array
-      bool doConversion_ = false;                 /// Convert memory representation to/from disk representation
-      bool doScaling_ = false;                    /// Apply scale factor for integer type
-      size_t stride_ = 0;                         /// Distance between each element (different from size_
-                                                  /// if elements not contiguous)
-      unsigned nextIndex_ = 0;                    /// Number of elements that have been set (dest
-                                                  /// buffer) or read (source buffer) since rewind().
-      StringList *ustrings_ = nullptr;            /// Optional array of ustrings (used if
-                                                  /// memoryRepresentation_ == ::UString)
+
+      /// Pathname from CompressedVectorNode to source/dest  object, e.g. "Indices/0"
+      ustring pathName_;
+
+      /// Type of element (e.g. ::Int8, ::UIin64, ::Real64...)
+      MemoryRepresentation memoryRepresentation_;
+
+      /// Address of first element, for non-ustring buffers
+      char *base_ = nullptr;
+
+      /// Total number of elements in array
+      size_t capacity_ = 0;
+
+      /// Convert memory representation to/from disk representation
+      bool doConversion_ = false;
+
+      /// Apply scale factor for integer type
+      bool doScaling_ = false;
+
+      /// Distance between each element (different from size_ if elements not contiguous)
+      size_t stride_ = 0;
+
+      /// Number of elements that have been set (dest buffer) or read (source buffer) since
+      /// rewind().
+      unsigned nextIndex_ = 0;
+
+      /// Optional array of ustrings (used if memoryRepresentation_ == ::UString)
+      StringList *ustrings_ = nullptr;
    };
 }

--- a/src/StringFunctions.h
+++ b/src/StringFunctions.h
@@ -43,7 +43,8 @@ namespace e57
    /// @brief Convert number to decimal string
    template <class T> std::string toString( T x )
    {
-      static_assert( std::is_integral<T>::value || std::is_enum<T>::value || std::is_floating_point<T>::value,
+      static_assert( std::is_integral<T>::value || std::is_enum<T>::value ||
+                        std::is_floating_point<T>::value,
                      "Numeric type required." );
 
       std::ostringstream ss;
@@ -51,8 +52,7 @@ namespace e57
       return ss.str();
    }
 
-   /// @brief Convert number to a hexadecimal strings
-   /// @note Hex strings don't have leading zeros.
+   /// @overload
    inline std::string hexString( uint8_t x )
    {
       std::ostringstream ss;
@@ -90,7 +90,8 @@ namespace e57
       return hexString( static_cast<uint8_t>( x ) );
    }
 
-   /// @overload
+   /// @brief Convert number to a hexadecimal strings
+   /// @note Hex strings don't have leading zeros.
    inline std::string hexString( int16_t x )
    {
       return hexString( static_cast<uint16_t>( x ) );

--- a/src/StringNode.cpp
+++ b/src/StringNode.cpp
@@ -27,145 +27,18 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-//! @file StringNode.cpp
+/// @file StringNode.cpp
 
 #include "StringFunctions.h"
 #include "StringNodeImpl.h"
 
 using namespace e57;
 
+// Put this function first so we can reference the code in doxygen using @skip
 /*!
-@class e57::StringNode
-@brief   An E57 element encoding a Unicode character string value.
-@details
-A StringNode is a terminal node (i.e. having no children) that holds an Unicode
-character string encoded in UTF-8. Once the StringNode value is set at creation,
-it may not be modified.
-
-See Node class discussion for discussion of the common functions that
-StructureNode supports.
-
-@section StringNode_invariant Class Invariant
-A class invariant is a list of statements about an object that are always true
-before and after any operation on the object. An invariant is useful for testing
-correct operation of an implementation. Statements in an invariant can involve
-only externally visible state, or can refer to internal implementation-specific
-state that is not visible to the API user. The following C++ code checks
-externally visible state for consistency and throws an exception if the
-invariant is violated:
-@dontinclude StringNode.cpp
-@skip beginExample StringNode::checkInvariant
-@until endExample StringNode::checkInvariant
-
-@see     Node
+@brief Check whether StringNode class invariant is true
+@copydetails IntegerNode::checkInvariant()
 */
-
-/*!
-@brief   Create an element storing a Unicode character string.
-@param   [in] destImageFile The ImageFile where the new node will eventually be
-stored.
-@param   [in] value         The Unicode character string value of the element,
-in UTF-8 encoding.
-@details
-The StringNode class corresponds to the ASTM E57 standard String element.
-See the class discussion at bottom of StringNode page for more details.
-
-The @a destImageFile indicates which ImageFile the StringNode will eventually be
-attached to. A node is attached to an ImageFile by adding it underneath the
-predefined root of the ImageFile (gotten from ImageFile::root). It is not an
-error to fail to attach the StringNode to the @a destImageFile. It is an error
-to attempt to attach the StringNode to a different ImageFile.
-
-If the StringNode is to be used in a CompressedVectorNode prototype, it is
-recommended to specify a
-@a value = "" (the default value).
-@pre     The @a destImageFile must be open (i.e. destImageFile.isOpen() must be
-true).
-@pre     The @a destImageFile must have been opened in write mode (i.e.
-destImageFile.isWritable() must be true).
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorFileReadOnly
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     StringNode::value, Node, CompressedVectorNode, CompressedVectorNode::prototype
-*/
-StringNode::StringNode( ImageFile destImageFile, const ustring &value ) :
-   impl_( new StringNodeImpl( destImageFile.impl(), value ) )
-{
-}
-
-//! @brief   Is this a root node.
-//! @copydetails Node::isRoot()
-bool StringNode::isRoot() const
-{
-   return impl_->isRoot();
-}
-
-//! @brief   Return parent of node, or self if a root node.
-//! @copydetails Node::parent()
-Node StringNode::parent() const
-{
-   return Node( impl_->parent() );
-}
-
-//! @brief   Get absolute pathname of node.
-//! @copydetails Node::pathName()
-ustring StringNode::pathName() const
-{
-   return impl_->pathName();
-}
-
-//! @brief   Get elementName string, that identifies the node in its parent..
-//! @copydetails Node::elementName()
-ustring StringNode::elementName() const
-{
-   return impl_->elementName();
-}
-
-//! @brief   Get the ImageFile that was declared as the destination for the node
-//! when it was created.
-//! @copydetails Node::destImageFile()
-ImageFile StringNode::destImageFile() const
-{
-   return ImageFile( impl_->destImageFile() );
-}
-
-//! @brief   Has node been attached into the tree of an ImageFile.
-//! @copydetails Node::isAttached()
-bool StringNode::isAttached() const
-{
-   return impl_->isAttached();
-}
-
-/*!
-@brief   Get Unicode character string value stored.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  The Unicode character string value stored.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-*/
-ustring StringNode::value() const
-{
-   return impl_->value();
-}
-
-//! @brief   Diagnostic function to print internal state of object to output
-//! stream in an indented format.
-//! @copydetails Node::dump()
-#ifdef E57_DEBUG
-void StringNode::dump( int indent, std::ostream &os ) const
-{
-   impl_->dump( indent, os );
-}
-#else
-void StringNode::dump( int indent, std::ostream &os ) const
-{
-}
-#endif
-
-//! @brief Check whether StringNode class invariant is true
-//! @copydetails IntegerNode::checkInvariant()
-// beginExample StringNode::checkInvariant
 void StringNode::checkInvariant( bool /*doRecurse*/, bool doUpcast )
 {
    // If destImageFile not open, can't test invariant (almost every call would
@@ -180,17 +53,165 @@ void StringNode::checkInvariant( bool /*doRecurse*/, bool doUpcast )
    {
       static_cast<Node>( *this ).checkInvariant( false, false );
    }
-   /// ? check legal UTF-8
+   // ? check legal UTF-8
 }
-// endExample StringNode::checkInvariant
 
 /*!
-@brief   Upcast a StringNode handle to a generic Node handle.
-@details An upcast is always safe, and the compiler can automatically insert it
-for initializations of Node variables and Node function arguments.
+@class e57::StringNode
+
+@brief An E57 element encoding a Unicode character string value.
+
+@details
+A StringNode is a terminal node (i.e. having no children) that holds an Unicode character string
+encoded in UTF-8. Once the StringNode value is set at creation, it may not be modified.
+
+See Node class discussion for discussion of the common functions that StructureNode supports.
+
+@section StringNode_invariant Class Invariant
+A class invariant is a list of statements about an object that are always true before and after any
+operation on the object. An invariant is useful for testing correct operation of an implementation.
+Statements in an invariant can involve only externally visible state, or can refer to internal
+implementation-specific state that is not visible to the API user. The following C++ code checks
+externally visible state for consistency and throws an exception if the invariant is violated:
+
+@dontinclude StringNode.cpp
+@skip void StringNode::checkInvariant
+@until ^}
+
+@see Node
+*/
+
+/*!
+@brief Create an element storing a Unicode character string.
+
+@param [in] destImageFile The ImageFile where the new node will eventually be stored.
+@param [in] value The Unicode character string value of the element, in UTF-8 encoding.
+
+@details
+The StringNode class corresponds to the ASTM E57 standard String element. See the class discussion
+at bottom of StringNode page for more details.
+
+The @a destImageFile indicates which ImageFile the StringNode will eventually be attached to. A node
+is attached to an ImageFile by adding it underneath the predefined root of the ImageFile (gotten
+from ImageFile::root). It is not an error to fail to attach the StringNode to the @a destImageFile.
+It is an error to attempt to attach the StringNode to a different ImageFile.
+
+If the StringNode is to be used in a CompressedVectorNode prototype, it is recommended to specify a
+@a value = "" (the default value).
+
+@pre The @a destImageFile must be open (i.e. destImageFile.isOpen() must be true).
+@pre The @a destImageFile must have been opened in write mode (i.e. destImageFile.isWritable() must
+be true).
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorFileReadOnly
+@throw ::ErrorInternal All objects in undocumented state
+
+@see StringNode::value, Node, CompressedVectorNode, CompressedVectorNode::prototype
+*/
+StringNode::StringNode( ImageFile destImageFile, const ustring &value ) :
+   impl_( new StringNodeImpl( destImageFile.impl(), value ) )
+{
+}
+
+/*!
+@brief Is this a root node.
+@copydetails Node::isRoot()
+*/
+bool StringNode::isRoot() const
+{
+   return impl_->isRoot();
+}
+
+/*!
+@brief Return parent of node, or self if a root node.
+@copydetails Node::parent()
+*/
+Node StringNode::parent() const
+{
+   return Node( impl_->parent() );
+}
+
+/*!
+@brief Get absolute pathname of node.
+@copydetails Node::pathName()
+*/
+ustring StringNode::pathName() const
+{
+   return impl_->pathName();
+}
+
+/*!
+@brief Get elementName string, that identifies the node in its parent.
+@copydetails Node::elementName()
+*/
+ustring StringNode::elementName() const
+{
+   return impl_->elementName();
+}
+
+/*!
+@brief Get the ImageFile that was declared as the destination for the node when it was created.
+@copydetails Node::destImageFile()
+*/
+ImageFile StringNode::destImageFile() const
+{
+   return ImageFile( impl_->destImageFile() );
+}
+
+/*!
+@brief Has node been attached into the tree of an ImageFile.
+@copydetails Node::isAttached()
+*/
+bool StringNode::isAttached() const
+{
+   return impl_->isAttached();
+}
+
+/*!
+@brief Get Unicode character string value stored.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+
+@post No visible state is modified.
+
+@return  The Unicode character string value stored.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+*/
+ustring StringNode::value() const
+{
+   return impl_->value();
+}
+
+/*!
+@brief Diagnostic function to print internal state of object to output stream in an indented format.
+@copydetails Node::dump()
+*/
+#ifdef E57_DEBUG
+void StringNode::dump( int indent, std::ostream &os ) const
+{
+   impl_->dump( indent, os );
+}
+#else
+void StringNode::dump( int indent, std::ostream &os ) const
+{
+}
+#endif
+
+/*!
+@brief Upcast a StringNode handle to a generic Node handle.
+
+@details
+An upcast is always safe, and the compiler can automatically insert it for initializations of Node
+variables and Node function arguments.
+
 @return  A smart Node handle referencing the underlying object.
-@throw   No E57Exceptions.
-@see     Explanation in Node, Node::type(), StringNode(const Node&)
+
+@throw No E57Exceptions.
+
+@see Explanation in Node, Node::type(), StringNode(const Node&)
 */
 StringNode::operator Node() const
 {
@@ -200,15 +221,18 @@ StringNode::operator Node() const
 }
 
 /*!
-@brief   Downcast a generic Node handle to a StringNode handle.
-@param   [in] n The generic handle to downcast.
-@details The handle @a n must be for an underlying StringNode, otherwise an
-exception is thrown. In designs that need to avoid the exception, use
-Node::type() to determine the actual type of the @a n before downcasting. This
-function must be explicitly called (c++ compiler cannot insert it
-automatically).
-@throw   ::ErrorBadNodeDowncast
-@see     Node::type(), StringNode::operator Node()
+@brief Downcast a generic Node handle to a StringNode handle.
+
+@param [in] n The generic handle to downcast.
+
+@details
+The handle @a n must be for an underlying StringNode, otherwise an exception is thrown. In designs
+that need to avoid the exception, use Node::type() to determine the actual type of the @a n before
+downcasting. This function must be explicitly called (c++ compiler cannot insert it automatically).
+
+@throw ::ErrorBadNodeDowncast
+
+@see Node::type(), StringNode::operator Node()
 */
 StringNode::StringNode( const Node &n )
 {
@@ -221,9 +245,8 @@ StringNode::StringNode( const Node &n )
    impl_ = std::static_pointer_cast<StringNodeImpl>( n.impl() );
 }
 
-//! @cond documentNonPublic   The following isn't part of the API, and isn't
-//! documented.
+/// @cond documentNonPublic The following isn't part of the API, and isn't documented.
 StringNode::StringNode( std::shared_ptr<StringNodeImpl> ni ) : impl_( ni )
 {
 }
-//! @endcond
+/// @endcond

--- a/src/StringNodeImpl.cpp
+++ b/src/StringNodeImpl.cpp
@@ -41,15 +41,15 @@ namespace e57
    {
       // don't checkImageFileOpen
 
-      /// Same node type?
+      // Same node type?
       if ( ni->type() != TypeString )
       {
          return ( false );
       }
 
-      /// ignore value_, doesn't have to match
+      // ignore value_, doesn't have to match
 
-      /// Types match
+      // Types match
       return ( true );
    }
 
@@ -57,7 +57,7 @@ namespace e57
    {
       // don't checkImageFileOpen
 
-      /// We have no sub-structure, so if path not empty return false
+      // We have no sub-structure, so if path not empty return false
       return pathName.empty();
    }
 
@@ -71,7 +71,7 @@ namespace e57
    {
       // don't checkImageFileOpen
 
-      /// We are a leaf node, so verify that we are listed in set.
+      // We are a leaf node, so verify that we are listed in set.
       if ( pathNames.find( relativePathName( origin ) ) == pathNames.end() )
       {
          throw E57_EXCEPTION2( ErrorNoBufferForElement, "this->pathName=" + this->pathName() );
@@ -95,7 +95,7 @@ namespace e57
 
       cf << space( indent ) << "<" << fieldName << " type=\"String\"";
 
-      /// Write value as child text, unless it is the default value
+      // Write value as child text, unless it is the default value
       if ( value_.empty() )
       {
          cf << "/>\n";
@@ -107,27 +107,27 @@ namespace e57
          size_t currentPosition = 0;
          size_t len = value_.length();
 
-         /// Loop, searching for occurrences of "]]>", which will be split across
-         /// two CDATA directives
+         // Loop, searching for occurrences of "]]>", which will be split across two CDATA
+         // directives
          while ( currentPosition < len )
          {
             size_t found = value_.find( "]]>", currentPosition );
 
             if ( found == std::string::npos )
             {
-               /// Didn't find any more "]]>", so can send the rest.
+               // Didn't find any more "]]>", so can send the rest.
                cf << value_.substr( currentPosition );
                break;
             }
 
-            /// Must output in two pieces, first send up to end of "]]"  (don't send
-            /// the following ">").
+            // Must output in two pieces, first send up to end of "]]"  (don't send the following
+            // ">").
             cf << value_.substr( currentPosition, found - currentPosition + 2 );
 
-            /// Then start a new CDATA
+            // Then start a new CDATA
             cf << "]]><![CDATA[";
 
-            /// Keep looping to send the ">" plus the remaining part of the string
+            // Keep looping to send the ">" plus the remaining part of the string
             currentPosition = found + 2;
          }
          cf << "]]></" << fieldName << ">\n";

--- a/src/StructureNode.cpp
+++ b/src/StructureNode.cpp
@@ -27,254 +27,21 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-//! @file StructureNode.cpp
+/// @file StructureNode.cpp
 
 #include "StringFunctions.h"
 #include "StructureNodeImpl.h"
 
 using namespace e57;
 
+// Put this function first so we can reference the code in doxygen using @skip
 /*!
-@class e57::StructureNode
-@brief   An E57 element containing named child nodes.
-@details
-A StructureNode is a container of named child nodes, which may be any of the
-eight node types. The children of a structure node must have unique
-elementNames. Once a child node is set with a particular elementName, it may not
-be modified.
-
-See Node class discussion for discussion of the common functions that
-StructureNode supports.
-@section structurenode_invariant Class Invariant
-A class invariant is a list of statements about an object that are always true
-before and after any operation on the object. An invariant is useful for testing
-correct operation of an implementation. Statements in an invariant can involve
-only externally visible state, or can refer to internal implementation-specific
-state that is not visible to the API user. The following C++ code checks
-externally visible state for consistency and throws an exception if the
-invariant is violated:
-@dontinclude StructureNode.cpp
-@skip beginExample StructureNode::checkInvariant
-@until endExample StructureNode::checkInvariant
-
-@see     Node
+@brief Check whether StructureNode class invariant is true
+@copydetails IntegerNode::checkInvariant()
 */
-
-/*!
-@brief   Create an empty StructureNode.
-@param   [in] destImageFile   The ImageFile where the new node will eventually
-be stored.
-@details
-A StructureNode is a container for collections of named E57 nodes.
-The @a destImageFile indicates which ImageFile the StructureNode will eventually
-be attached to. A node is attached to an ImageFile by adding it underneath the
-predefined root of the ImageFile (gotten from ImageFile::root). It is not an
-error to fail to attach the StructureNode to the @a destImageFile. It is an
-error to attempt to attach the StructureNode to a different ImageFile.
-@pre     The @a destImageFile must be open (i.e. destImageFile.isOpen() must be
-true).
-@pre     The @a destImageFile must have been opened in write mode (i.e.
-destImageFile.isWritable() must be true).
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     Node
-*/
-StructureNode::StructureNode( ImageFile destImageFile ) : impl_( new StructureNodeImpl( destImageFile.impl() ) )
-{
-}
-
-//! @brief   Is this a root node.
-//! @copydetails Node::isRoot()
-bool StructureNode::isRoot() const
-{
-   return impl_->isRoot();
-}
-
-//! @brief   Return parent of node, or self if a root node.
-//! @copydetails Node::parent()
-Node StructureNode::parent() const
-{
-   return Node( impl_->parent() );
-}
-
-//! @brief   Get absolute pathname of node.
-//! @copydetails Node::pathName()
-ustring StructureNode::pathName() const
-{
-   return impl_->pathName();
-}
-
-//! @brief   Get elementName string, that identifies the node in its parent.
-//! @copydetails Node::elementName()
-ustring StructureNode::elementName() const
-{
-   return impl_->elementName();
-}
-
-//! @brief   Get the ImageFile that was declared as the destination for the node
-//! when it was created.
-//! @copydetails Node::destImageFile()
-ImageFile StructureNode::destImageFile() const
-{
-   return ImageFile( impl_->destImageFile() );
-}
-
-//! @brief   Has node been attached into the tree of an ImageFile.
-//! @copydetails Node::isAttached()
-bool StructureNode::isAttached() const
-{
-   return impl_->isAttached();
-}
-
-/*!
-@brief   Return number of child nodes contained by this StructureNode.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  Number of child nodes contained by this StructureNode.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     StructureNode::get(int64_t) const,
-StructureNode::set, VectorNode::childCount
-*/
-int64_t StructureNode::childCount() const
-{
-   return impl_->childCount();
-}
-
-/*!
-@brief   Is the given pathName defined relative to this node.
-@param   [in] pathName   The absolute pathname, or pathname relative to this
-object, to check.
-@details
-The @a pathName may be relative to this node, or absolute (starting with a "/").
-The origin of the absolute path name is the root of the tree that contains this
-StructureNode. If this StructureNode is not attached to an ImageFile, the @a
-pathName origin root will not the root node of an ImageFile.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  true if pathName is currently defined.
-@throw   ::ErrorBadPathName
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ImageFile::root, VectorNode::isDefined
-*/
-bool StructureNode::isDefined( const ustring &pathName ) const
-{
-   return impl_->isDefined( pathName );
-}
-
-/*!
-@brief   Get a child element by positional index.
-@param   [in] index   The index of child element to get, starting at 0.
-@details
-The order of children is not specified, and may be different than order the
-children were added to the StructureNode. The order of children may change if
-more children are added to the StructureNode.
-@pre     0 <= @a index < childCount()
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  A smart Node handle referencing the child node.
-@throw   ::ErrorChildIndexOutOfBounds
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     StructureNode::childCount,
-StructureNode::get(const ustring&) const, VectorNode::get
-*/
-Node StructureNode::get( int64_t index ) const
-{
-   return Node( impl_->get( index ) );
-}
-
-/*!
-@brief   Get a child by path name.
-@param   [in] pathName   The absolute pathname, or pathname relative to this
-object, of the object to get. The @a pathName may be relative to this node, or
-absolute (starting with a "/"). The origin of the absolute path name is the root
-of the tree that contains this StructureNode. If this StructureNode is not
-attached to an ImageFile, the @a pathName origin root will not the root node of
-an ImageFile.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@pre     The @a pathName must be defined (i.e. isDefined(pathName)).
-@post    No visible state is modified.
-@return  A smart Node handle referencing the child node.
-@throw   ::ErrorBadPathName
-@throw   ::ErrorPathUndefined
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     StructureNode::get(int64_t) const
-*/
-Node StructureNode::get( const ustring &pathName ) const
-{
-   return Node( impl_->get( pathName ) );
-}
-
-/*!
-@brief   Add a new child at a given path
-    @param   [in] pathName  The absolute pathname, or pathname relative to this
-object, that the child object @a n will be given.
-@param   [in] n         The node to be added to the tree with given @a pathName.
-@details
-The @a pathName may be relative to this node, or absolute (starting with a "/").
-The origin of the absolute path name is the root of the tree that contains this
-StructureNode. If this StructureNode is not attached to an ImageFile, the @a
-pathName origin root will not the root node of an ImageFile.
-
-The path name formed from all element names in @a pathName except the last must
-exist. If the @a pathName identifies the child of a VectorNode, then the last
-element name in @a pathName must be numeric, and be equal to the childCount of
-that VectorNode (the request is equivalent to VectorNode::append). The
-StructureNode must not be a descendent of a homogeneous VectorNode with more
-than one child.
-
-The element naming grammar specified by the ASTM E57 format standard are not
-enforced in this function. This would be very difficult to do dynamically, as
-some of the naming rules involve combinations of names.
-@pre     The new child node @a n must be a root node (i.e. n.isRoot()).
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@pre     The associated destImageFile must have been opened in write mode (i.e.
-destImageFile().isWritable()).
-@pre     The @a pathName must not already be defined (i.e.
-!isDefined(pathName)).
-@pre     The associated destImageFile of this StructureNode and of @a n must be
-same (i.e. destImageFile() == n.destImageFile()).
-@post    The @a pathName will be defined (i.e. isDefined(pathName)).
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorBadPathName
-@throw   ::ErrorPathUndefined
-@throw   ::ErrorSetTwice
-@throw   ::ErrorAlreadyHasParent
-@throw   ::ErrorDifferentDestImageFile
-@throw   ::ErrorHomogeneousViolation
-@throw   ::ErrorFileReadOnly
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     VectorNode::append
-*/
-void StructureNode::set( const ustring &pathName, const Node &n )
-{
-   impl_->set( pathName, n.impl(), false );
-}
-
-//! @brief   Diagnostic function to print internal state of object to output
-//! stream in an indented format.
-//! @copydetails Node::dump()
-#ifdef E57_DEBUG
-void StructureNode::dump( int indent, std::ostream &os ) const
-{
-   impl_->dump( indent, os );
-}
-#else
-void StructureNode::dump( int indent, std::ostream &os ) const
-{
-}
-#endif
-
-//! @brief Check whether StructureNode class invariant is true
-//! @copydetails IntegerNode::checkInvariant()
-// beginExample StructureNode::checkInvariant
 void StructureNode::checkInvariant( bool doRecurse, bool doUpcast )
 {
-   // If destImageFile not open, can't test invariant (almost every call would
-   // throw)
+   // If destImageFile not open, can't test invariant (almost every call would throw)
    if ( !destImageFile().isOpen() )
    {
       return;
@@ -317,33 +84,309 @@ void StructureNode::checkInvariant( bool doRecurse, bool doUpcast )
       }
    }
 }
-// endExample StructureNode::checkInvariant
 
 /*!
-@brief   Upcast a StructureNode handle to a generic Node handle.
-@details An upcast is always safe, and the compiler can automatically insert it
-for initializations of Node variables and Node function arguments.
-@return  A smart Node handle referencing the underlying object.
-@throw   No E57Exceptions.
-@see     explanation in Node, Node::type(), StructureNode(const Node&)
+@class e57::StructureNode
+
+@brief An E57 element containing named child nodes.
+
+@details
+A StructureNode is a container of named child nodes, which may be any of the eight node types. The
+children of a structure node must have unique elementNames. Once a child node is set with a
+particular elementName, it may not be modified.
+
+See Node class discussion for discussion of the common functions that StructureNode supports.
+
+@section structurenode_invariant Class Invariant
+A class invariant is a list of statements about an object that are always true before and after any
+operation on the object. An invariant is useful for testing correct operation of an implementation.
+Statements in an invariant can involve only externally visible state, or can refer to internal
+implementation-specific state that is not visible to the API user. The following C++ code checks
+externally visible state for consistency and throws an exception if the invariant is violated:
+
+@dontinclude StructureNode.cpp
+@skip void StructureNode::checkInvariant
+@until ^}
+
+@see Node
+*/
+
+/*!
+@brief Create an empty StructureNode.
+
+@param [in] destImageFile The ImageFile where the new node will eventually be stored.
+
+@details
+A StructureNode is a container for collections of named E57 nodes. The @a destImageFile indicates
+which ImageFile the StructureNode will eventually be attached to. A node is attached to an ImageFile
+by adding it underneath the predefined root of the ImageFile (gotten from ImageFile::root). It is
+not an error to fail to attach the StructureNode to the @a destImageFile. It is an error to attempt
+to attach the StructureNode to a different ImageFile.
+
+@pre The @a destImageFile must be open (i.e. destImageFile.isOpen() must be true).
+@pre The @a destImageFile must have been opened in write mode (i.e. destImageFile.isWritable() must
+be true).
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see Node
+*/
+StructureNode::StructureNode( ImageFile destImageFile ) :
+   impl_( new StructureNodeImpl( destImageFile.impl() ) )
+{
+}
+
+/*!
+@brief Is this a root node.
+@copydetails Node::isRoot()
+*/
+bool StructureNode::isRoot() const
+{
+   return impl_->isRoot();
+}
+
+/*!
+@brief Return parent of node, or self if a root node.
+@copydetails Node::parent()
+*/
+Node StructureNode::parent() const
+{
+   return Node( impl_->parent() );
+}
+
+/*!
+@brief Get absolute pathname of node.
+@copydetails Node::pathName()
+*/
+ustring StructureNode::pathName() const
+{
+   return impl_->pathName();
+}
+
+/*!
+@brief Get elementName string, that identifies the node in its parent.
+@copydetails Node::elementName()
+*/
+ustring StructureNode::elementName() const
+{
+   return impl_->elementName();
+}
+
+/*!
+@brief Get the ImageFile that was declared as the destination for the node when it was created.
+@copydetails Node::destImageFile()
+*/
+ImageFile StructureNode::destImageFile() const
+{
+   return ImageFile( impl_->destImageFile() );
+}
+
+/*!
+@brief Has node been attached into the tree of an ImageFile.
+@copydetails Node::isAttached()
+*/
+bool StructureNode::isAttached() const
+{
+   return impl_->isAttached();
+}
+
+/*!
+@brief Return number of child nodes contained by this StructureNode.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return Number of child nodes contained by this StructureNode.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see StructureNode::get(int64_t) const,
+StructureNode::set, VectorNode::childCount
+*/
+int64_t StructureNode::childCount() const
+{
+   return impl_->childCount();
+}
+
+/*!
+@brief Is the given pathName defined relative to this node.
+
+@param [in] pathName The absolute pathname, or pathname relative to this object, to check.
+
+@details
+The @a pathName may be relative to this node, or absolute (starting with a "/"). The origin of the
+absolute path name is the root of the tree that contains this StructureNode. If this StructureNode
+is not attached to an ImageFile, the @a pathName origin root will not the root node of an ImageFile.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return true if pathName is currently defined.
+
+@throw ::ErrorBadPathName
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ImageFile::root, VectorNode::isDefined
+*/
+bool StructureNode::isDefined( const ustring &pathName ) const
+{
+   return impl_->isDefined( pathName );
+}
+
+/*!
+@brief Get a child element by positional index.
+
+@param [in] index The index of child element to get, starting at 0.
+
+@details
+The order of children is not specified, and may be different than order the children were added to
+the StructureNode. The order of children may change if more children are added to the StructureNode.
+
+@pre 0 <= @a index < childCount()
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return A smart Node handle referencing the child node.
+
+@throw ::ErrorChildIndexOutOfBounds
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see StructureNode::childCount,
+StructureNode::get(const ustring&) const, VectorNode::get
+*/
+Node StructureNode::get( int64_t index ) const
+{
+   return Node( impl_->get( index ) );
+}
+
+/*!
+@brief Get a child by path name.
+
+@param [in] pathName The absolute pathname, or pathname relative to this object, of the object to
+get. The @a pathName may be relative to this node, or absolute (starting with a "/"). The origin of
+the absolute path name is the root of the tree that contains this StructureNode. If this
+StructureNode is not attached to an ImageFile, the @a pathName origin root will not the root node of
+an ImageFile.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@pre The @a pathName must be defined (i.e. isDefined(pathName)).
+@post No visible state is modified.
+
+@return A smart Node handle referencing the child node.
+
+@throw ::ErrorBadPathName
+@throw ::ErrorPathUndefined
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see StructureNode::get(int64_t) const
+*/
+Node StructureNode::get( const ustring &pathName ) const
+{
+   return Node( impl_->get( pathName ) );
+}
+
+/*!
+@brief Add a new child at a given path
+
+@param [in] pathName The absolute pathname, or pathname relative to this object, that the child
+object @a n will be given.
+@param [in] n The node to be added to the tree with given @a pathName.
+
+@details
+The @a pathName may be relative to this node, or absolute (starting with a "/"). The origin of the
+absolute path name is the root of the tree that contains this StructureNode. If this StructureNode
+is not attached to an ImageFile, the @a pathName origin root will not the root node of an ImageFile.
+
+The path name formed from all element names in @a pathName except the last must exist. If the @a
+pathName identifies the child of a VectorNode, then the last element name in @a pathName must be
+numeric, and be equal to the childCount of that VectorNode (the request is equivalent to
+VectorNode::append). The StructureNode must not be a descendent of a homogeneous VectorNode with
+more than one child.
+
+The element naming grammar specified by the ASTM E57 format standard are not enforced in this
+function. This would be very difficult to do dynamically, as some of the naming rules involve
+combinations of names.
+
+@pre The new child node @a n must be a root node (i.e. n.isRoot()).
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@pre The associated destImageFile must have been opened in write mode (i.e.
+destImageFile().isWritable()).
+@pre The @a pathName must not already be defined (i.e. !isDefined(pathName)).
+@pre The associated destImageFile of this StructureNode and of @a n must be same (i.e.
+destImageFile() == n.destImageFile()).
+@post The @a pathName will be defined (i.e. isDefined(pathName)).
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorBadPathName
+@throw ::ErrorPathUndefined
+@throw ::ErrorSetTwice
+@throw ::ErrorAlreadyHasParent
+@throw ::ErrorDifferentDestImageFile
+@throw ::ErrorHomogeneousViolation
+@throw ::ErrorFileReadOnly
+@throw ::ErrorInternal All objects in undocumented state
+
+@see VectorNode::append
+*/
+void StructureNode::set( const ustring &pathName, const Node &n )
+{
+   impl_->set( pathName, n.impl(), false );
+}
+
+/*!
+@brief Diagnostic function to print internal state of object to output stream in an indented format.
+@copydetails Node::dump()
+*/
+#ifdef E57_DEBUG
+void StructureNode::dump( int indent, std::ostream &os ) const
+{
+   impl_->dump( indent, os );
+}
+#else
+void StructureNode::dump( int indent, std::ostream &os ) const
+{
+}
+#endif
+
+/*!
+@brief Upcast a StructureNode handle to a generic Node handle.
+
+@details
+An upcast is always safe, and the compiler can automatically insert it for initializations of Node
+variables and Node function arguments.
+
+@return A smart Node handle referencing the underlying object.
+
+@throw No E57Exceptions.
+
+@see explanation in Node, Node::type(), StructureNode(const Node&)
 */
 StructureNode::operator Node() const
 {
-   /// Implicitly upcast from shared_ptr<StructureNodeImpl> to SharedNodeImplPtr
-   /// and construct a Node object
+   // Implicitly upcast from shared_ptr<StructureNodeImpl> to SharedNodeImplPtr and construct a Node
+   // object
    return Node( impl_ );
 }
 
 /*!
-@brief   Downcast a generic Node handle to a StructureNode handle.
-@param   [in] n The generic handle to downcast.
-@details The handle @a n must be for an underlying StructureNode, otherwise an
-exception is thrown. In designs that need to avoid the exception, use
-Node::type() to determine the actual type of the @a n before downcasting. This
-function must be explicitly called (c++ compiler cannot insert it
+@brief Downcast a generic Node handle to a StructureNode handle.
+
+@param [in] n The generic handle to downcast.
+
+@details
+The handle @a n must be for an underlying StructureNode, otherwise an exception is thrown. In
+designs that need to avoid the exception, use Node::type() to determine the actual type of the @a n
+before downcasting. This function must be explicitly called (c++ compiler cannot insert it
 automatically).
-@throw   ::ErrorBadNodeDowncast
-@see     Node::type(), StructureNode::operator Node()
+
+@throw ::ErrorBadNodeDowncast
+
+@see Node::type(), StructureNode::operator Node()
 */
 StructureNode::StructureNode( const Node &n )
 {
@@ -352,17 +395,17 @@ StructureNode::StructureNode( const Node &n )
       throw E57_EXCEPTION2( ErrorBadNodeDowncast, "nodeType=" + toString( n.type() ) );
    }
 
-   /// Set our shared_ptr to the downcast shared_ptr
+   // Set our shared_ptr to the downcast shared_ptr
    impl_ = std::static_pointer_cast<StructureNodeImpl>( n.impl() );
 }
 
-//! @cond documentNonPublic   The following isn't part of the API, and isn't
-//! documented.
-StructureNode::StructureNode( std::weak_ptr<ImageFileImpl> fileParent ) : impl_( new StructureNodeImpl( fileParent ) )
+/// @cond documentNonPublic The following isn't part of the API, and isn't documented.
+StructureNode::StructureNode( std::weak_ptr<ImageFileImpl> fileParent ) :
+   impl_( new StructureNodeImpl( fileParent ) )
 {
 }
 
 StructureNode::StructureNode( std::shared_ptr<StructureNodeImpl> ni ) : impl_( ni )
 {
 }
-//! @endcond
+/// @endcond

--- a/src/StructureNodeImpl.cpp
+++ b/src/StructureNodeImpl.cpp
@@ -34,42 +34,43 @@
 
 using namespace e57;
 
-StructureNodeImpl::StructureNodeImpl( ImageFileImplWeakPtr destImageFile ) : NodeImpl( destImageFile )
+StructureNodeImpl::StructureNodeImpl( ImageFileImplWeakPtr destImageFile ) :
+   NodeImpl( destImageFile )
 {
    checkImageFileOpen( __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) );
 }
 
 NodeType StructureNodeImpl::type() const
 {
-   /// don't checkImageFileOpen
+   // don't checkImageFileOpen
    return TypeStructure;
 }
 
 //??? use visitor?
 bool StructureNodeImpl::isTypeEquivalent( NodeImplSharedPtr ni )
 {
-   /// don't checkImageFileOpen
+   // don't checkImageFileOpen
 
-   /// Same node type?
+   // Same node type?
    if ( ni->type() != TypeStructure )
    {
       return ( false );
    }
 
-   /// Downcast to shared_ptr<StructureNodeImpl>
+   // Downcast to shared_ptr<StructureNodeImpl>
    std::shared_ptr<StructureNodeImpl> si( std::static_pointer_cast<StructureNodeImpl>( ni ) );
 
-   /// Same number of children?
+   // Same number of children?
    if ( childCount() != si->childCount() )
    {
       return ( false );
    }
 
-   /// Check each child is equivalent
+   // Check each child is equivalent
    for ( unsigned i = 0; i < childCount(); i++ )
    { //??? vector iterator?
       ustring myChildsFieldName = children_.at( i )->elementName();
-      /// Check if matching field name is in same position (to speed things up)
+      // Check if matching field name is in same position (to speed things up)
       if ( myChildsFieldName == si->children_.at( i )->elementName() )
       {
          if ( !children_.at( i )->isTypeEquivalent( si->children_.at( i ) ) )
@@ -79,8 +80,7 @@ bool StructureNodeImpl::isTypeEquivalent( NodeImplSharedPtr ni )
       }
       else
       {
-         /// Children in different order, so lookup by name and check if equal
-         /// to our child
+         // Children in different order, so lookup by name and check if equal to our child
          if ( !si->isDefined( myChildsFieldName ) )
          {
             return ( false );
@@ -92,7 +92,7 @@ bool StructureNodeImpl::isTypeEquivalent( NodeImplSharedPtr ni )
       }
    }
 
-   /// Types match
+   // Types match
    return ( true );
 }
 
@@ -105,10 +105,10 @@ bool StructureNodeImpl::isDefined( const ustring &pathName )
 
 void StructureNodeImpl::setAttachedRecursive()
 {
-   /// Mark this node as attached to an ImageFile
+   // Mark this node as attached to an ImageFile
    isAttached_ = true;
 
-   /// Not a leaf node, so mark all our children
+   // Not a leaf node, so mark all our children
    for ( auto &child : children_ )
    {
       child->setAttachedRecursive();
@@ -127,9 +127,9 @@ NodeImplSharedPtr StructureNodeImpl::get( int64_t index )
    checkImageFileOpen( __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) );
    if ( index < 0 || index >= static_cast<int64_t>( children_.size() ) )
    { // %%% Possible truncation on platforms where size_t = uint64
-      throw E57_EXCEPTION2( ErrorChildIndexOutOfBounds, "this->pathName=" + this->pathName() +
-                                                           " index=" + toString( index ) +
-                                                           " size=" + toString( children_.size() ) );
+      throw E57_EXCEPTION2( ErrorChildIndexOutOfBounds,
+                            "this->pathName=" + this->pathName() + " index=" + toString( index ) +
+                               " size=" + toString( children_.size() ) );
    }
    return ( children_.at( static_cast<unsigned>( index ) ) );
 }
@@ -141,14 +141,15 @@ NodeImplSharedPtr StructureNodeImpl::get( const ustring &pathName )
 
    if ( !ni )
    {
-      throw E57_EXCEPTION2( ErrorPathUndefined, "this->pathName=" + this->pathName() + " pathName=" + pathName );
+      throw E57_EXCEPTION2( ErrorPathUndefined,
+                            "this->pathName=" + this->pathName() + " pathName=" + pathName );
    }
    return ( ni );
 }
 
 NodeImplSharedPtr StructureNodeImpl::lookup( const ustring &pathName )
 {
-   /// don't checkImageFileOpen
+   // don't checkImageFileOpen
    //??? use lookup(fields, level) instead, for speed.
    bool isRelative;
    std::vector<ustring> fields;
@@ -161,14 +162,14 @@ NodeImplSharedPtr StructureNodeImpl::lookup( const ustring &pathName )
       {
          if ( isRelative )
          {
-            return NodeImplSharedPtr(); /// empty pointer
+            return NodeImplSharedPtr(); // empty pointer
          }
 
          NodeImplSharedPtr root( getRoot() );
          return ( root );
       }
 
-      /// Find child with elementName that matches first field in path
+      // Find child with elementName that matches first field in path
       unsigned i;
       for ( i = 0; i < children_.size(); i++ )
       {
@@ -179,7 +180,7 @@ NodeImplSharedPtr StructureNodeImpl::lookup( const ustring &pathName )
       }
       if ( i == children_.size() )
       {
-         return NodeImplSharedPtr(); /// empty pointer
+         return NodeImplSharedPtr(); // empty pointer
       }
 
       if ( fields.size() == 1 )
@@ -188,18 +189,18 @@ NodeImplSharedPtr StructureNodeImpl::lookup( const ustring &pathName )
       }
 
       //??? use level here rather than unparse
-      /// Remove first field in path
+      // Remove first field in path
       fields.erase( fields.begin() );
 
-      /// Call lookup on child object with remaining fields in path name
+      // Call lookup on child object with remaining fields in path name
       return children_.at( i )->lookup( imf->pathNameUnparse( true, fields ) );
    }
 
-   /// Absolute pathname and we aren't at the root
-   /// Find root of the tree
+   // Absolute pathname and we aren't at the root
+   // Find root of the tree
    NodeImplSharedPtr root( getRoot() );
 
-   /// Call lookup on root
+   // Call lookup on root
    return ( root->lookup( pathName ) );
 }
 
@@ -209,34 +210,36 @@ void StructureNodeImpl::set( int64_t index64, NodeImplSharedPtr ni )
 
    auto index = static_cast<unsigned>( index64 );
 
-   /// Allow index == current number of elements, interpret as append
+   // Allow index == current number of elements, interpret as append
    if ( index64 < 0 || index64 > UINT_MAX || index > children_.size() )
    {
-      throw E57_EXCEPTION2( ErrorChildIndexOutOfBounds, "this->pathName=" + this->pathName() +
-                                                           " index=" + toString( index64 ) +
-                                                           " size=" + toString( children_.size() ) );
+      throw E57_EXCEPTION2( ErrorChildIndexOutOfBounds,
+                            "this->pathName=" + this->pathName() + " index=" + toString( index64 ) +
+                               " size=" + toString( children_.size() ) );
    }
 
-   /// Enforce "set once" policy, only allow append
+   // Enforce "set once" policy, only allow append
    if ( index != children_.size() )
    {
-      throw E57_EXCEPTION2( ErrorSetTwice, "this->pathName=" + this->pathName() + " index=" + toString( index64 ) );
+      throw E57_EXCEPTION2( ErrorSetTwice, "this->pathName=" + this->pathName() +
+                                              " index=" + toString( index64 ) );
    }
 
-   /// Verify that child is destined for same ImageFile as this is
+   // Verify that child is destined for same ImageFile as this is
    ImageFileImplSharedPtr thisDest( destImageFile() );
    ImageFileImplSharedPtr niDest( ni->destImageFile() );
    if ( thisDest != niDest )
    {
       throw E57_EXCEPTION2( ErrorDifferentDestImageFile,
-                            "this->destImageFile" + thisDest->fileName() + " ni->destImageFile" + niDest->fileName() );
+                            "this->destImageFile" + thisDest->fileName() + " ni->destImageFile" +
+                               niDest->fileName() );
    }
 
-   /// Field name is string version of index value, e.g. "14"
+   // Field name is string version of index value, e.g. "14"
    std::stringstream elementName;
    elementName << index;
 
-   /// If this struct is type constrained, can't add new child
+   // If this struct is type constrained, can't add new child
    if ( isTypeConstrained() )
    {
       throw E57_EXCEPTION2( ErrorHomogeneousViolation, "this->pathName=" + this->pathName() );
@@ -255,31 +258,30 @@ void StructureNodeImpl::set( const ustring &pathName, NodeImplSharedPtr ni, bool
    // COMPRESSED_VECTOR
 
 #ifdef E57_MAX_VERBOSE
-   std::cout << "StructureNodeImpl::set(pathName=" << pathName << ", ni, autoPathCreate=" << autoPathCreate
-             << std::endl;
+   std::cout << "StructureNodeImpl::set(pathName=" << pathName
+             << ", ni, autoPathCreate=" << autoPathCreate << std::endl;
 #endif
 
    bool isRelative;
    std::vector<ustring> fields;
 
-   /// Path may be absolute or relative with several levels.  Break string into
-   /// individual levels.
+   // Path may be absolute or relative with several levels.  Break string into individual levels.
    ImageFileImplSharedPtr imf( destImageFile_ );
    imf->pathNameParse( pathName, isRelative, fields ); // throws if bad pathName
    if ( isRelative )
    {
-      /// Relative path, starting from current object, e.g. "foo/17/bar"
+      // Relative path, starting from current object, e.g. "foo/17/bar"
       set( fields, 0, ni, autoPathCreate );
    }
    else
    {
-      /// Absolute path (starting from root), e.g. "/foo/17/bar"
+      // Absolute path (starting from root), e.g. "/foo/17/bar"
       getRoot()->set( fields, 0, ni, autoPathCreate );
    }
 }
 
-void StructureNodeImpl::set( const std::vector<ustring> &fields, unsigned level, NodeImplSharedPtr ni,
-                             bool autoPathCreate )
+void StructureNodeImpl::set( const std::vector<ustring> &fields, unsigned level,
+                             NodeImplSharedPtr ni, bool autoPathCreate )
 {
 #ifdef E57_MAX_VERBOSE
    std::cout << "StructureNodeImpl::set: level=" << level << std::endl;
@@ -294,57 +296,56 @@ void StructureNodeImpl::set( const std::vector<ustring> &fields, unsigned level,
    // index, else throw
    // bad_path
 
-   /// Check if trying to set the root node "/", which is illegal
+   // Check if trying to set the root node "/", which is illegal
    if ( level == 0 && fields.empty() )
    {
       throw E57_EXCEPTION2( ErrorSetTwice, "this->pathName=" + this->pathName() + " element=/" );
    }
 
-   /// Serial search for matching field name, if find match, have error since
-   /// can't set twice
+   // Serial search for matching field name, if find match, have error since can't set twice
    for ( auto &child : children_ )
    {
       if ( fields.at( level ) == child->elementName() )
       {
          if ( level == fields.size() - 1 )
          {
-            /// Enforce "set once" policy, don't allow reset
-            throw E57_EXCEPTION2( ErrorSetTwice, "this->pathName=" + this->pathName() + " element=" + fields[level] );
+            // Enforce "set once" policy, don't allow reset
+            throw E57_EXCEPTION2( ErrorSetTwice, "this->pathName=" + this->pathName() +
+                                                    " element=" + fields[level] );
          }
 
-         /// Recurse on child
+         // Recurse on child
          child->set( fields, level + 1, ni );
 
          return;
       }
    }
-   /// Didn't find matching field name, so have a new child.
+   // Didn't find matching field name, so have a new child.
 
-   /// If this struct is type constrained, can't add new child
+   // If this struct is type constrained, can't add new child
    if ( isTypeConstrained() )
    {
       throw E57_EXCEPTION2( ErrorHomogeneousViolation, "this->pathName=" + this->pathName() );
    }
 
-   /// Check if we are at bottom level
+   // Check if we are at bottom level
    if ( level == fields.size() - 1 )
    {
-      /// At bottom, so append node at end of children
+      // At bottom, so append node at end of children
       ni->setParent( shared_from_this(), fields.at( level ) );
       children_.push_back( ni );
    }
    else
    {
-      /// Not at bottom level, if not autoPathCreate have an error
+      // Not at bottom level, if not autoPathCreate have an error
       if ( !autoPathCreate )
       {
-         throw E57_EXCEPTION2( ErrorPathUndefined,
-                               "this->pathName=" + this->pathName() + " field=" + fields.at( level ) );
+         throw E57_EXCEPTION2( ErrorPathUndefined, "this->pathName=" + this->pathName() +
+                                                      " field=" + fields.at( level ) );
       }
       //??? what if extra fields are numbers?
 
-      /// Do autoPathCreate: Create nested Struct objects for extra field names
-      /// in path
+      // Do autoPathCreate: Create nested Struct objects for extra field names in path
       NodeImplSharedPtr parent( shared_from_this() );
       for ( ; level != fields.size() - 1; level++ )
       {
@@ -358,18 +359,18 @@ void StructureNodeImpl::set( const std::vector<ustring> &fields, unsigned level,
 
 void StructureNodeImpl::append( NodeImplSharedPtr ni )
 {
-   /// don't checkImageFileOpen, set() will do it
+   // don't checkImageFileOpen, set() will do it
 
-   /// Create new node at end of list with integer field name
+   // Create new node at end of list with integer field name
    set( childCount(), ni );
 }
 
 //??? use visitor?
 void StructureNodeImpl::checkLeavesInSet( const StringSet &pathNames, NodeImplSharedPtr origin )
 {
-   /// don't checkImageFileOpen
+   // don't checkImageFileOpen
 
-   /// Not a leaf node, so check all our children
+   // Not a leaf node, so check all our children
    for ( auto &child : children_ )
    {
       child->checkLeavesInSet( pathNames, origin );
@@ -377,9 +378,10 @@ void StructureNodeImpl::checkLeavesInSet( const StringSet &pathNames, NodeImplSh
 }
 
 //??? use visitor?
-void StructureNodeImpl::writeXml( ImageFileImplSharedPtr imf, CheckedFile &cf, int indent, const char *forcedFieldName )
+void StructureNodeImpl::writeXml( ImageFileImplSharedPtr imf, CheckedFile &cf, int indent,
+                                  const char *forcedFieldName )
 {
-   /// don't checkImageFileOpen
+   // don't checkImageFileOpen
 
    ustring fieldName;
    if ( forcedFieldName != nullptr )
@@ -395,9 +397,9 @@ void StructureNodeImpl::writeXml( ImageFileImplSharedPtr imf, CheckedFile &cf, i
 
    const int numSpaces = indent + static_cast<int>( fieldName.length() ) + 2;
 
-   /// If this struct is the root for the E57 file, add name space declarations
-   /// Note the prototype of a CompressedVector is a separate tree, so don't
-   /// want to write out namespaces if not the ImageFile root
+   // If this struct is the root for the E57 file, add name space declarations. Note the prototype
+   // of a CompressedVector is a separate tree, so don't want to write out namespaces if not the
+   // ImageFile root
    if ( isRoot() && shared_from_this() == imf->root() )
    {
       bool gotDefaultNamespace = false;
@@ -421,8 +423,7 @@ void StructureNodeImpl::writeXml( ImageFileImplSharedPtr imf, CheckedFile &cf, i
             << imf->extensionsUri( index ) << "\"";
       }
 
-      /// If user didn't explicitly declare a default namespace, use the current
-      /// E57 standard one.
+      // If user didn't explicitly declare a default namespace, use the current E57 standard one.
       if ( !gotDefaultNamespace )
       {
          cf << "\n" << space( numSpaces ) << "xmlns=\"" << VERSION_1_0_URI << "\"";
@@ -432,18 +433,18 @@ void StructureNodeImpl::writeXml( ImageFileImplSharedPtr imf, CheckedFile &cf, i
    {
       cf << ">\n";
 
-      /// Write all children nested inside Structure element
+      // Write all children nested inside Structure element
       for ( auto &child : children_ )
       {
          child->writeXml( imf, cf, indent + 2 );
       }
 
-      /// Write closing tag
+      // Write closing tag
       cf << space( indent ) << "</" << fieldName << ">\n";
    }
    else
    {
-      /// XML element has no child elements
+      // XML element has no child elements
       cf << "/>\n";
    }
 }
@@ -452,7 +453,7 @@ void StructureNodeImpl::writeXml( ImageFileImplSharedPtr imf, CheckedFile &cf, i
 #ifdef E57_DEBUG
 void StructureNodeImpl::dump( int indent, std::ostream &os ) const
 {
-   /// don't checkImageFileOpen
+   // don't checkImageFileOpen
    os << space( indent ) << "type:        Structure"
       << " (" << type() << ")" << std::endl;
    NodeImpl::dump( indent, os );

--- a/src/StructureNodeImpl.h
+++ b/src/StructureNodeImpl.h
@@ -49,8 +49,10 @@ namespace e57
       NodeImplSharedPtr get( const ustring &pathName ) override;
 
       virtual void set( int64_t index, NodeImplSharedPtr ni );
-      void set( const ustring &pathName, NodeImplSharedPtr ni, bool autoPathCreate = false ) override;
-      void set( const StringList &fields, unsigned level, NodeImplSharedPtr ni, bool autoPathCreate = false ) override;
+      void set( const ustring &pathName, NodeImplSharedPtr ni,
+                bool autoPathCreate = false ) override;
+      void set( const StringList &fields, unsigned level, NodeImplSharedPtr ni,
+                bool autoPathCreate = false ) override;
       virtual void append( NodeImplSharedPtr ni );
 
       void checkLeavesInSet( const StringSet &pathNames, NodeImplSharedPtr origin ) override;
@@ -64,6 +66,7 @@ namespace e57
 
    protected:
       friend class CompressedVectorReaderImpl;
+
       NodeImplSharedPtr lookup( const ustring &pathName ) override;
 
       std::vector<NodeImplSharedPtr> children_;

--- a/src/VectorNode.cpp
+++ b/src/VectorNode.cpp
@@ -27,281 +27,21 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-//! @file VectorNode.cpp
+/// @file VectorNode.cpp
 
 #include "StringFunctions.h"
 #include "VectorNodeImpl.h"
 
 using namespace e57;
 
+// Put this function first so we can reference the code in doxygen using @skip
 /*!
-@class e57::VectorNode
-@brief   An E57 element containing ordered vector of child nodes.
-@details
-A VectorNode is a container of ordered child nodes.
-The child nodes are automatically assigned an elementName, which is a string
-version of the positional index of the child starting at "0". Child nodes may
-only be appended onto the end of a VectorNode.
-
-A VectorNode that is created with a restriction that its children must have the
-same type is called a "homogeneous VectorNode". A VectorNode without such a
-restriction is called a "heterogeneous VectorNode".
-
-See Node class discussion for discussion of the common functions that
-StructureNode supports.
-@section vectornode_invariant Class Invariant
-A class invariant is a list of statements about an object that are always true
-before and after any operation on the object. An invariant is useful for testing
-correct operation of an implementation. Statements in an invariant can involve
-only externally visible state, or can refer to internal implementation-specific
-state that is not visible to the API user. The following C++ code checks
-externally visible state for consistency and throws an exception if the
-invariant is violated:
-@dontinclude VectorNode.cpp
-@skip beginExample VectorNode::checkInvariant
-@until endExample VectorNode::checkInvariant
-
-@see     Node
+@brief Check whether VectorNode class invariant is true
+@copydetails IntegerNode::checkInvariant()
 */
-
-/*!
-@brief   Create a new empty Vector node.
-@param   [in] destImageFile         The ImageFile where the new node will
-eventually be stored.
-@param   [in] allowHeteroChildren   Will child elements of differing types be
-allowed in this VectorNode.
-@details
-A VectorNode is a ordered container of E57 nodes.
-The @a destImageFile indicates which ImageFile the VectorNode will eventually be
-attached to. A node is attached to an ImageFile by adding it underneath the
-predefined root of the ImageFile (gotten from ImageFile::root). It is not an
-error to fail to attach the VectorNode to the @a destImageFile. It is an error
-to attempt to attach the VectorNode to a different ImageFile.
-
-If @a allowHeteroChildren is false, then the children that are appended to the
-VectorNode must be identical in every visible characteristic except the stored
-values. These visible characteristics include number of children (for
-StructureNode and VectorNode descendents), number of records/prototypes/codecs
-(for CompressedVectorNode), minimum/maximum attributes (for IntegerNode,
-ScaledIntegerNode, FloatNode), byteCount (for BlobNode), scale/offset (for
-ScaledIntegerNode), and all elementNames. The enforcement of this homogeneity
-rule begins when the second child is appended to the VectorNode, thus it is not
-an error to modify a child of a homogeneous VectorNode containing only one
-child.
-
-If @a allowHeteroChildren is true, then the types of the children of the
-VectorNode are completely unconstrained.
-@pre     The @a destImageFile must be open (i.e. destImageFile.isOpen() must be
-true).
-@pre     The @a destImageFile must have been opened in write mode (i.e.
-destImageFile.isWritable() must be true).
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     Node, VectorNode::allowHeteroChildren, ::ErrorHomogeneousViolation
-*/
-VectorNode::VectorNode( ImageFile destImageFile, bool allowHeteroChildren ) :
-   impl_( new VectorNodeImpl( destImageFile.impl(), allowHeteroChildren ) )
-{
-}
-
-//! @brief   Is this a root node.
-//! @copydetails Node::isRoot()
-bool VectorNode::isRoot() const
-{
-   return impl_->isRoot();
-}
-
-//! @brief   Return parent of node, or self if a root node.
-//! @copydetails Node::parent()
-Node VectorNode::parent() const
-{
-   return Node( impl_->parent() );
-}
-
-//! @brief   Get absolute pathname of node.
-//! @copydetails Node::pathName()
-ustring VectorNode::pathName() const
-{
-   return impl_->pathName();
-}
-
-//! @brief   Get elementName string, that identifies the node in its parent..
-//! @copydetails Node::elementName()
-ustring VectorNode::elementName() const
-{
-   return impl_->elementName();
-}
-
-//! @brief   Get the ImageFile that was declared as the destination for the node
-//! when it was created.
-//! @copydetails Node::destImageFile()
-ImageFile VectorNode::destImageFile() const
-{
-   return ImageFile( impl_->destImageFile() );
-}
-
-//! @brief   Has node been attached into the tree of an ImageFile.
-//! @copydetails Node::isAttached()
-bool VectorNode::isAttached() const
-{
-   return impl_->isAttached();
-}
-
-/*!
-@brief   Get whether child elements are allowed to be different types?
-@details
-See the class discussion at bottom of VectorNode page for details of
-homogeneous/heterogeneous VectorNode. The returned attribute is determined when
-the VectorNode is created, and cannot be changed.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  True if child elements can be different types.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     ::ErrorHomogeneousViolation
-*/
-bool VectorNode::allowHeteroChildren() const
-{
-   return impl_->allowHeteroChildren();
-}
-
-/*!
-@brief   Get number of child elements in this VectorNode.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  Number of child elements in this VectorNode.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     VectorNode::get(int64_t), VectorNode::append, StructureNode::childCount
-*/
-int64_t VectorNode::childCount() const
-{
-   return impl_->childCount();
-}
-
-/*!
-@brief   Is the given pathName defined relative to this node.
-@param   [in] pathName   The absolute pathname, or pathname relative to this
-object, to check.
-@details
-The @a pathName may be relative to this node, or absolute (starting with a "/").
-The origin of the absolute path name is the root of the tree that contains this
-VectorNode. If this VectorNode is not attached to an ImageFile, the @a pathName
-origin root will not the root node of an ImageFile.
-
-The element names of child elements of VectorNodes are numbers, encoded as
-strings, starting at "0".
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@post    No visible state is modified.
-@return  true if pathName is currently defined.
-@throw   ::ErrorBadPathName
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     StructureNode::isDefined
-*/
-bool VectorNode::isDefined( const ustring &pathName ) const
-{
-   return impl_->isDefined( pathName );
-}
-
-/*!
-@brief   Get a child element by positional index.
-@param   [in] index   The index of child element to get, starting at 0.
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@pre     0 <= @a index < childCount()
-@post    No visible state is modified.
-@return  A smart Node handle referencing the child node.
-@throw   ::ErrorChildIndexOutOfBounds
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     VectorNode::childCount, VectorNode::append, StructureNode::get(int64_t) const
-*/
-Node VectorNode::get( int64_t index ) const
-{
-   return Node( impl_->get( index ) );
-}
-
-/*!
-@brief   Get a child element by string path name
-@param   [in] pathName   The pathname, either absolute or relative, of the
-object to get.
-@details
-The @a pathName may be relative to this node, or absolute (starting with a "/").
-The origin of the absolute path name is the root of the tree that contains this
-VectorNode. If this VectorNode is not attached to an ImageFile, the @a pathName
-origin root will not the root node of an ImageFile.
-
-The element names of child elements of VectorNodes are numbers, encoded as
-strings, starting at "0".
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@pre     The @a pathName must be defined (i.e. isDefined(pathName)).
-@post    No visible state is modified.
-@return  A smart Node handle referencing the child node.
-@throw   ::ErrorBadPathName
-@throw   ::ErrorPathUndefined
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     VectorNode::childCount, VectorNode::append, StructureNode::get(int64_t) const
-*/
-Node VectorNode::get( const ustring &pathName ) const
-{
-   return Node( impl_->get( pathName ) );
-}
-
-/*!
-@brief   Append a child element to end of VectorNode.
-@param   [in] n   The node to be added as a child at end of the VectorNode.
-@details
-If the VectorNode is homogeneous and already has at least one child, then @a n
-must be identical to the existing children in every visible characteristic
-except the stored values. These visible characteristics include number of
-children (for StructureNode and VectorNode descendents), number of
-records/prototypes/codecs (for CompressedVectorNode), minimum/maximum attributes
-(for IntegerNode, ScaledIntegerNode, FloatNode), byteCount (for BlobNode),
-scale/offset (for ScaledIntegerNode), and all elementNames.
-
-The VectorNode must not be a descendent of a homogeneous VectorNode with more
-than one child.
-@pre     The new child node @a n must be a root node (not already having a
-parent).
-@pre     The destination ImageFile must be open (i.e. destImageFile().isOpen()).
-@pre     The associated destImageFile must have been opened in write mode (i.e.
-destImageFile().isWritable()).
-@post    the childCount is incremented.
-@throw   ::ErrorImageFileNotOpen
-@throw   ::ErrorHomogeneousViolation
-@throw   ::ErrorFileReadOnly
-@throw   ::ErrorAlreadyHasParent
-@throw   ::ErrorDifferentDestImageFile
-@throw   ::ErrorInternal           All objects in undocumented state
-@see     VectorNode::childCount, VectorNode::get(int64_t), StructureNode::set
-*/
-void VectorNode::append( const Node &n )
-{
-   impl_->append( n.impl() );
-}
-
-//! @brief   Diagnostic function to print internal state of object to output
-//! stream in an indented format.
-//! @copydetails Node::dump()
-#ifdef E57_DEBUG
-void VectorNode::dump( int indent, std::ostream &os ) const
-{
-   impl_->dump( indent, os );
-}
-#else
-void VectorNode::dump( int indent, std::ostream &os ) const
-{
-}
-#endif
-
-//! @brief Check whether VectorNode class invariant is true
-//! @copydetails IntegerNode::checkInvariant()
-// beginExample VectorNode::checkInvariant
 void VectorNode::checkInvariant( bool doRecurse, bool doUpcast )
 {
-   // If destImageFile not open, can't test invariant (almost every call would
-   // throw)
+   // If destImageFile not open, can't test invariant (almost every call would throw)
    if ( !destImageFile().isOpen() )
    {
       return;
@@ -344,33 +84,336 @@ void VectorNode::checkInvariant( bool doRecurse, bool doUpcast )
       }
    }
 }
-// endExample VectorNode::checkInvariant
 
 /*!
-@brief   Upcast a VectorNode handle to a generic Node handle.
-@details An upcast is always safe, and the compiler can automatically insert it
-for initializations of Node variables and Node function arguments.
-@return  A smart Node handle referencing the underlying object.
-@throw   No E57Exceptions.
-@see     explanation in Node, Node::type(), VectorNode(const Node&)
+@class e57::VectorNode
+
+@brief An E57 element containing ordered vector of child nodes.
+
+@details
+A VectorNode is a container of ordered child nodes. The child nodes are automatically assigned an
+elementName, which is a string version of the positional index of the child starting at "0". Child
+nodes may only be appended onto the end of a VectorNode.
+
+A VectorNode that is created with a restriction that its children must have the same type is called
+a "homogeneous VectorNode". A VectorNode without such a restriction is called a "heterogeneous
+VectorNode".
+
+See Node class discussion for discussion of the common functions that StructureNode supports.
+
+@section vectornode_invariant Class Invariant
+A class invariant is a list of statements about an object that are always true before and after any
+operation on the object. An invariant is useful for testing correct operation of an implementation.
+Statements in an invariant can involve only externally visible state, or can refer to internal
+implementation-specific state that is not visible to the API user. The following C++ code checks
+externally visible state for consistency and throws an exception if the invariant is violated:
+
+@dontinclude VectorNode.cpp
+@skip void VectorNode::checkInvariant
+@until ^}
+
+@see Node
+*/
+
+/*!
+@brief Create a new empty Vector node.
+
+@param [in] destImageFile The ImageFile where the new node will eventually be stored.
+@param [in] allowHeteroChildren Will child elements of differing types be allowed in this
+VectorNode.
+
+@details
+A VectorNode is a ordered container of E57 nodes.
+
+The @a destImageFile indicates which ImageFile the VectorNode will eventually be attached to. A node
+is attached to an ImageFile by adding it underneath the predefined root of the ImageFile (gotten
+from ImageFile::root). It is not an error to fail to attach the VectorNode to the @a destImageFile.
+It is an error to attempt to attach the VectorNode to a different ImageFile.
+
+If @a allowHeteroChildren is false, then the children that are appended to the VectorNode must be
+identical in every visible characteristic except the stored values. These visible characteristics
+include number of children (for StructureNode and VectorNode descendents), number of
+records/prototypes/codecs (for CompressedVectorNode), minimum/maximum attributes (for IntegerNode,
+ScaledIntegerNode, FloatNode), byteCount (for BlobNode), scale/offset (for ScaledIntegerNode), and
+all elementNames. The enforcement of this homogeneity rule begins when the second child is appended
+to the VectorNode, thus it is not an error to modify a child of a homogeneous VectorNode containing
+only one child.
+
+If @a allowHeteroChildren is true, then the types of the children of the VectorNode are completely
+unconstrained.
+
+@pre The @a destImageFile must be open (i.e. destImageFile.isOpen() must be true).
+@pre The @a destImageFile must have been opened in write mode (i.e. destImageFile.isWritable() must
+be true).
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see Node, VectorNode::allowHeteroChildren, ::ErrorHomogeneousViolation
+*/
+VectorNode::VectorNode( ImageFile destImageFile, bool allowHeteroChildren ) :
+   impl_( new VectorNodeImpl( destImageFile.impl(), allowHeteroChildren ) )
+{
+}
+
+/*!
+@brief Is this a root node.
+@copydetails Node::isRoot()
+*/
+bool VectorNode::isRoot() const
+{
+   return impl_->isRoot();
+}
+
+/*!
+@brief Return parent of node, or self if a root node.
+@copydetails Node::parent()
+*/
+Node VectorNode::parent() const
+{
+   return Node( impl_->parent() );
+}
+
+/*!
+@brief Get absolute pathname of node.
+@copydetails Node::pathName()
+*/
+ustring VectorNode::pathName() const
+{
+   return impl_->pathName();
+}
+
+/*!
+@brief Get elementName string, that identifies the node in its parent.
+@copydetails Node::elementName()
+*/
+ustring VectorNode::elementName() const
+{
+   return impl_->elementName();
+}
+
+/*!
+@brief Get the ImageFile that was declared as the destination for the node when it was created.
+@copydetails Node::destImageFile()
+*/
+ImageFile VectorNode::destImageFile() const
+{
+   return ImageFile( impl_->destImageFile() );
+}
+
+/*!
+@brief Has node been attached into the tree of an ImageFile.
+@copydetails Node::isAttached()
+*/
+bool VectorNode::isAttached() const
+{
+   return impl_->isAttached();
+}
+
+/*!
+@brief Get whether child elements are allowed to be different types
+
+@details
+See the class discussion at bottom of VectorNode page for details of homogeneous/heterogeneous
+VectorNode. The returned attribute is determined when the VectorNode is created, and cannot be
+changed.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return True if child elements can be different types.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see ::ErrorHomogeneousViolation
+*/
+bool VectorNode::allowHeteroChildren() const
+{
+   return impl_->allowHeteroChildren();
+}
+
+/*!
+@brief Get number of child elements in this VectorNode.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return Number of child elements in this VectorNode.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see VectorNode::get(int64_t), VectorNode::append, StructureNode::childCount
+*/
+int64_t VectorNode::childCount() const
+{
+   return impl_->childCount();
+}
+
+/*!
+@brief Is the given pathName defined relative to this node.
+
+@param [in] pathName The absolute pathname, or pathname relative to this object, to check.
+
+@details
+The @a pathName may be relative to this node, or absolute (starting with a "/"). The origin of the
+absolute path name is the root of the tree that contains this VectorNode. If this VectorNode is not
+attached to an ImageFile, the @a pathName origin root will not the root node of an ImageFile.
+
+The element names of child elements of VectorNodes are numbers, encoded as strings, starting at "0".
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@post No visible state is modified.
+
+@return true if pathName is currently defined.
+
+@throw ::ErrorBadPathName
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see StructureNode::isDefined
+*/
+bool VectorNode::isDefined( const ustring &pathName ) const
+{
+   return impl_->isDefined( pathName );
+}
+
+/*!
+@brief Get a child element by positional index.
+
+@param [in] index The index of child element to get, starting at 0.
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@pre 0 <= @a index < childCount()
+@post No visible state is modified.
+
+@return A smart Node handle referencing the child node.
+
+@throw ::ErrorChildIndexOutOfBounds
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see VectorNode::childCount, VectorNode::append, StructureNode::get(int64_t) const
+*/
+Node VectorNode::get( int64_t index ) const
+{
+   return Node( impl_->get( index ) );
+}
+
+/*!
+@brief Get a child element by string path name
+
+@param [in] pathName The pathname, either absolute or relative, of the object to get.
+
+@details
+The @a pathName may be relative to this node, or absolute (starting with a "/"). The origin of the
+absolute path name is the root of the tree that contains this VectorNode. If this VectorNode is not
+attached to an ImageFile, the @a pathName origin root will not the root node of an ImageFile.
+
+The element names of child elements of VectorNodes are numbers, encoded as strings, starting at "0".
+
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@pre The @a pathName must be defined (i.e. isDefined(pathName)).
+@post No visible state is modified.
+
+@return A smart Node handle referencing the child node.
+
+@throw ::ErrorBadPathName
+@throw ::ErrorPathUndefined
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorInternal All objects in undocumented state
+
+@see VectorNode::childCount, VectorNode::append, StructureNode::get(int64_t) const
+*/
+Node VectorNode::get( const ustring &pathName ) const
+{
+   return Node( impl_->get( pathName ) );
+}
+
+/*!
+@brief Append a child element to end of VectorNode.
+
+@param [in] n The node to be added as a child at end of the VectorNode.
+
+@details
+If the VectorNode is homogeneous and already has at least one child, then @a n must be identical to
+the existing children in every visible characteristic except the stored values. These visible
+characteristics include number of children (for StructureNode and VectorNode descendents), number of
+records/prototypes/codecs (for CompressedVectorNode), minimum/maximum attributes (for IntegerNode,
+ScaledIntegerNode, FloatNode), byteCount (for BlobNode), scale/offset (for ScaledIntegerNode), and
+all elementNames.
+
+The VectorNode must not be a descendent of a homogeneous VectorNode with more than one child.
+
+@pre The new child node @a n must be a root node (not already having a parent).
+@pre The destination ImageFile must be open (i.e. destImageFile().isOpen()).
+@pre The associated destImageFile must have been opened in write mode (i.e.
+destImageFile().isWritable()).
+@post the childCount is incremented.
+
+@throw ::ErrorImageFileNotOpen
+@throw ::ErrorHomogeneousViolation
+@throw ::ErrorFileReadOnly
+@throw ::ErrorAlreadyHasParent
+@throw ::ErrorDifferentDestImageFile
+@throw ::ErrorInternal All objects in undocumented state
+
+@see VectorNode::childCount, VectorNode::get(int64_t), StructureNode::set
+*/
+void VectorNode::append( const Node &n )
+{
+   impl_->append( n.impl() );
+}
+
+/*!
+@brief Diagnostic function to print internal state of object to output stream in an indented format.
+@copydetails Node::dump()
+*/
+#ifdef E57_DEBUG
+void VectorNode::dump( int indent, std::ostream &os ) const
+{
+   impl_->dump( indent, os );
+}
+#else
+void VectorNode::dump( int indent, std::ostream &os ) const
+{
+}
+#endif
+
+/*!
+@brief Upcast a VectorNode handle to a generic Node handle.
+
+@details
+An upcast is always safe, and the compiler can automatically insert it for initializations of Node
+variables and Node function arguments.
+
+@return A smart Node handle referencing the underlying object.
+
+@throw No E57Exceptions.
+
+@see explanation in Node, Node::type(), VectorNode(const Node&)
 */
 VectorNode::operator Node() const
 {
-   /// Implicitly upcast from shared_ptr<VectorNodeImpl> to SharedNodeImplPtr
-   /// and construct a Node object
+   // Implicitly upcast from shared_ptr<VectorNodeImpl> to SharedNodeImplPtr and construct a Node
+   // object
    return Node( impl_ );
 }
 
 /*!
-@brief   Downcast a generic Node handle to a VectorNode handle.
-@param   [in] n The generic handle to downcast.
-@details The handle @a n must be for an underlying VectorNode, otherwise an
-exception is thrown. In designs that need to avoid the exception, use
-Node::type() to determine the actual type of the @a n before downcasting. This
-function must be explicitly called (c++ compiler cannot insert it
-automatically).
-@throw   ::ErrorBadNodeDowncast
-@see     Node::type(), VectorNode::operator Node()
+@brief Downcast a generic Node handle to a VectorNode handle.
+
+@param [in] n The generic handle to downcast.
+
+@details
+The handle @a n must be for an underlying VectorNode, otherwise an exception is thrown. In designs
+that need to avoid the exception, use Node::type() to determine the actual type of the @a n before
+downcasting. This function must be explicitly called (c++ compiler cannot insert it automatically).
+
+@throw ::ErrorBadNodeDowncast
+
+@see Node::type(), VectorNode::operator Node()
 */
 VectorNode::VectorNode( const Node &n )
 {
@@ -379,13 +422,12 @@ VectorNode::VectorNode( const Node &n )
       throw E57_EXCEPTION2( ErrorBadNodeDowncast, "nodeType=" + toString( n.type() ) );
    }
 
-   /// Set our shared_ptr to the downcast shared_ptr
+   // Set our shared_ptr to the downcast shared_ptr
    impl_ = std::static_pointer_cast<VectorNodeImpl>( n.impl() );
 }
 
-//! @cond documentNonPublic   The following isn't part of the API, and isn't
-//! documented.
+/// @cond documentNonPublic The following isn't part of the API, and isn't documented.
 VectorNode::VectorNode( std::shared_ptr<VectorNodeImpl> ni ) : impl_( ni )
 {
 }
-//! @endcond
+/// @endcond

--- a/src/VectorNodeImpl.cpp
+++ b/src/VectorNodeImpl.cpp
@@ -34,14 +34,14 @@ namespace e57
    VectorNodeImpl::VectorNodeImpl( ImageFileImplWeakPtr destImageFile, bool allowHeteroChildren ) :
       StructureNodeImpl( destImageFile ), allowHeteroChildren_( allowHeteroChildren )
    {
-      /// don't checkImageFileOpen, StructNodeImpl() will do it
+      // don't checkImageFileOpen, StructNodeImpl() will do it
    }
 
    bool VectorNodeImpl::isTypeEquivalent( NodeImplSharedPtr ni )
    {
-      /// don't checkImageFileOpen
+      // don't checkImageFileOpen
 
-      /// Same node type?
+      // Same node type?
       if ( ni->type() != TypeVector )
       {
          return ( false );
@@ -49,19 +49,19 @@ namespace e57
 
       std::shared_ptr<VectorNodeImpl> ai( std::static_pointer_cast<VectorNodeImpl>( ni ) );
 
-      /// allowHeteroChildren must match
+      // allowHeteroChildren must match
       if ( allowHeteroChildren_ != ai->allowHeteroChildren_ )
       {
          return ( false );
       }
 
-      /// Same number of children?
+      // Same number of children?
       if ( childCount() != ai->childCount() )
       {
          return ( false );
       }
 
-      /// Check each child, must be in same order
+      // Check each child, must be in same order
       for ( unsigned i = 0; i < childCount(); i++ )
       {
          if ( !children_.at( i )->isTypeEquivalent( ai->children_.at( i ) ) )
@@ -70,7 +70,7 @@ namespace e57
          }
       }
 
-      /// Types match
+      // Types match
       return ( true );
    }
 
@@ -85,23 +85,25 @@ namespace e57
       checkImageFileOpen( __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) );
       if ( !allowHeteroChildren_ )
       {
-         /// New node type must match all existing children
+         // New node type must match all existing children
          for ( auto &child : children_ )
          {
             if ( !child->isTypeEquivalent( ni ) )
             {
-               throw E57_EXCEPTION2( ErrorHomogeneousViolation, "this->pathName=" + this->pathName() );
+               throw E57_EXCEPTION2( ErrorHomogeneousViolation,
+                                     "this->pathName=" + this->pathName() );
             }
          }
       }
 
-      ///??? for now, use base implementation
+      //??? for now, use base implementation
       StructureNodeImpl::set( index64, ni );
    }
 
-   void VectorNodeImpl::writeXml( ImageFileImplSharedPtr imf, CheckedFile &cf, int indent, const char *forcedFieldName )
+   void VectorNodeImpl::writeXml( ImageFileImplSharedPtr imf, CheckedFile &cf, int indent,
+                                  const char *forcedFieldName )
    {
-      /// don't checkImageFileOpen
+      // don't checkImageFileOpen
 
       ustring fieldName;
       if ( forcedFieldName != nullptr )
@@ -125,7 +127,7 @@ namespace e57
 #ifdef E57_DEBUG
    void VectorNodeImpl::dump( int indent, std::ostream &os ) const
    {
-      /// don't checkImageFileOpen
+      // don't checkImageFileOpen
       os << space( indent ) << "type:        Vector"
          << " (" << type() << ")" << std::endl;
       NodeImpl::dump( indent, os );

--- a/src/WriterImpl.cpp
+++ b/src/WriterImpl.cpp
@@ -33,14 +33,17 @@
 
 namespace e57
 {
-   //! @brief This function writes the projection image
-   //! @param image 1 of 3 projects or the visual
-   //! @param imageType identifies the image format desired.
-   //! @param pBuffer pointer the buffer
-   //! @param start position in the block to start reading
-   //! @param count size of desired chunk or buffer size
-   static size_t _writeImage2DNode( const StructureNode &image, Image2DType imageType, uint8_t *pBuffer, int64_t start,
-                                    size_t count )
+   /*!
+   @brief This function writes the projection image
+
+   @param image 1 of 3 projects or the visual
+   @param imageType identifies the image format desired.
+   @param pBuffer pointer the buffer
+   @param start position in the block to start reading
+   @param count size of desired chunk or buffer size
+   */
+   static size_t _writeImage2DNode( const StructureNode &image, Image2DType imageType,
+                                    uint8_t *pBuffer, int64_t start, size_t count )
    {
       size_t transferred = 0;
 
@@ -85,7 +88,8 @@ namespace e57
    {
       // We are using the E57 v1.0 data format standard fieldnames.
       // The standard fieldnames are used without an extension prefix (in the default namespace).
-      // We explicitly register it for completeness (the reference implementation would do it for us, if we didn't).
+      // We explicitly register it for completeness (the reference implementation would do it for
+      // us, if we didn't).
       imf_.extensionsAdd( "", e57::VERSION_1_0_URI );
 
       // Set per-file properties.
@@ -197,7 +201,8 @@ namespace e57
 
       if ( !image2DHeader.associatedData3DGuid.empty() )
       {
-         image.set( "associatedData3DGuid", StringNode( imf_, image2DHeader.associatedData3DGuid ) );
+         image.set( "associatedData3DGuid",
+                    StringNode( imf_, image2DHeader.associatedData3DGuid ) );
       }
 
       if ( image2DHeader.acquisitionDateTime.dateTimeValue > 0.0 )
@@ -205,9 +210,11 @@ namespace e57
          StructureNode acquisitionDateTime( imf_ );
 
          image.set( "acquisitionDateTime", acquisitionDateTime );
-         acquisitionDateTime.set( "dateTimeValue", FloatNode( imf_, image2DHeader.acquisitionDateTime.dateTimeValue ) );
-         acquisitionDateTime.set( "isAtomicClockReferenced",
-                                  IntegerNode( imf_, image2DHeader.acquisitionDateTime.isAtomicClockReferenced ) );
+         acquisitionDateTime.set(
+            "dateTimeValue", FloatNode( imf_, image2DHeader.acquisitionDateTime.dateTimeValue ) );
+         acquisitionDateTime.set(
+            "isAtomicClockReferenced",
+            IntegerNode( imf_, image2DHeader.acquisitionDateTime.isAtomicClockReferenced ) );
       }
 
       // Create pose structure for image.
@@ -239,23 +246,28 @@ namespace e57
          if ( image2DHeader.visualReferenceRepresentation.jpegImageSize > 0 )
          {
             visualReferenceRepresentation.set(
-               "jpegImage", BlobNode( imf_, image2DHeader.visualReferenceRepresentation.jpegImageSize ) );
+               "jpegImage",
+               BlobNode( imf_, image2DHeader.visualReferenceRepresentation.jpegImageSize ) );
          }
          else if ( image2DHeader.visualReferenceRepresentation.pngImageSize > 0 )
          {
             visualReferenceRepresentation.set(
-               "pngImage", BlobNode( imf_, image2DHeader.visualReferenceRepresentation.pngImageSize ) );
+               "pngImage",
+               BlobNode( imf_, image2DHeader.visualReferenceRepresentation.pngImageSize ) );
          }
          if ( image2DHeader.visualReferenceRepresentation.imageMaskSize > 0 )
          {
             visualReferenceRepresentation.set(
-               "imageMask", BlobNode( imf_, image2DHeader.visualReferenceRepresentation.imageMaskSize ) );
+               "imageMask",
+               BlobNode( imf_, image2DHeader.visualReferenceRepresentation.imageMaskSize ) );
          }
 
          visualReferenceRepresentation.set(
-            "imageHeight", IntegerNode( imf_, image2DHeader.visualReferenceRepresentation.imageHeight ) );
+            "imageHeight",
+            IntegerNode( imf_, image2DHeader.visualReferenceRepresentation.imageHeight ) );
          visualReferenceRepresentation.set(
-            "imageWidth", IntegerNode( imf_, image2DHeader.visualReferenceRepresentation.imageWidth ) );
+            "imageWidth",
+            IntegerNode( imf_, image2DHeader.visualReferenceRepresentation.imageWidth ) );
       }
       else if ( image2DHeader.pinholeRepresentation.jpegImageSize > 0 ||
                 image2DHeader.pinholeRepresentation.pngImageSize > 0 )
@@ -265,29 +277,36 @@ namespace e57
 
          if ( image2DHeader.pinholeRepresentation.jpegImageSize > 0 )
          {
-            pinholeRepresentation.set( "jpegImage",
-                                       BlobNode( imf_, image2DHeader.pinholeRepresentation.jpegImageSize ) );
+            pinholeRepresentation.set(
+               "jpegImage", BlobNode( imf_, image2DHeader.pinholeRepresentation.jpegImageSize ) );
          }
          else if ( image2DHeader.pinholeRepresentation.pngImageSize > 0 )
          {
-            pinholeRepresentation.set( "pngImage", BlobNode( imf_, image2DHeader.pinholeRepresentation.pngImageSize ) );
+            pinholeRepresentation.set(
+               "pngImage", BlobNode( imf_, image2DHeader.pinholeRepresentation.pngImageSize ) );
          }
          if ( image2DHeader.pinholeRepresentation.imageMaskSize > 0 )
          {
-            pinholeRepresentation.set( "imageMask",
-                                       BlobNode( imf_, image2DHeader.pinholeRepresentation.imageMaskSize ) );
+            pinholeRepresentation.set(
+               "imageMask", BlobNode( imf_, image2DHeader.pinholeRepresentation.imageMaskSize ) );
          }
 
-         pinholeRepresentation.set( "focalLength", FloatNode( imf_, image2DHeader.pinholeRepresentation.focalLength ) );
-         pinholeRepresentation.set( "imageHeight",
-                                    IntegerNode( imf_, image2DHeader.pinholeRepresentation.imageHeight ) );
-         pinholeRepresentation.set( "imageWidth", IntegerNode( imf_, image2DHeader.pinholeRepresentation.imageWidth ) );
-         pinholeRepresentation.set( "pixelHeight", FloatNode( imf_, image2DHeader.pinholeRepresentation.pixelHeight ) );
-         pinholeRepresentation.set( "pixelWidth", FloatNode( imf_, image2DHeader.pinholeRepresentation.pixelWidth ) );
-         pinholeRepresentation.set( "principalPointX",
-                                    FloatNode( imf_, image2DHeader.pinholeRepresentation.principalPointX ) );
-         pinholeRepresentation.set( "principalPointY",
-                                    FloatNode( imf_, image2DHeader.pinholeRepresentation.principalPointY ) );
+         pinholeRepresentation.set(
+            "focalLength", FloatNode( imf_, image2DHeader.pinholeRepresentation.focalLength ) );
+         pinholeRepresentation.set(
+            "imageHeight", IntegerNode( imf_, image2DHeader.pinholeRepresentation.imageHeight ) );
+         pinholeRepresentation.set(
+            "imageWidth", IntegerNode( imf_, image2DHeader.pinholeRepresentation.imageWidth ) );
+         pinholeRepresentation.set(
+            "pixelHeight", FloatNode( imf_, image2DHeader.pinholeRepresentation.pixelHeight ) );
+         pinholeRepresentation.set(
+            "pixelWidth", FloatNode( imf_, image2DHeader.pinholeRepresentation.pixelWidth ) );
+         pinholeRepresentation.set(
+            "principalPointX",
+            FloatNode( imf_, image2DHeader.pinholeRepresentation.principalPointX ) );
+         pinholeRepresentation.set(
+            "principalPointY",
+            FloatNode( imf_, image2DHeader.pinholeRepresentation.principalPointY ) );
       }
       else if ( image2DHeader.sphericalRepresentation.jpegImageSize > 0 ||
                 image2DHeader.sphericalRepresentation.pngImageSize > 0 )
@@ -297,28 +316,28 @@ namespace e57
 
          if ( image2DHeader.sphericalRepresentation.jpegImageSize > 0 )
          {
-            sphericalRepresentation.set( "jpegImage",
-                                         BlobNode( imf_, image2DHeader.sphericalRepresentation.jpegImageSize ) );
+            sphericalRepresentation.set(
+               "jpegImage", BlobNode( imf_, image2DHeader.sphericalRepresentation.jpegImageSize ) );
          }
          else if ( image2DHeader.sphericalRepresentation.pngImageSize > 0 )
          {
-            sphericalRepresentation.set( "pngImage",
-                                         BlobNode( imf_, image2DHeader.sphericalRepresentation.pngImageSize ) );
+            sphericalRepresentation.set(
+               "pngImage", BlobNode( imf_, image2DHeader.sphericalRepresentation.pngImageSize ) );
          }
          if ( image2DHeader.sphericalRepresentation.imageMaskSize > 0 )
          {
-            sphericalRepresentation.set( "imageMask",
-                                         BlobNode( imf_, image2DHeader.sphericalRepresentation.imageMaskSize ) );
+            sphericalRepresentation.set(
+               "imageMask", BlobNode( imf_, image2DHeader.sphericalRepresentation.imageMaskSize ) );
          }
 
-         sphericalRepresentation.set( "imageHeight",
-                                      IntegerNode( imf_, image2DHeader.sphericalRepresentation.imageHeight ) );
-         sphericalRepresentation.set( "imageWidth",
-                                      IntegerNode( imf_, image2DHeader.sphericalRepresentation.imageWidth ) );
-         sphericalRepresentation.set( "pixelHeight",
-                                      FloatNode( imf_, image2DHeader.sphericalRepresentation.pixelHeight ) );
-         sphericalRepresentation.set( "pixelWidth",
-                                      FloatNode( imf_, image2DHeader.sphericalRepresentation.pixelWidth ) );
+         sphericalRepresentation.set(
+            "imageHeight", IntegerNode( imf_, image2DHeader.sphericalRepresentation.imageHeight ) );
+         sphericalRepresentation.set(
+            "imageWidth", IntegerNode( imf_, image2DHeader.sphericalRepresentation.imageWidth ) );
+         sphericalRepresentation.set(
+            "pixelHeight", FloatNode( imf_, image2DHeader.sphericalRepresentation.pixelHeight ) );
+         sphericalRepresentation.set(
+            "pixelWidth", FloatNode( imf_, image2DHeader.sphericalRepresentation.pixelWidth ) );
       }
       else if ( image2DHeader.cylindricalRepresentation.jpegImageSize > 0 ||
                 image2DHeader.cylindricalRepresentation.pngImageSize > 0 )
@@ -328,37 +347,43 @@ namespace e57
 
          if ( image2DHeader.cylindricalRepresentation.jpegImageSize > 0 )
          {
-            cylindricalRepresentation.set( "jpegImage",
-                                           BlobNode( imf_, image2DHeader.cylindricalRepresentation.jpegImageSize ) );
+            cylindricalRepresentation.set(
+               "jpegImage",
+               BlobNode( imf_, image2DHeader.cylindricalRepresentation.jpegImageSize ) );
          }
          else if ( image2DHeader.cylindricalRepresentation.pngImageSize > 0 )
          {
-            cylindricalRepresentation.set( "pngImage",
-                                           BlobNode( imf_, image2DHeader.cylindricalRepresentation.pngImageSize ) );
+            cylindricalRepresentation.set(
+               "pngImage", BlobNode( imf_, image2DHeader.cylindricalRepresentation.pngImageSize ) );
          }
          if ( image2DHeader.cylindricalRepresentation.imageMaskSize > 0 )
          {
-            cylindricalRepresentation.set( "imageMask",
-                                           BlobNode( imf_, image2DHeader.cylindricalRepresentation.imageMaskSize ) );
+            cylindricalRepresentation.set(
+               "imageMask",
+               BlobNode( imf_, image2DHeader.cylindricalRepresentation.imageMaskSize ) );
          }
 
-         cylindricalRepresentation.set( "imageHeight",
-                                        IntegerNode( imf_, image2DHeader.cylindricalRepresentation.imageHeight ) );
-         cylindricalRepresentation.set( "imageWidth",
-                                        IntegerNode( imf_, image2DHeader.cylindricalRepresentation.imageWidth ) );
-         cylindricalRepresentation.set( "pixelHeight",
-                                        FloatNode( imf_, image2DHeader.cylindricalRepresentation.pixelHeight ) );
-         cylindricalRepresentation.set( "pixelWidth",
-                                        FloatNode( imf_, image2DHeader.cylindricalRepresentation.pixelWidth ) );
-         cylindricalRepresentation.set( "principalPointY",
-                                        FloatNode( imf_, image2DHeader.cylindricalRepresentation.principalPointY ) );
-         cylindricalRepresentation.set( "radius", FloatNode( imf_, image2DHeader.cylindricalRepresentation.radius ) );
+         cylindricalRepresentation.set(
+            "imageHeight",
+            IntegerNode( imf_, image2DHeader.cylindricalRepresentation.imageHeight ) );
+         cylindricalRepresentation.set(
+            "imageWidth", IntegerNode( imf_, image2DHeader.cylindricalRepresentation.imageWidth ) );
+         cylindricalRepresentation.set(
+            "pixelHeight", FloatNode( imf_, image2DHeader.cylindricalRepresentation.pixelHeight ) );
+         cylindricalRepresentation.set(
+            "pixelWidth", FloatNode( imf_, image2DHeader.cylindricalRepresentation.pixelWidth ) );
+         cylindricalRepresentation.set(
+            "principalPointY",
+            FloatNode( imf_, image2DHeader.cylindricalRepresentation.principalPointY ) );
+         cylindricalRepresentation.set(
+            "radius", FloatNode( imf_, image2DHeader.cylindricalRepresentation.radius ) );
       }
       return pos;
    }
 
-   size_t WriterImpl::WriteImage2DData( int64_t imageIndex, Image2DType imageType, Image2DProjection imageProjection,
-                                        uint8_t *pBuffer, int64_t start, size_t count )
+   size_t WriterImpl::WriteImage2DData( int64_t imageIndex, Image2DType imageType,
+                                        Image2DProjection imageProjection, uint8_t *pBuffer,
+                                        int64_t start, size_t count )
    {
       if ( ( imageIndex < 0 ) || ( imageIndex >= images2D_.childCount() ) )
       {
@@ -375,8 +400,10 @@ namespace e57
          case ProjectionVisual:
             if ( image.isDefined( "visualReferenceRepresentation" ) )
             {
-               StructureNode visualReferenceRepresentation( image.get( "visualReferenceRepresentation" ) );
-               return _writeImage2DNode( visualReferenceRepresentation, imageType, pBuffer, start, count );
+               StructureNode visualReferenceRepresentation(
+                  image.get( "visualReferenceRepresentation" ) );
+               return _writeImage2DNode( visualReferenceRepresentation, imageType, pBuffer, start,
+                                         count );
             }
             break;
 
@@ -392,7 +419,8 @@ namespace e57
             if ( image.isDefined( "sphericalRepresentation" ) )
             {
                StructureNode sphericalRepresentation( image.get( "sphericalRepresentation" ) );
-               return _writeImage2DNode( sphericalRepresentation, imageType, pBuffer, start, count );
+               return _writeImage2DNode( sphericalRepresentation, imageType, pBuffer, start,
+                                         count );
             }
             break;
 
@@ -400,7 +428,8 @@ namespace e57
             if ( image.isDefined( "cylindricalRepresentation" ) )
             {
                StructureNode cylindricalRepresentation( image.get( "cylindricalRepresentation" ) );
-               return _writeImage2DNode( cylindricalRepresentation, imageType, pBuffer, start, count );
+               return _writeImage2DNode( cylindricalRepresentation, imageType, pBuffer, start,
+                                         count );
             }
             break;
       }
@@ -463,17 +492,20 @@ namespace e57
 
       if ( !data3DHeader.sensorHardwareVersion.empty() )
       {
-         scan.set( "sensorHardwareVersion", StringNode( imf_, data3DHeader.sensorHardwareVersion ) );
+         scan.set( "sensorHardwareVersion",
+                   StringNode( imf_, data3DHeader.sensorHardwareVersion ) );
       }
 
       if ( !data3DHeader.sensorSoftwareVersion.empty() )
       {
-         scan.set( "sensorSoftwareVersion", StringNode( imf_, data3DHeader.sensorSoftwareVersion ) );
+         scan.set( "sensorSoftwareVersion",
+                   StringNode( imf_, data3DHeader.sensorSoftwareVersion ) );
       }
 
       if ( !data3DHeader.sensorFirmwareVersion.empty() )
       {
-         scan.set( "sensorFirmwareVersion", StringNode( imf_, data3DHeader.sensorFirmwareVersion ) );
+         scan.set( "sensorFirmwareVersion",
+                   StringNode( imf_, data3DHeader.sensorFirmwareVersion ) );
       }
 
       // Add temp/humidity to scan.
@@ -497,22 +529,29 @@ namespace e57
       {
          StructureNode ibox( imf_ );
 
-         if ( ( data3DHeader.indexBounds.rowMinimum != 0 ) || ( data3DHeader.indexBounds.rowMaximum != 0 ) )
+         if ( ( data3DHeader.indexBounds.rowMinimum != 0 ) ||
+              ( data3DHeader.indexBounds.rowMaximum != 0 ) )
          {
             ibox.set( "rowMinimum", IntegerNode( imf_, data3DHeader.indexBounds.rowMinimum ) );
             ibox.set( "rowMaximum", IntegerNode( imf_, data3DHeader.indexBounds.rowMaximum ) );
          }
 
-         if ( ( data3DHeader.indexBounds.columnMinimum != 0 ) || ( data3DHeader.indexBounds.columnMaximum != 0 ) )
+         if ( ( data3DHeader.indexBounds.columnMinimum != 0 ) ||
+              ( data3DHeader.indexBounds.columnMaximum != 0 ) )
          {
-            ibox.set( "columnMinimum", IntegerNode( imf_, data3DHeader.indexBounds.columnMinimum ) );
-            ibox.set( "columnMaximum", IntegerNode( imf_, data3DHeader.indexBounds.columnMaximum ) );
+            ibox.set( "columnMinimum",
+                      IntegerNode( imf_, data3DHeader.indexBounds.columnMinimum ) );
+            ibox.set( "columnMaximum",
+                      IntegerNode( imf_, data3DHeader.indexBounds.columnMaximum ) );
          }
 
-         if ( ( data3DHeader.indexBounds.returnMinimum != 0 ) || ( data3DHeader.indexBounds.returnMaximum != 0 ) )
+         if ( ( data3DHeader.indexBounds.returnMinimum != 0 ) ||
+              ( data3DHeader.indexBounds.returnMaximum != 0 ) )
          {
-            ibox.set( "returnMinimum", IntegerNode( imf_, data3DHeader.indexBounds.returnMinimum ) );
-            ibox.set( "returnMaximum", IntegerNode( imf_, data3DHeader.indexBounds.returnMaximum ) );
+            ibox.set( "returnMinimum",
+                      IntegerNode( imf_, data3DHeader.indexBounds.returnMinimum ) );
+            ibox.set( "returnMaximum",
+                      IntegerNode( imf_, data3DHeader.indexBounds.returnMaximum ) );
          }
 
          scan.set( "indexBounds", ibox );
@@ -530,8 +569,10 @@ namespace e57
          {
             case NumericalNodeType::Integer:
             {
-               intbox.set( "intensityMinimum", IntegerNode( imf_, static_cast<int64_t>( intensityMin ) ) );
-               intbox.set( "intensityMaximum", IntegerNode( imf_, static_cast<int64_t>( intensityMax ) ) );
+               intbox.set( "intensityMinimum",
+                           IntegerNode( imf_, static_cast<int64_t>( intensityMin ) ) );
+               intbox.set( "intensityMaximum",
+                           IntegerNode( imf_, static_cast<int64_t>( intensityMax ) ) );
 
                break;
             }
@@ -546,26 +587,32 @@ namespace e57
                const auto rawIntegerMaximum =
                   static_cast<int64_t>( std::floor( ( intensityMax - offset ) / scale + .5 ) );
 
-               intbox.set( "intensityMinimum", ScaledIntegerNode( imf_, rawIntegerMinimum, rawIntegerMinimum,
-                                                                  rawIntegerMaximum, scale, offset ) );
-               intbox.set( "intensityMaximum", ScaledIntegerNode( imf_, rawIntegerMaximum, rawIntegerMinimum,
-                                                                  rawIntegerMaximum, scale, offset ) );
+               intbox.set( "intensityMinimum",
+                           ScaledIntegerNode( imf_, rawIntegerMinimum, rawIntegerMinimum,
+                                              rawIntegerMaximum, scale, offset ) );
+               intbox.set( "intensityMaximum",
+                           ScaledIntegerNode( imf_, rawIntegerMaximum, rawIntegerMinimum,
+                                              rawIntegerMaximum, scale, offset ) );
 
                break;
             }
 
             case NumericalNodeType::Float:
             {
-               intbox.set( "intensityMinimum", FloatNode( imf_, 0.0, PrecisionSingle, intensityMin ) );
-               intbox.set( "intensityMaximum", FloatNode( imf_, 0.0, PrecisionSingle, intensityMax ) );
+               intbox.set( "intensityMinimum",
+                           FloatNode( imf_, 0.0, PrecisionSingle, intensityMin ) );
+               intbox.set( "intensityMaximum",
+                           FloatNode( imf_, 0.0, PrecisionSingle, intensityMax ) );
 
                break;
             }
 
             case NumericalNodeType::Double:
             {
-               intbox.set( "intensityMinimum", FloatNode( imf_, 0.0, PrecisionDouble, intensityMin ) );
-               intbox.set( "intensityMaximum", FloatNode( imf_, 0.0, PrecisionDouble, intensityMax ) );
+               intbox.set( "intensityMinimum",
+                           FloatNode( imf_, 0.0, PrecisionDouble, intensityMin ) );
+               intbox.set( "intensityMaximum",
+                           FloatNode( imf_, 0.0, PrecisionDouble, intensityMax ) );
 
                break;
             }
@@ -574,22 +621,29 @@ namespace e57
          scan.set( "intensityLimits", intbox );
       }
 
-      if ( ( data3DHeader.colorLimits.colorRedMaximum != 0.0 ) || ( data3DHeader.colorLimits.colorRedMinimum != 0.0 ) )
+      if ( ( data3DHeader.colorLimits.colorRedMaximum != 0.0 ) ||
+           ( data3DHeader.colorLimits.colorRedMinimum != 0.0 ) )
       {
          StructureNode colorbox( imf_ );
 
-         colorbox.set( "colorRedMaximum",
-                       IntegerNode( imf_, static_cast<int64_t>( data3DHeader.colorLimits.colorRedMaximum ) ) );
-         colorbox.set( "colorRedMinimum",
-                       IntegerNode( imf_, static_cast<int64_t>( data3DHeader.colorLimits.colorRedMinimum ) ) );
+         colorbox.set(
+            "colorRedMaximum",
+            IntegerNode( imf_, static_cast<int64_t>( data3DHeader.colorLimits.colorRedMaximum ) ) );
+         colorbox.set(
+            "colorRedMinimum",
+            IntegerNode( imf_, static_cast<int64_t>( data3DHeader.colorLimits.colorRedMinimum ) ) );
          colorbox.set( "colorGreenMaximum",
-                       IntegerNode( imf_, static_cast<int64_t>( data3DHeader.colorLimits.colorGreenMaximum ) ) );
+                       IntegerNode( imf_, static_cast<int64_t>(
+                                             data3DHeader.colorLimits.colorGreenMaximum ) ) );
          colorbox.set( "colorGreenMinimum",
-                       IntegerNode( imf_, static_cast<int64_t>( data3DHeader.colorLimits.colorGreenMinimum ) ) );
+                       IntegerNode( imf_, static_cast<int64_t>(
+                                             data3DHeader.colorLimits.colorGreenMinimum ) ) );
          colorbox.set( "colorBlueMaximum",
-                       IntegerNode( imf_, static_cast<int64_t>( data3DHeader.colorLimits.colorBlueMaximum ) ) );
+                       IntegerNode( imf_, static_cast<int64_t>(
+                                             data3DHeader.colorLimits.colorBlueMaximum ) ) );
          colorbox.set( "colorBlueMinimum",
-                       IntegerNode( imf_, static_cast<int64_t>( data3DHeader.colorLimits.colorBlueMinimum ) ) );
+                       IntegerNode( imf_, static_cast<int64_t>(
+                                             data3DHeader.colorLimits.colorBlueMinimum ) ) );
 
          scan.set( "colorLimits", colorbox );
       }
@@ -618,8 +672,10 @@ namespace e57
 
          sbox.set( "rangeMinimum", FloatNode( imf_, data3DHeader.sphericalBounds.rangeMinimum ) );
          sbox.set( "rangeMaximum", FloatNode( imf_, data3DHeader.sphericalBounds.rangeMaximum ) );
-         sbox.set( "elevationMinimum", FloatNode( imf_, data3DHeader.sphericalBounds.elevationMinimum ) );
-         sbox.set( "elevationMaximum", FloatNode( imf_, data3DHeader.sphericalBounds.elevationMaximum ) );
+         sbox.set( "elevationMinimum",
+                   FloatNode( imf_, data3DHeader.sphericalBounds.elevationMinimum ) );
+         sbox.set( "elevationMaximum",
+                   FloatNode( imf_, data3DHeader.sphericalBounds.elevationMaximum ) );
          sbox.set( "azimuthStart", FloatNode( imf_, data3DHeader.sphericalBounds.azimuthStart ) );
          sbox.set( "azimuthEnd", FloatNode( imf_, data3DHeader.sphericalBounds.azimuthEnd ) );
 
@@ -656,9 +712,11 @@ namespace e57
       {
          StructureNode acquisitionStart( imf_ );
 
-         acquisitionStart.set( "dateTimeValue", FloatNode( imf_, data3DHeader.acquisitionStart.dateTimeValue ) );
-         acquisitionStart.set( "isAtomicClockReferenced",
-                               IntegerNode( imf_, data3DHeader.acquisitionStart.isAtomicClockReferenced ) );
+         acquisitionStart.set( "dateTimeValue",
+                               FloatNode( imf_, data3DHeader.acquisitionStart.dateTimeValue ) );
+         acquisitionStart.set(
+            "isAtomicClockReferenced",
+            IntegerNode( imf_, data3DHeader.acquisitionStart.isAtomicClockReferenced ) );
 
          scan.set( "acquisitionStart", acquisitionStart );
       }
@@ -666,9 +724,11 @@ namespace e57
       {
          StructureNode acquisitionEnd( imf_ );
 
-         acquisitionEnd.set( "dateTimeValue", FloatNode( imf_, data3DHeader.acquisitionEnd.dateTimeValue ) );
-         acquisitionEnd.set( "isAtomicClockReferenced",
-                             IntegerNode( imf_, data3DHeader.acquisitionEnd.isAtomicClockReferenced ) );
+         acquisitionEnd.set( "dateTimeValue",
+                             FloatNode( imf_, data3DHeader.acquisitionEnd.dateTimeValue ) );
+         acquisitionEnd.set(
+            "isAtomicClockReferenced",
+            IntegerNode( imf_, data3DHeader.acquisitionEnd.isAtomicClockReferenced ) );
 
          scan.set( "acquisitionEnd", acquisitionEnd );
       }
@@ -736,17 +796,18 @@ namespace e57
       //      "/data3D/0/points/0/cartesianX"
       StructureNode proto( imf_ );
 
-      // Because ScaledInteger min/max are the raw integer min/max, we must calculate them from the data min/max
+      // Because ScaledInteger min/max are the raw integer min/max, we must calculate them from the
+      // data min/max
       const double pointRangeScale = data3DHeader.pointFields.pointRangeScale;
       const double pointRangeOffset = 0.0;
 
       const double pointRangeMin = data3DHeader.pointFields.pointRangeMinimum;
       const double pointRangeMax = data3DHeader.pointFields.pointRangeMaximum;
 
-      const auto pointRangeMinimum =
-         static_cast<int64_t>( std::floor( ( pointRangeMin - pointRangeOffset ) / pointRangeScale + .5 ) );
-      const auto pointRangeMaximum =
-         static_cast<int64_t>( std::floor( ( pointRangeMax - pointRangeOffset ) / pointRangeScale + .5 ) );
+      const auto pointRangeMinimum = static_cast<int64_t>(
+         std::floor( ( pointRangeMin - pointRangeOffset ) / pointRangeScale + .5 ) );
+      const auto pointRangeMaximum = static_cast<int64_t>(
+         std::floor( ( pointRangeMax - pointRangeOffset ) / pointRangeScale + .5 ) );
 
       const auto getPointProto = [=]() -> Node {
          switch ( data3DHeader.pointFields.pointRangeNodeType )
@@ -758,8 +819,8 @@ namespace e57
 
             case NumericalNodeType::ScaledInteger:
             {
-               return ScaledIntegerNode( imf_, 0, pointRangeMinimum, pointRangeMaximum, pointRangeScale,
-                                         pointRangeOffset );
+               return ScaledIntegerNode( imf_, 0, pointRangeMinimum, pointRangeMaximum,
+                                         pointRangeScale, pointRangeOffset );
             }
 
             case NumericalNodeType::Float:
@@ -799,8 +860,10 @@ namespace e57
       const double angleScale = data3DHeader.pointFields.angleScale;
       const double angleOffset = 0.0;
 
-      const auto angleMinimum = static_cast<int64_t>( std::floor( ( angleMin - angleOffset ) / angleScale + .5 ) );
-      const auto angleMaximum = static_cast<int64_t>( std::floor( ( angleMax - angleOffset ) / angleScale + .5 ) );
+      const auto angleMinimum =
+         static_cast<int64_t>( std::floor( ( angleMin - angleOffset ) / angleScale + .5 ) );
+      const auto angleMaximum =
+         static_cast<int64_t>( std::floor( ( angleMax - angleOffset ) / angleScale + .5 ) );
 
       const auto getAngleProto = [=]() -> Node {
          switch ( data3DHeader.pointFields.angleNodeType )
@@ -812,7 +875,8 @@ namespace e57
 
             case NumericalNodeType::ScaledInteger:
             {
-               return ScaledIntegerNode( imf_, 0, angleMinimum, angleMaximum, angleScale, angleOffset );
+               return ScaledIntegerNode( imf_, 0, angleMinimum, angleMaximum, angleScale,
+                                         angleOffset );
             }
 
             case NumericalNodeType::Float:
@@ -862,26 +926,26 @@ namespace e57
                const auto rawIntegerMinimum =
                   static_cast<int64_t>( std::floor( ( intensityMin - offset ) / scale + .5 ) );
 
-               proto.set( "intensity",
-                          ScaledIntegerNode( imf_, 0, rawIntegerMinimum, rawIntegerMaximum, scale, offset ) );
+               proto.set( "intensity", ScaledIntegerNode( imf_, 0, rawIntegerMinimum,
+                                                          rawIntegerMaximum, scale, offset ) );
 
                break;
             }
 
             case NumericalNodeType::Float:
             {
-               proto.set( "intensity",
-                          FloatNode( imf_, 0.0, PrecisionSingle, data3DHeader.intensityLimits.intensityMinimum,
-                                     data3DHeader.intensityLimits.intensityMaximum ) );
+               proto.set( "intensity", FloatNode( imf_, 0.0, PrecisionSingle,
+                                                  data3DHeader.intensityLimits.intensityMinimum,
+                                                  data3DHeader.intensityLimits.intensityMaximum ) );
 
                break;
             }
 
             case NumericalNodeType::Double:
             {
-               proto.set( "intensity",
-                          FloatNode( imf_, 0.0, PrecisionDouble, data3DHeader.intensityLimits.intensityMinimum,
-                                     data3DHeader.intensityLimits.intensityMaximum ) );
+               proto.set( "intensity", FloatNode( imf_, 0.0, PrecisionDouble,
+                                                  data3DHeader.intensityLimits.intensityMinimum,
+                                                  data3DHeader.intensityLimits.intensityMaximum ) );
 
                break;
             }
@@ -890,38 +954,46 @@ namespace e57
 
       if ( data3DHeader.pointFields.colorRedField )
       {
-         proto.set( "colorRed", IntegerNode( imf_, 0, static_cast<int64_t>( data3DHeader.colorLimits.colorRedMinimum ),
-                                             static_cast<int64_t>( data3DHeader.colorLimits.colorRedMaximum ) ) );
+         proto.set(
+            "colorRed",
+            IntegerNode( imf_, 0, static_cast<int64_t>( data3DHeader.colorLimits.colorRedMinimum ),
+                         static_cast<int64_t>( data3DHeader.colorLimits.colorRedMaximum ) ) );
       }
       if ( data3DHeader.pointFields.colorGreenField )
       {
          proto.set( "colorGreen",
-                    IntegerNode( imf_, 0, static_cast<int64_t>( data3DHeader.colorLimits.colorGreenMinimum ),
-                                 static_cast<int64_t>( data3DHeader.colorLimits.colorGreenMaximum ) ) );
+                    IntegerNode(
+                       imf_, 0, static_cast<int64_t>( data3DHeader.colorLimits.colorGreenMinimum ),
+                       static_cast<int64_t>( data3DHeader.colorLimits.colorGreenMaximum ) ) );
       }
       if ( data3DHeader.pointFields.colorBlueField )
       {
-         proto.set( "colorBlue",
-                    IntegerNode( imf_, 0, static_cast<int64_t>( data3DHeader.colorLimits.colorBlueMinimum ),
-                                 static_cast<int64_t>( data3DHeader.colorLimits.colorBlueMaximum ) ) );
+         proto.set(
+            "colorBlue",
+            IntegerNode( imf_, 0, static_cast<int64_t>( data3DHeader.colorLimits.colorBlueMinimum ),
+                         static_cast<int64_t>( data3DHeader.colorLimits.colorBlueMaximum ) ) );
       }
 
       if ( data3DHeader.pointFields.returnIndexField )
       {
-         proto.set( "returnIndex", IntegerNode( imf_, 0, UINT8_MIN, data3DHeader.pointFields.returnMaximum ) );
+         proto.set( "returnIndex",
+                    IntegerNode( imf_, 0, UINT8_MIN, data3DHeader.pointFields.returnMaximum ) );
       }
       if ( data3DHeader.pointFields.returnCountField )
       {
-         proto.set( "returnCount", IntegerNode( imf_, 0, UINT8_MIN, data3DHeader.pointFields.returnMaximum ) );
+         proto.set( "returnCount",
+                    IntegerNode( imf_, 0, UINT8_MIN, data3DHeader.pointFields.returnMaximum ) );
       }
 
       if ( data3DHeader.pointFields.rowIndexField )
       {
-         proto.set( "rowIndex", IntegerNode( imf_, 0, UINT32_MIN, data3DHeader.pointFields.rowIndexMaximum ) );
+         proto.set( "rowIndex",
+                    IntegerNode( imf_, 0, UINT32_MIN, data3DHeader.pointFields.rowIndexMaximum ) );
       }
       if ( data3DHeader.pointFields.columnIndexField )
       {
-         proto.set( "columnIndex", IntegerNode( imf_, 0, UINT32_MIN, data3DHeader.pointFields.columnIndexMaximum ) );
+         proto.set( "columnIndex", IntegerNode( imf_, 0, UINT32_MIN,
+                                                data3DHeader.pointFields.columnIndexMaximum ) );
       }
 
       if ( data3DHeader.pointFields.timeStampField )
@@ -948,20 +1020,22 @@ namespace e57
                const auto rawIntegerMaximum =
                   static_cast<int64_t>( std::floor( ( timeMaximum - offset ) / scale + .5 ) );
 
-               proto.set( "timeStamp",
-                          ScaledIntegerNode( imf_, 0, rawIntegerMinimum, rawIntegerMaximum, scale, offset ) );
+               proto.set( "timeStamp", ScaledIntegerNode( imf_, 0, rawIntegerMinimum,
+                                                          rawIntegerMaximum, scale, offset ) );
                break;
             }
 
             case NumericalNodeType::Float:
             {
-               proto.set( "timeStamp", FloatNode( imf_, 0.0, PrecisionSingle, FLOAT_MIN, FLOAT_MAX ) );
+               proto.set( "timeStamp",
+                          FloatNode( imf_, 0.0, PrecisionSingle, FLOAT_MIN, FLOAT_MAX ) );
                break;
             }
 
             case NumericalNodeType::Double:
             {
-               proto.set( "timeStamp", FloatNode( imf_, 0.0, PrecisionDouble, DOUBLE_MIN, DOUBLE_MAX ) );
+               proto.set( "timeStamp",
+                          FloatNode( imf_, 0.0, PrecisionDouble, DOUBLE_MIN, DOUBLE_MAX ) );
                break;
             }
          }
@@ -1029,8 +1103,8 @@ namespace e57
    }
 
    template <typename COORDTYPE>
-   CompressedVectorWriter WriterImpl::SetUpData3DPointsData( int64_t dataIndex, size_t count,
-                                                             const Data3DPointsData_t<COORDTYPE> &buffers )
+   CompressedVectorWriter WriterImpl::SetUpData3DPointsData(
+      int64_t dataIndex, size_t count, const Data3DPointsData_t<COORDTYPE> &buffers )
    {
       static_assert( std::is_floating_point<COORDTYPE>::value, "Floating point type required." );
 
@@ -1056,17 +1130,20 @@ namespace e57
 
       if ( proto.isDefined( "sphericalRange" ) && ( buffers.sphericalRange != nullptr ) )
       {
-         sourceBuffers.emplace_back( imf_, "sphericalRange", buffers.sphericalRange, count, true, true );
+         sourceBuffers.emplace_back( imf_, "sphericalRange", buffers.sphericalRange, count, true,
+                                     true );
       }
 
       if ( proto.isDefined( "sphericalAzimuth" ) && ( buffers.sphericalAzimuth != nullptr ) )
       {
-         sourceBuffers.emplace_back( imf_, "sphericalAzimuth", buffers.sphericalAzimuth, count, true, true );
+         sourceBuffers.emplace_back( imf_, "sphericalAzimuth", buffers.sphericalAzimuth, count,
+                                     true, true );
       }
 
       if ( proto.isDefined( "sphericalElevation" ) && ( buffers.sphericalElevation != nullptr ) )
       {
-         sourceBuffers.emplace_back( imf_, "sphericalElevation", buffers.sphericalElevation, count, true, true );
+         sourceBuffers.emplace_back( imf_, "sphericalElevation", buffers.sphericalElevation, count,
+                                     true, true );
       }
 
       if ( proto.isDefined( "intensity" ) && ( buffers.intensity != nullptr ) )
@@ -1114,19 +1191,24 @@ namespace e57
          sourceBuffers.emplace_back( imf_, "timeStamp", buffers.timeStamp, count, true, true );
       }
 
-      if ( proto.isDefined( "cartesianInvalidState" ) && ( buffers.cartesianInvalidState != nullptr ) )
+      if ( proto.isDefined( "cartesianInvalidState" ) &&
+           ( buffers.cartesianInvalidState != nullptr ) )
       {
-         sourceBuffers.emplace_back( imf_, "cartesianInvalidState", buffers.cartesianInvalidState, count, true );
+         sourceBuffers.emplace_back( imf_, "cartesianInvalidState", buffers.cartesianInvalidState,
+                                     count, true );
       }
 
-      if ( proto.isDefined( "sphericalInvalidState" ) && ( buffers.sphericalInvalidState != nullptr ) )
+      if ( proto.isDefined( "sphericalInvalidState" ) &&
+           ( buffers.sphericalInvalidState != nullptr ) )
       {
-         sourceBuffers.emplace_back( imf_, "sphericalInvalidState", buffers.sphericalInvalidState, count, true );
+         sourceBuffers.emplace_back( imf_, "sphericalInvalidState", buffers.sphericalInvalidState,
+                                     count, true );
       }
 
       if ( proto.isDefined( "isIntensityInvalid" ) && ( buffers.isIntensityInvalid != nullptr ) )
       {
-         sourceBuffers.emplace_back( imf_, "isIntensityInvalid", buffers.isIntensityInvalid, count, true );
+         sourceBuffers.emplace_back( imf_, "isIntensityInvalid", buffers.isIntensityInvalid, count,
+                                     true );
       }
 
       if ( proto.isDefined( "isColorInvalid" ) && ( buffers.isColorInvalid != nullptr ) )
@@ -1136,7 +1218,8 @@ namespace e57
 
       if ( proto.isDefined( "isTimeStampInvalid" ) && ( buffers.isTimeStampInvalid != nullptr ) )
       {
-         sourceBuffers.emplace_back( imf_, "isTimeStampInvalid", buffers.isTimeStampInvalid, count, true );
+         sourceBuffers.emplace_back( imf_, "isTimeStampInvalid", buffers.isTimeStampInvalid, count,
+                                     true );
       }
 
       // E57_EXT_surface_normals
@@ -1165,15 +1248,16 @@ namespace e57
    }
 
    // Explicit template instantiation
-   template CompressedVectorWriter WriterImpl::SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
-                                                                      const Data3DPointsData_t<float> &buffers );
+   template CompressedVectorWriter WriterImpl::SetUpData3DPointsData(
+      int64_t dataIndex, size_t pointCount, const Data3DPointsData_t<float> &buffers );
 
-   template CompressedVectorWriter WriterImpl::SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
-                                                                      const Data3DPointsData_t<double> &buffers );
+   template CompressedVectorWriter WriterImpl::SetUpData3DPointsData(
+      int64_t dataIndex, size_t pointCount, const Data3DPointsData_t<double> &buffers );
 
    // This function writes out the group data
-   bool WriterImpl::WriteData3DGroupsData( int64_t dataIndex, int64_t groupCount, int64_t *idElementValue,
-                                           int64_t *startPointIndex, int64_t *pointCount )
+   bool WriterImpl::WriteData3DGroupsData( int64_t dataIndex, int64_t groupCount,
+                                           int64_t *idElementValue, int64_t *startPointIndex,
+                                           int64_t *pointCount )
    {
       if ( ( dataIndex < 0 ) || ( dataIndex >= data3D_.childCount() ) )
       {

--- a/src/WriterImpl.h
+++ b/src/WriterImpl.h
@@ -33,7 +33,6 @@
 
 namespace e57
 {
-   //! most of the functions follows Writer
    class WriterImpl
    {
    public:
@@ -52,8 +51,9 @@ namespace e57
 
       int64_t NewImage2D( Image2D &image2DHeader );
 
-      size_t WriteImage2DData( int64_t imageIndex, Image2DType imageType, Image2DProjection imageProjection,
-                               uint8_t *pBuffer, int64_t start, size_t count );
+      size_t WriteImage2DData( int64_t imageIndex, Image2DType imageType,
+                               Image2DProjection imageProjection, uint8_t *pBuffer, int64_t start,
+                               size_t count );
 
       int64_t NewData3D( Data3D &data3DHeader );
 

--- a/test/include/Helpers.h
+++ b/test/include/Helpers.h
@@ -4,14 +4,14 @@
 
 // GoogleTest's ASSERT_NO_THROW() doesn't let us show any info about the exceptions.
 // This wrapper macro will output the e57::E57Exception context on failure.
-#define E57_ASSERT_NO_THROW( code )                                                                                    \
-   try                                                                                                                 \
-   {                                                                                                                   \
-      code;                                                                                                            \
-   }                                                                                                                   \
-   catch ( e57::E57Exception & err )                                                                                   \
-   {                                                                                                                   \
-      FAIL() << err.errorStr() << ": " << err.context();                                                               \
+#define E57_ASSERT_NO_THROW( code )                                                                \
+   try                                                                                             \
+   {                                                                                               \
+      code;                                                                                        \
+   }                                                                                               \
+   catch ( e57::E57Exception & err )                                                               \
+   {                                                                                               \
+      FAIL() << err.errorStr() << ": " << err.context();                                           \
    }
 
 #define E57_ASSERT_THROW( code ) ASSERT_THROW( code, e57::E57Exception )

--- a/test/src/RandomNum.cpp
+++ b/test/src/RandomNum.cpp
@@ -15,7 +15,8 @@ namespace
    // Use a uniform distribution [0, 1].
    // For explanation of second param, see:
    //    https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution
-   static std::uniform_real_distribution<> dis( 0, std::nextafter( 1, std::numeric_limits<float>::max() ) );
+   static std::uniform_real_distribution<> dis(
+      0, std::nextafter( 1, std::numeric_limits<float>::max() ) );
 }
 
 namespace Random

--- a/test/src/test_SimpleData.cpp
+++ b/test/src/test_SimpleData.cpp
@@ -43,8 +43,9 @@ TEST( SimpleDataHeader, AutoSetNodeTypes )
 
    dataHeader.pointCount = 1;
 
-   // dataHeader.pointFields.pointRangeNodeType and dataHeader.pointFields.angleNodeType default to Float but we are
-   // using a double structure. The constructor should correct these and set them to Double.
+   // dataHeader.pointFields.pointRangeNodeType and dataHeader.pointFields.angleNodeType default to
+   // Float but we are using a double structure. The constructor should correct these and set them
+   // to Double.
    e57::Data3DPointsData_d pointsData( dataHeader );
 
    EXPECT_EQ( dataHeader.pointFields.pointRangeNodeType, e57::NumericalNodeType::Double );
@@ -99,8 +100,8 @@ TEST( SimpleDataHeader, HeaderMinMaxDouble )
    EXPECT_EQ( dataHeader.pointFields.timeMaximum, e57::DOUBLE_MAX );
 }
 
-// Checks that the Data3D header and the the cartesianX FloatNode data are the same when read, written, and read again.
-// https://github.com/asmaloney/libE57Format/issues/126
+// Checks that the Data3D header and the the cartesianX FloatNode data are the same when read,
+// written, and read again. https://github.com/asmaloney/libE57Format/issues/126
 TEST( SimpleData, ReadWrite )
 {
    e57::Reader *originalReader = nullptr;
@@ -110,7 +111,8 @@ TEST( SimpleData, ReadWrite )
 
    // 1. Read in original file
    {
-      E57_ASSERT_NO_THROW( originalReader = new e57::Reader( TestData::Path() + "/self/ColouredCubeDouble.e57", {} ) );
+      E57_ASSERT_NO_THROW( originalReader = new e57::Reader(
+                              TestData::Path() + "/self/ColouredCubeDouble.e57", {} ) );
 
       ASSERT_TRUE( originalReader->GetE57Root( originalFileHeader ) );
       ASSERT_TRUE( originalReader->ReadData3D( 0, originalData3DHeader ) );
@@ -119,7 +121,8 @@ TEST( SimpleData, ReadWrite )
 
       originalPointsData = new e57::Data3DPointsData_d( originalData3DHeader );
 
-      auto vectorReader = originalReader->SetUpData3DPointsData( 0, cNumPoints, *originalPointsData );
+      auto vectorReader =
+         originalReader->SetUpData3DPointsData( 0, cNumPoints, *originalPointsData );
 
       const uint64_t cNumRead = vectorReader.read();
 
@@ -173,13 +176,17 @@ TEST( SimpleData, ReadWrite )
 
    EXPECT_EQ( originalData3DHeader.colorLimits, copyData3DHeader.colorLimits );
 
-   EXPECT_EQ( originalData3DHeader.pointFields.cartesianXField, copyData3DHeader.pointFields.cartesianXField );
-   EXPECT_EQ( originalData3DHeader.pointFields.cartesianYField, copyData3DHeader.pointFields.cartesianYField );
-   EXPECT_EQ( originalData3DHeader.pointFields.cartesianZField, copyData3DHeader.pointFields.cartesianZField );
+   EXPECT_EQ( originalData3DHeader.pointFields.cartesianXField,
+              copyData3DHeader.pointFields.cartesianXField );
+   EXPECT_EQ( originalData3DHeader.pointFields.cartesianYField,
+              copyData3DHeader.pointFields.cartesianYField );
+   EXPECT_EQ( originalData3DHeader.pointFields.cartesianZField,
+              copyData3DHeader.pointFields.cartesianZField );
    EXPECT_EQ( originalData3DHeader.pointFields.cartesianInvalidStateField,
               copyData3DHeader.pointFields.cartesianInvalidStateField );
 
-   EXPECT_EQ( originalData3DHeader.pointFields.sphericalRangeField, copyData3DHeader.pointFields.sphericalRangeField );
+   EXPECT_EQ( originalData3DHeader.pointFields.sphericalRangeField,
+              copyData3DHeader.pointFields.sphericalRangeField );
    EXPECT_EQ( originalData3DHeader.pointFields.sphericalAzimuthField,
               copyData3DHeader.pointFields.sphericalAzimuthField );
    EXPECT_EQ( originalData3DHeader.pointFields.sphericalElevationField,
@@ -187,51 +194,79 @@ TEST( SimpleData, ReadWrite )
    EXPECT_EQ( originalData3DHeader.pointFields.sphericalInvalidStateField,
               copyData3DHeader.pointFields.sphericalInvalidStateField );
 
-   EXPECT_EQ( originalData3DHeader.pointFields.pointRangeMinimum, copyData3DHeader.pointFields.pointRangeMinimum );
-   EXPECT_EQ( originalData3DHeader.pointFields.pointRangeMaximum, copyData3DHeader.pointFields.pointRangeMaximum );
+   EXPECT_EQ( originalData3DHeader.pointFields.pointRangeMinimum,
+              copyData3DHeader.pointFields.pointRangeMinimum );
+   EXPECT_EQ( originalData3DHeader.pointFields.pointRangeMaximum,
+              copyData3DHeader.pointFields.pointRangeMaximum );
 
-   EXPECT_EQ( originalData3DHeader.pointFields.pointRangeNodeType, copyData3DHeader.pointFields.pointRangeNodeType );
-   EXPECT_EQ( originalData3DHeader.pointFields.pointRangeScale, copyData3DHeader.pointFields.pointRangeScale );
+   EXPECT_EQ( originalData3DHeader.pointFields.pointRangeNodeType,
+              copyData3DHeader.pointFields.pointRangeNodeType );
+   EXPECT_EQ( originalData3DHeader.pointFields.pointRangeScale,
+              copyData3DHeader.pointFields.pointRangeScale );
 
-   EXPECT_EQ( originalData3DHeader.pointFields.angleMinimum, copyData3DHeader.pointFields.angleMinimum );
-   EXPECT_EQ( originalData3DHeader.pointFields.angleMaximum, copyData3DHeader.pointFields.angleMaximum );
-   EXPECT_EQ( originalData3DHeader.pointFields.angleScale, copyData3DHeader.pointFields.angleScale );
+   EXPECT_EQ( originalData3DHeader.pointFields.angleMinimum,
+              copyData3DHeader.pointFields.angleMinimum );
+   EXPECT_EQ( originalData3DHeader.pointFields.angleMaximum,
+              copyData3DHeader.pointFields.angleMaximum );
+   EXPECT_EQ( originalData3DHeader.pointFields.angleScale,
+              copyData3DHeader.pointFields.angleScale );
 
-   EXPECT_EQ( originalData3DHeader.pointFields.rowIndexField, copyData3DHeader.pointFields.rowIndexField );
-   EXPECT_EQ( originalData3DHeader.pointFields.rowIndexMaximum, copyData3DHeader.pointFields.rowIndexMaximum );
+   EXPECT_EQ( originalData3DHeader.pointFields.rowIndexField,
+              copyData3DHeader.pointFields.rowIndexField );
+   EXPECT_EQ( originalData3DHeader.pointFields.rowIndexMaximum,
+              copyData3DHeader.pointFields.rowIndexMaximum );
 
-   EXPECT_EQ( originalData3DHeader.pointFields.columnIndexField, copyData3DHeader.pointFields.columnIndexField );
-   EXPECT_EQ( originalData3DHeader.pointFields.columnIndexMaximum, copyData3DHeader.pointFields.columnIndexMaximum );
+   EXPECT_EQ( originalData3DHeader.pointFields.columnIndexField,
+              copyData3DHeader.pointFields.columnIndexField );
+   EXPECT_EQ( originalData3DHeader.pointFields.columnIndexMaximum,
+              copyData3DHeader.pointFields.columnIndexMaximum );
 
-   EXPECT_EQ( originalData3DHeader.pointFields.returnIndexField, copyData3DHeader.pointFields.returnIndexField );
-   EXPECT_EQ( originalData3DHeader.pointFields.returnCountField, copyData3DHeader.pointFields.returnCountField );
-   EXPECT_EQ( originalData3DHeader.pointFields.returnMaximum, copyData3DHeader.pointFields.returnMaximum );
+   EXPECT_EQ( originalData3DHeader.pointFields.returnIndexField,
+              copyData3DHeader.pointFields.returnIndexField );
+   EXPECT_EQ( originalData3DHeader.pointFields.returnCountField,
+              copyData3DHeader.pointFields.returnCountField );
+   EXPECT_EQ( originalData3DHeader.pointFields.returnMaximum,
+              copyData3DHeader.pointFields.returnMaximum );
 
-   EXPECT_EQ( originalData3DHeader.pointFields.timeStampField, copyData3DHeader.pointFields.timeStampField );
+   EXPECT_EQ( originalData3DHeader.pointFields.timeStampField,
+              copyData3DHeader.pointFields.timeStampField );
    EXPECT_EQ( originalData3DHeader.pointFields.isTimeStampInvalidField,
               copyData3DHeader.pointFields.isTimeStampInvalidField );
-   EXPECT_EQ( originalData3DHeader.pointFields.timeMinimum, copyData3DHeader.pointFields.timeMinimum );
-   EXPECT_EQ( originalData3DHeader.pointFields.timeMaximum, copyData3DHeader.pointFields.timeMaximum );
+   EXPECT_EQ( originalData3DHeader.pointFields.timeMinimum,
+              copyData3DHeader.pointFields.timeMinimum );
+   EXPECT_EQ( originalData3DHeader.pointFields.timeMaximum,
+              copyData3DHeader.pointFields.timeMaximum );
 
-   EXPECT_EQ( originalData3DHeader.pointFields.intensityField, copyData3DHeader.pointFields.intensityField );
+   EXPECT_EQ( originalData3DHeader.pointFields.intensityField,
+              copyData3DHeader.pointFields.intensityField );
    EXPECT_EQ( originalData3DHeader.pointFields.isIntensityInvalidField,
               copyData3DHeader.pointFields.isIntensityInvalidField );
-   EXPECT_EQ( originalData3DHeader.pointFields.intensityScale, copyData3DHeader.pointFields.intensityScale );
+   EXPECT_EQ( originalData3DHeader.pointFields.intensityScale,
+              copyData3DHeader.pointFields.intensityScale );
 
-   EXPECT_EQ( originalData3DHeader.pointFields.colorRedField, copyData3DHeader.pointFields.colorRedField );
-   EXPECT_EQ( originalData3DHeader.pointFields.colorGreenField, copyData3DHeader.pointFields.colorGreenField );
-   EXPECT_EQ( originalData3DHeader.pointFields.colorBlueField, copyData3DHeader.pointFields.colorBlueField );
-   EXPECT_EQ( originalData3DHeader.pointFields.isColorInvalidField, copyData3DHeader.pointFields.isColorInvalidField );
+   EXPECT_EQ( originalData3DHeader.pointFields.colorRedField,
+              copyData3DHeader.pointFields.colorRedField );
+   EXPECT_EQ( originalData3DHeader.pointFields.colorGreenField,
+              copyData3DHeader.pointFields.colorGreenField );
+   EXPECT_EQ( originalData3DHeader.pointFields.colorBlueField,
+              copyData3DHeader.pointFields.colorBlueField );
+   EXPECT_EQ( originalData3DHeader.pointFields.isColorInvalidField,
+              copyData3DHeader.pointFields.isColorInvalidField );
 
-   EXPECT_EQ( originalData3DHeader.pointFields.normalXField, copyData3DHeader.pointFields.normalXField );
-   EXPECT_EQ( originalData3DHeader.pointFields.normalYField, copyData3DHeader.pointFields.normalYField );
-   EXPECT_EQ( originalData3DHeader.pointFields.normalZField, copyData3DHeader.pointFields.normalZField );
+   EXPECT_EQ( originalData3DHeader.pointFields.normalXField,
+              copyData3DHeader.pointFields.normalXField );
+   EXPECT_EQ( originalData3DHeader.pointFields.normalYField,
+              copyData3DHeader.pointFields.normalYField );
+   EXPECT_EQ( originalData3DHeader.pointFields.normalZField,
+              copyData3DHeader.pointFields.normalZField );
 
    EXPECT_EQ( originalData3DHeader.pointCount, copyData3DHeader.pointCount );
 
    // 5. Compare the cartesianX FloatNode data
-   e57::CompressedVectorNode originalPointsStructureNode( originalReader->GetRawData3D().get( "/data3D/0/points" ) );
-   e57::CompressedVectorNode copyPointsStructureNode( copyReader->GetRawData3D().get( "/data3D/0/points" ) );
+   e57::CompressedVectorNode originalPointsStructureNode(
+      originalReader->GetRawData3D().get( "/data3D/0/points" ) );
+   e57::CompressedVectorNode copyPointsStructureNode(
+      copyReader->GetRawData3D().get( "/data3D/0/points" ) );
 
    const e57::StructureNode originalProto( originalPointsStructureNode.prototype() );
    const e57::StructureNode copyProto( copyPointsStructureNode.prototype() );

--- a/test/src/test_SimpleReader.cpp
+++ b/test/src/test_SimpleReader.cpp
@@ -52,7 +52,8 @@ TEST( SimpleReaderData, BadCRC )
 
 TEST( SimpleReaderData, DoNotCheckCRC )
 {
-   E57_ASSERT_NO_THROW( e57::Reader( TestData::Path() + "/self/bad-crc.e57", { e57::ChecksumNone } ) );
+   E57_ASSERT_NO_THROW(
+      e57::Reader( TestData::Path() + "/self/bad-crc.e57", { e57::ChecksumNone } ) );
 }
 
 // https://github.com/asmaloney/libE57Format/issues/26
@@ -71,7 +72,8 @@ TEST( SimpleReaderData, ColouredCubeFloat )
 {
    e57::Reader *reader = nullptr;
 
-   E57_ASSERT_NO_THROW( reader = new e57::Reader( TestData::Path() + "/self/ColouredCubeFloat.e57", {} ) );
+   E57_ASSERT_NO_THROW(
+      reader = new e57::Reader( TestData::Path() + "/self/ColouredCubeFloat.e57", {} ) );
 
    ASSERT_TRUE( reader->IsOpen() );
    EXPECT_EQ( reader->GetImage2DCount(), 0 );
@@ -108,7 +110,8 @@ TEST( SimpleReaderData, ColouredCubeFloatToDouble )
 {
    e57::Reader *reader = nullptr;
 
-   E57_ASSERT_NO_THROW( reader = new e57::Reader( TestData::Path() + "/self/ColouredCubeFloat.e57", {} ) );
+   E57_ASSERT_NO_THROW(
+      reader = new e57::Reader( TestData::Path() + "/self/ColouredCubeFloat.e57", {} ) );
 
    ASSERT_TRUE( reader->IsOpen() );
    EXPECT_EQ( reader->GetImage2DCount(), 0 );
@@ -145,7 +148,8 @@ TEST( SimpleReaderData, BunnyDouble )
 {
    e57::Reader *reader = nullptr;
 
-   E57_ASSERT_NO_THROW( reader = new e57::Reader( TestData::Path() + "/reference/bunnyDouble.e57", {} ) );
+   E57_ASSERT_NO_THROW( reader =
+                           new e57::Reader( TestData::Path() + "/reference/bunnyDouble.e57", {} ) );
 
    ASSERT_TRUE( reader->IsOpen() );
    EXPECT_EQ( reader->GetImage2DCount(), 0 );
@@ -182,7 +186,8 @@ TEST( SimpleReaderData, BunnyInt32 )
 {
    e57::Reader *reader = nullptr;
 
-   E57_ASSERT_NO_THROW( reader = new e57::Reader( TestData::Path() + "/reference/bunnyInt32.e57", {} ) );
+   E57_ASSERT_NO_THROW( reader =
+                           new e57::Reader( TestData::Path() + "/reference/bunnyInt32.e57", {} ) );
 
    ASSERT_TRUE( reader->IsOpen() );
    EXPECT_EQ( reader->GetImage2DCount(), 0 );
@@ -219,8 +224,8 @@ TEST( SimpleReaderData, ColourRepresentation )
 {
    e57::Reader *reader = nullptr;
 
-   E57_ASSERT_NO_THROW( reader =
-                           new e57::Reader( TestData::Path() + "/3rdParty/las2e57/ColourRepresentation.e57", {} ) );
+   E57_ASSERT_NO_THROW( reader = new e57::Reader(
+                           TestData::Path() + "/3rdParty/las2e57/ColourRepresentation.e57", {} ) );
 
    ASSERT_TRUE( reader->IsOpen() );
    EXPECT_EQ( reader->GetImage2DCount(), 0 );

--- a/test/src/test_SimpleWriter.cpp
+++ b/test/src/test_SimpleWriter.cpp
@@ -21,19 +21,23 @@ namespace
    using Cube = std::array<Point, 8>;
 
    constexpr auto cCubeCorners =
-      Cube{ Point{ -0.5f, -0.5f, -0.5f }, { 0.5f, -0.5f, -0.5f }, { 0.5f, 0.5f, -0.5f }, { -0.5f, 0.5f, -0.5f },
-            Point{ -0.5f, 0.5f, 0.5f },   { 0.5f, 0.5f, 0.5f },   { 0.5f, -0.5f, 0.5f }, { -0.5f, -0.5f, 0.5f } };
+      Cube{ Point{ -0.5f, -0.5f, -0.5f }, { 0.5f, -0.5f, -0.5f }, { 0.5f, 0.5f, -0.5f },
+            Point{ -0.5f, 0.5f, -0.5f },  { -0.5f, 0.5f, 0.5f },  { 0.5f, 0.5f, 0.5f },
+            Point{ 0.5f, -0.5f, 0.5f },   { -0.5f, -0.5f, 0.5f } };
 
    constexpr auto cIndexSequence = std::make_index_sequence<3>{};
 
    template <class T, size_t... Is, size_t N>
-   constexpr std::array<T, N> multiply( std::array<T, N> const &src, std::index_sequence<Is...>, T const &mul )
+   constexpr std::array<T, N> multiply( std::array<T, N> const &src, std::index_sequence<Is...>,
+                                        T const &mul )
    {
       return std::array<T, N>{ { ( src[Is] * mul )... } };
    }
 
-   // Call a function for each of the corner points for a cube centred on the origin, sized using cubeSize.
-   void generateCubeCornerPoints( float inCubeSize, const std::function<void( const Point &inPoint )> &lambda )
+   // Call a function for each of the corner points for a cube centred on the origin, sized using
+   // cubeSize.
+   void generateCubeCornerPoints( float inCubeSize,
+                                  const std::function<void( const Point &inPoint )> &lambda )
    {
       for ( const auto &point : cCubeCorners )
       {
@@ -45,9 +49,11 @@ namespace
    // Create "inPointsPerFace" pseudo-random points per face for a cube centred on the origin,
    // sized using cubeSize, and call a function for each of them.
    // This gives us a cube with non-uniform points which can be useful for testing.
-   // (Note that we set a seed in each test so the results will always be the same pseudo-random points.)
-   void generateCubePoints( float inCubeSize, uint16_t inPointsPerFace,
-                            const std::function<void( uint8_t inFace, const Point &inPoint )> &lambda )
+   // (Note that we set a seed in each test so the results will always be the same pseudo-random
+   // points.)
+   void generateCubePoints(
+      float inCubeSize, uint16_t inPointsPerFace,
+      const std::function<void( uint8_t inFace, const Point &inPoint )> &lambda )
    {
       Point point;
 
@@ -87,8 +93,8 @@ namespace
 
    // Fill in a point and its colour given an index, which face it is on, and the data.
    template <typename T>
-   inline void fillColouredCartesianPoint( e57::Data3DPointsData_t<T> &ioPointsData, int64_t inIndex, uint8_t inFace,
-                                           const Point &inPoint )
+   inline void fillColouredCartesianPoint( e57::Data3DPointsData_t<T> &ioPointsData,
+                                           int64_t inIndex, uint8_t inFace, const Point &inPoint )
    {
       static_assert( std::is_floating_point<T>::value, "Floating point type required." );
 
@@ -176,13 +182,19 @@ TEST( SimpleWriter, ColouredCubeDouble )
 
       fillColouredCartesianPoint( pointsData, i, inFace, inPoint );
 
-      header.pointFields.pointRangeMinimum = std::min( pointsData.cartesianX[i], header.pointFields.pointRangeMinimum );
-      header.pointFields.pointRangeMinimum = std::min( pointsData.cartesianY[i], header.pointFields.pointRangeMinimum );
-      header.pointFields.pointRangeMinimum = std::min( pointsData.cartesianZ[i], header.pointFields.pointRangeMinimum );
+      header.pointFields.pointRangeMinimum =
+         std::min( pointsData.cartesianX[i], header.pointFields.pointRangeMinimum );
+      header.pointFields.pointRangeMinimum =
+         std::min( pointsData.cartesianY[i], header.pointFields.pointRangeMinimum );
+      header.pointFields.pointRangeMinimum =
+         std::min( pointsData.cartesianZ[i], header.pointFields.pointRangeMinimum );
 
-      header.pointFields.pointRangeMaximum = std::max( pointsData.cartesianX[i], header.pointFields.pointRangeMaximum );
-      header.pointFields.pointRangeMaximum = std::max( pointsData.cartesianY[i], header.pointFields.pointRangeMaximum );
-      header.pointFields.pointRangeMaximum = std::max( pointsData.cartesianZ[i], header.pointFields.pointRangeMaximum );
+      header.pointFields.pointRangeMaximum =
+         std::max( pointsData.cartesianX[i], header.pointFields.pointRangeMaximum );
+      header.pointFields.pointRangeMaximum =
+         std::max( pointsData.cartesianY[i], header.pointFields.pointRangeMaximum );
+      header.pointFields.pointRangeMaximum =
+         std::max( pointsData.cartesianZ[i], header.pointFields.pointRangeMaximum );
 
       ++i;
    };
@@ -228,19 +240,19 @@ TEST( SimpleWriter, ColouredCubeFloat )
 
       fillColouredCartesianPoint( pointsData, i, inFace, inPoint );
 
-      header.pointFields.pointRangeMinimum =
-         std::min( static_cast<double>( pointsData.cartesianX[i] ), header.pointFields.pointRangeMinimum );
-      header.pointFields.pointRangeMinimum =
-         std::min( static_cast<double>( pointsData.cartesianY[i] ), header.pointFields.pointRangeMinimum );
-      header.pointFields.pointRangeMinimum =
-         std::min( static_cast<double>( pointsData.cartesianZ[i] ), header.pointFields.pointRangeMinimum );
+      header.pointFields.pointRangeMinimum = std::min(
+         static_cast<double>( pointsData.cartesianX[i] ), header.pointFields.pointRangeMinimum );
+      header.pointFields.pointRangeMinimum = std::min(
+         static_cast<double>( pointsData.cartesianY[i] ), header.pointFields.pointRangeMinimum );
+      header.pointFields.pointRangeMinimum = std::min(
+         static_cast<double>( pointsData.cartesianZ[i] ), header.pointFields.pointRangeMinimum );
 
-      header.pointFields.pointRangeMaximum =
-         std::max( static_cast<double>( pointsData.cartesianX[i] ), header.pointFields.pointRangeMaximum );
-      header.pointFields.pointRangeMaximum =
-         std::max( static_cast<double>( pointsData.cartesianY[i] ), header.pointFields.pointRangeMaximum );
-      header.pointFields.pointRangeMaximum =
-         std::max( static_cast<double>( pointsData.cartesianZ[i] ), header.pointFields.pointRangeMaximum );
+      header.pointFields.pointRangeMaximum = std::max(
+         static_cast<double>( pointsData.cartesianX[i] ), header.pointFields.pointRangeMaximum );
+      header.pointFields.pointRangeMaximum = std::max(
+         static_cast<double>( pointsData.cartesianY[i] ), header.pointFields.pointRangeMaximum );
+      header.pointFields.pointRangeMaximum = std::max(
+         static_cast<double>( pointsData.cartesianZ[i] ), header.pointFields.pointRangeMaximum );
 
       ++i;
    };
@@ -289,13 +301,19 @@ TEST( SimpleWriter, ColouredCubeScaledInt )
 
       fillColouredCartesianPoint( pointsData, i, inFace, inPoint );
 
-      header.pointFields.pointRangeMinimum = std::min( pointsData.cartesianX[i], header.pointFields.pointRangeMinimum );
-      header.pointFields.pointRangeMinimum = std::min( pointsData.cartesianY[i], header.pointFields.pointRangeMinimum );
-      header.pointFields.pointRangeMinimum = std::min( pointsData.cartesianZ[i], header.pointFields.pointRangeMinimum );
+      header.pointFields.pointRangeMinimum =
+         std::min( pointsData.cartesianX[i], header.pointFields.pointRangeMinimum );
+      header.pointFields.pointRangeMinimum =
+         std::min( pointsData.cartesianY[i], header.pointFields.pointRangeMinimum );
+      header.pointFields.pointRangeMinimum =
+         std::min( pointsData.cartesianZ[i], header.pointFields.pointRangeMinimum );
 
-      header.pointFields.pointRangeMaximum = std::max( pointsData.cartesianX[i], header.pointFields.pointRangeMaximum );
-      header.pointFields.pointRangeMaximum = std::max( pointsData.cartesianY[i], header.pointFields.pointRangeMaximum );
-      header.pointFields.pointRangeMaximum = std::max( pointsData.cartesianZ[i], header.pointFields.pointRangeMaximum );
+      header.pointFields.pointRangeMaximum =
+         std::max( pointsData.cartesianX[i], header.pointFields.pointRangeMaximum );
+      header.pointFields.pointRangeMaximum =
+         std::max( pointsData.cartesianY[i], header.pointFields.pointRangeMaximum );
+      header.pointFields.pointRangeMaximum =
+         std::max( pointsData.cartesianZ[i], header.pointFields.pointRangeMaximum );
 
       ++i;
    };
@@ -572,7 +590,8 @@ TEST( SimpleWriterData, VisualRefImage )
 
    E57_ASSERT_NO_THROW( writer = new e57::Writer( "./VisualRefImage.e57", options ) );
 
-   std::ifstream image( TestData::Path() + "/images/image.jpg", std::ifstream::ate | std::ifstream::binary );
+   std::ifstream image( TestData::Path() + "/images/image.jpg",
+                        std::ifstream::ate | std::ifstream::binary );
 
    ASSERT_EQ( image.rdstate(), std::ios_base::goodbit );
 
@@ -595,7 +614,8 @@ TEST( SimpleWriterData, VisualRefImage )
    image2DHeader.visualReferenceRepresentation.imageHeight = 300;
    image2DHeader.visualReferenceRepresentation.jpegImageSize = cImageSize;
 
-   writer->WriteImage2DData( image2DHeader, e57::ImageJPEG, e57::ProjectionVisual, 0, imageBuffer, cImageSize );
+   writer->WriteImage2DData( image2DHeader, e57::ImageJPEG, e57::ProjectionVisual, 0, imageBuffer,
+                             cImageSize );
 
    delete[] imageBuffer;
 


### PR DESCRIPTION
- go over all comments and make them consistent in their use of doxygen tags
- remove some useless comments
- clarify some doxygen docs
- fix some incorrect doxygen markup
- change line length to 100 (from 120) in clang-format
- reformat all code