### PR TITLE
E57Simple: Rename Data3DPointsData* structs to be explicit

### DIFF
--- a/include/E57SimpleData.h
+++ b/include/E57SimpleData.h
@@ -732,14 +732,19 @@ namespace e57
       bool _selfAllocated = false;
    };
 
-   using Data3DPointsData = Data3DPointsData_t<float>;
-   using Data3DPointsData_d = Data3DPointsData_t<double>;
+   using Data3DPointsFloat = Data3DPointsData_t<float>;
+   using Data3DPointsDouble = Data3DPointsData_t<double>;
 
-   extern template Data3DPointsData_t<float>::Data3DPointsData_t( Data3D &data3D );
-   extern template Data3DPointsData_t<double>::Data3DPointsData_t( Data3D &data3D );
+   using Data3DPointsData [[deprecated( "Will be removed in 4.0. Use Data3DPointsFloat." )]] =
+      Data3DPointsData_t<float>;
+   using Data3DPointsData_d [[deprecated( "Will be removed in 4.0. Use Data3DPointsDouble." )]] =
+      Data3DPointsData_t<double>;
 
-   extern template Data3DPointsData_t<float>::~Data3DPointsData_t();
-   extern template Data3DPointsData_t<double>::~Data3DPointsData_t();
+   extern template Data3DPointsFloat::Data3DPointsData_t( Data3D &data3D );
+   extern template Data3DPointsDouble::Data3DPointsData_t( Data3D &data3D );
+
+   extern template Data3DPointsFloat::~Data3DPointsData_t();
+   extern template Data3DPointsDouble::~Data3DPointsData_t();
 
    /// @brief Stores an image that is to be used only as a visual reference.
    struct E57_DLL VisualReferenceRepresentation

--- a/include/E57SimpleReader.h
+++ b/include/E57SimpleReader.h
@@ -175,11 +175,11 @@ namespace e57
       /// @param [in] buffers pointers to user-provided buffers
       /// @return vector reader setup to read the selected data into the provided buffers
       CompressedVectorReader SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
-                                                    const Data3DPointsData &buffers ) const;
+                                                    const Data3DPointsFloat &buffers ) const;
 
       /// @overload
       CompressedVectorReader SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
-                                                    const Data3DPointsData_d &buffers ) const;
+                                                    const Data3DPointsDouble &buffers ) const;
 
       ///@}
 

--- a/include/E57SimpleWriter.h
+++ b/include/E57SimpleWriter.h
@@ -138,10 +138,10 @@ namespace e57
       /// @param [in,out] data3DHeader metadata about what is included in the buffers
       /// @param [in] buffers pointers to user-provided buffers containing the actual data
       /// @return Returns the index of the new scan's data3D block.
-      int64_t WriteData3DData( Data3D &data3DHeader, const Data3DPointsData &buffers );
+      int64_t WriteData3DData( Data3D &data3DHeader, const Data3DPointsFloat &buffers );
 
       /// @overload
-      int64_t WriteData3DData( Data3D &data3DHeader, const Data3DPointsData_d &buffers );
+      int64_t WriteData3DData( Data3D &data3DHeader, const Data3DPointsDouble &buffers );
 
       /// @brief Writes a new Data3D header
       /// @details The user needs to config a Data3D structure with all the scanning information

--- a/src/E57SimpleData.cpp
+++ b/src/E57SimpleData.cpp
@@ -51,6 +51,8 @@ namespace e57
    template <typename COORDTYPE>
    Data3DPointsData_t<COORDTYPE>::Data3DPointsData_t( Data3D &data3D ) : _selfAllocated( true )
    {
+      static_assert( std::is_floating_point<COORDTYPE>::value, "Floating point type required." );
+
       _validateData3D( data3D );
 
       constexpr bool cIsFloat = std::is_same<COORDTYPE, float>::value;
@@ -202,6 +204,8 @@ namespace e57
 
    template <typename COORDTYPE> Data3DPointsData_t<COORDTYPE>::~Data3DPointsData_t()
    {
+      static_assert( std::is_floating_point<COORDTYPE>::value, "Floating point type required." );
+
       if ( !_selfAllocated )
       {
          return;
@@ -242,9 +246,9 @@ namespace e57
       *this = Data3DPointsData_t<COORDTYPE>();
    }
 
-   template Data3DPointsData_t<float>::Data3DPointsData_t( Data3D &data3D );
-   template Data3DPointsData_t<double>::Data3DPointsData_t( Data3D &data3D );
+   template Data3DPointsFloat::Data3DPointsData_t( Data3D &data3D );
+   template Data3DPointsDouble::Data3DPointsData_t( Data3D &data3D );
 
-   template Data3DPointsData_t<float>::~Data3DPointsData_t();
-   template Data3DPointsData_t<double>::~Data3DPointsData_t();
+   template Data3DPointsFloat::~Data3DPointsData_t();
+   template Data3DPointsDouble::~Data3DPointsData_t();
 } // end namespace e57

--- a/src/E57SimpleReader.cpp
+++ b/src/E57SimpleReader.cpp
@@ -135,13 +135,13 @@ namespace e57
    }
 
    CompressedVectorReader Reader::SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
-                                                         const Data3DPointsData &buffers ) const
+                                                         const Data3DPointsFloat &buffers ) const
    {
       return impl_->SetUpData3DPointsData( dataIndex, pointCount, buffers );
    }
 
    CompressedVectorReader Reader::SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
-                                                         const Data3DPointsData_d &buffers ) const
+                                                         const Data3DPointsDouble &buffers ) const
    {
       return impl_->SetUpData3DPointsData( dataIndex, pointCount, buffers );
    }

--- a/src/E57SimpleWriter.cpp
+++ b/src/E57SimpleWriter.cpp
@@ -220,7 +220,7 @@ namespace e57
       return static_cast<int64_t>( written );
    }
 
-   int64_t Writer::WriteData3DData( Data3D &data3DHeader, const Data3DPointsData &buffers )
+   int64_t Writer::WriteData3DData( Data3D &data3DHeader, const Data3DPointsFloat &buffers )
    {
       _fillMinMaxData( data3DHeader, buffers );
 
@@ -235,7 +235,7 @@ namespace e57
       return scanIndex;
    }
 
-   int64_t Writer::WriteData3DData( Data3D &data3DHeader, const Data3DPointsData_d &buffers )
+   int64_t Writer::WriteData3DData( Data3D &data3DHeader, const Data3DPointsDouble &buffers )
    {
       _fillMinMaxData( data3DHeader, buffers );
 

--- a/test/src/test_SimpleData.cpp
+++ b/test/src/test_SimpleData.cpp
@@ -14,7 +14,7 @@ TEST( SimpleDataHeader, InvalidPointCount )
 {
    e57::Data3D dataHeader;
 
-   E57_ASSERT_THROW( e57::Data3DPointsData pointsData( dataHeader ) );
+   E57_ASSERT_THROW( e57::Data3DPointsFloat pointsData( dataHeader ) );
 }
 
 TEST( SimpleDataHeader, InvalidPointRangeNodeType )
@@ -24,7 +24,7 @@ TEST( SimpleDataHeader, InvalidPointRangeNodeType )
    dataHeader.pointCount = 1;
    dataHeader.pointFields.pointRangeNodeType = e57::NumericalNodeType::Integer;
 
-   E57_ASSERT_THROW( e57::Data3DPointsData pointsData( dataHeader ) );
+   E57_ASSERT_THROW( e57::Data3DPointsFloat pointsData( dataHeader ) );
 }
 
 TEST( SimpleDataHeader, InvalidAngleNodeType )
@@ -34,7 +34,7 @@ TEST( SimpleDataHeader, InvalidAngleNodeType )
    dataHeader.pointCount = 1;
    dataHeader.pointFields.angleNodeType = e57::NumericalNodeType::Integer;
 
-   E57_ASSERT_THROW( e57::Data3DPointsData pointsData( dataHeader ) );
+   E57_ASSERT_THROW( e57::Data3DPointsFloat pointsData( dataHeader ) );
 }
 
 TEST( SimpleDataHeader, AutoSetNodeTypes )
@@ -46,7 +46,7 @@ TEST( SimpleDataHeader, AutoSetNodeTypes )
    // dataHeader.pointFields.pointRangeNodeType and dataHeader.pointFields.angleNodeType default to
    // Float but we are using a double structure. The constructor should correct these and set them
    // to Double.
-   e57::Data3DPointsData_d pointsData( dataHeader );
+   e57::Data3DPointsDouble pointsData( dataHeader );
 
    EXPECT_EQ( dataHeader.pointFields.pointRangeNodeType, e57::NumericalNodeType::Double );
    EXPECT_EQ( dataHeader.pointFields.angleNodeType, e57::NumericalNodeType::Double );
@@ -66,7 +66,7 @@ TEST( SimpleDataHeader, HeaderMinMaxFloat )
    EXPECT_EQ( dataHeader.pointFields.timeMaximum, e57::DOUBLE_MAX );
 
    // This call should adjust our min/max for a variety of fields since we are using floats.
-   e57::Data3DPointsData pointsData( dataHeader );
+   e57::Data3DPointsFloat pointsData( dataHeader );
 
    EXPECT_EQ( dataHeader.pointFields.pointRangeMinimum, e57::FLOAT_MIN );
    EXPECT_EQ( dataHeader.pointFields.pointRangeMaximum, e57::FLOAT_MAX );
@@ -90,7 +90,7 @@ TEST( SimpleDataHeader, HeaderMinMaxDouble )
    EXPECT_EQ( dataHeader.pointFields.timeMaximum, e57::DOUBLE_MAX );
 
    // This call should NOT adjust our min/max for a variety of fields since we are using doubles.
-   e57::Data3DPointsData_d pointsData( dataHeader );
+   e57::Data3DPointsDouble pointsData( dataHeader );
 
    EXPECT_EQ( dataHeader.pointFields.pointRangeMinimum, e57::DOUBLE_MIN );
    EXPECT_EQ( dataHeader.pointFields.pointRangeMaximum, e57::DOUBLE_MAX );
@@ -107,7 +107,7 @@ TEST( SimpleData, ReadWrite )
    e57::Reader *originalReader = nullptr;
    e57::E57Root originalFileHeader;
    e57::Data3D originalData3DHeader;
-   e57::Data3DPointsData_d *originalPointsData = nullptr;
+   e57::Data3DPointsDouble *originalPointsData = nullptr;
 
    // 1. Read in original file
    {
@@ -119,7 +119,7 @@ TEST( SimpleData, ReadWrite )
 
       const uint64_t cNumPoints = originalData3DHeader.pointCount;
 
-      originalPointsData = new e57::Data3DPointsData_d( originalData3DHeader );
+      originalPointsData = new e57::Data3DPointsDouble( originalData3DHeader );
 
       auto vectorReader =
          originalReader->SetUpData3DPointsData( 0, cNumPoints, *originalPointsData );
@@ -157,7 +157,7 @@ TEST( SimpleData, ReadWrite )
 
       const uint64_t cNumPoints = copyData3DHeader.pointCount;
 
-      e57::Data3DPointsData_d copyPointsData( copyData3DHeader );
+      e57::Data3DPointsDouble copyPointsData( copyData3DHeader );
 
       auto vectorReader = copyReader->SetUpData3DPointsData( 0, cNumPoints, copyPointsData );
 

--- a/test/src/test_SimpleReader.cpp
+++ b/test/src/test_SimpleReader.cpp
@@ -93,7 +93,7 @@ TEST( SimpleReaderData, ColouredCubeFloat )
 
    const uint64_t cNumPoints = data3DHeader.pointCount;
 
-   e57::Data3DPointsData pointsData( data3DHeader );
+   e57::Data3DPointsFloat pointsData( data3DHeader );
 
    auto vectorReader = reader->SetUpData3DPointsData( 0, cNumPoints, pointsData );
 
@@ -131,7 +131,7 @@ TEST( SimpleReaderData, ColouredCubeFloatToDouble )
 
    const uint64_t cNumPoints = data3DHeader.pointCount;
 
-   e57::Data3DPointsData_d pointsData( data3DHeader );
+   e57::Data3DPointsDouble pointsData( data3DHeader );
 
    auto vectorReader = reader->SetUpData3DPointsData( 0, cNumPoints, pointsData );
 
@@ -169,7 +169,7 @@ TEST( SimpleReaderData, BunnyDouble )
 
    const uint64_t cNumPoints = data3DHeader.pointCount;
 
-   e57::Data3DPointsData pointsData( data3DHeader );
+   e57::Data3DPointsFloat pointsData( data3DHeader );
 
    auto vectorReader = reader->SetUpData3DPointsData( 0, cNumPoints, pointsData );
 
@@ -207,7 +207,7 @@ TEST( SimpleReaderData, BunnyInt32 )
 
    const uint64_t cNumPoints = data3DHeader.pointCount;
 
-   e57::Data3DPointsData pointsData( data3DHeader );
+   e57::Data3DPointsFloat pointsData( data3DHeader );
 
    auto vectorReader = reader->SetUpData3DPointsData( 0, cNumPoints, pointsData );
 
@@ -245,7 +245,7 @@ TEST( SimpleReaderData, ColourRepresentation )
 
    const uint64_t cNumPoints = data3DHeader.pointCount;
 
-   e57::Data3DPointsData pointsData( data3DHeader );
+   e57::Data3DPointsFloat pointsData( data3DHeader );
 
    auto vectorReader = reader->SetUpData3DPointsData( 0, cNumPoints, pointsData );
 

--- a/test/src/test_SimpleWriter.cpp
+++ b/test/src/test_SimpleWriter.cpp
@@ -170,7 +170,7 @@ TEST( SimpleWriter, ColouredCubeDouble )
 
    setUsingColouredCartesianPoints( header );
 
-   e57::Data3DPointsData_d pointsData( header );
+   e57::Data3DPointsDouble pointsData( header );
 
    // reset these so we can calculate them using min/max
    header.pointFields.pointRangeMinimum = e57::DOUBLE_MAX;
@@ -228,7 +228,7 @@ TEST( SimpleWriter, ColouredCubeFloat )
 
    setUsingColouredCartesianPoints( header );
 
-   e57::Data3DPointsData pointsData( header );
+   e57::Data3DPointsFloat pointsData( header );
 
    // reset these so we can calculate them using min/max
    header.pointFields.pointRangeMinimum = e57::FLOAT_MAX;
@@ -289,7 +289,7 @@ TEST( SimpleWriter, ColouredCubeScaledInt )
 
    setUsingColouredCartesianPoints( header );
 
-   e57::Data3DPointsData_d pointsData( header );
+   e57::Data3DPointsDouble pointsData( header );
 
    // reset these so we can calculate them using min/max
    header.pointFields.pointRangeMinimum = e57::DOUBLE_MAX;
@@ -342,7 +342,7 @@ TEST( SimpleWriter, MultipleScans )
    header.pointFields.cartesianYField = true;
    header.pointFields.cartesianZField = true;
 
-   e57::Data3DPointsData pointsData( header );
+   e57::Data3DPointsFloat pointsData( header );
 
    // scan 1
    header.guid = "Multiple Scans Scan 1 Header GUID";
@@ -406,7 +406,7 @@ TEST( SimpleWriter, CartesianPoints )
    header.pointFields.cartesianYField = true;
    header.pointFields.cartesianZField = true;
 
-   e57::Data3DPointsData pointsData( header );
+   e57::Data3DPointsFloat pointsData( header );
 
    for ( int64_t i = 0; i < cNumPoints; ++i )
    {
@@ -438,7 +438,7 @@ TEST( SimpleWriter, ColouredCartesianPoints )
 
    setUsingColouredCartesianPoints( header );
 
-   e57::Data3DPointsData pointsData( header );
+   e57::Data3DPointsFloat pointsData( header );
 
    for ( int64_t i = 0; i < cNumPoints; ++i )
    {
@@ -486,7 +486,7 @@ TEST( SimpleWriter, MinMaxIssuesCartesianFloat )
    header.pointFields.intensityNodeType = e57::NumericalNodeType::ScaledInteger;
    header.pointFields.intensityScale = 0.1;
 
-   e57::Data3DPointsData pointsData( header );
+   e57::Data3DPointsFloat pointsData( header );
 
    for ( int64_t i = 0; i < cNumPoints; ++i )
    {
@@ -548,7 +548,7 @@ TEST( SimpleWriter, MinMaxIssuesSpericalDouble )
    header.pointFields.intensityNodeType = e57::NumericalNodeType::ScaledInteger;
    header.pointFields.intensityScale = 0.1;
 
-   e57::Data3DPointsData_d pointsData( header );
+   e57::Data3DPointsDouble pointsData( header );
 
    for ( int64_t i = 0; i < cNumPoints; ++i )
    {


### PR DESCRIPTION
`Data3DPointsData` ➡️ `Data3DPointsFloat`
`Data3DPointsData_d` ➡️ `Data3DPointsDouble`

Old versions are marked as deprecated.