### PR TITLE
src/StringFunctions.h: add missing <cstdint> header

### DIFF
--- a/src/StringFunctions.h
+++ b/src/StringFunctions.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iomanip>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
Without the change build fails on weekly `gcc-13` as:

    In file included from src/StructureNode.cpp:32:
    src/StringFunctions.h:56:34:
      error: 'uint8_t' was not declared in this scope
       56 |    inline std::string hexString( uint8_t x )
          |                                  ^~~~~~~
    src/StringFunctions.h:32:1:
      note: 'uint8_t' is defined in header '<cstdint>';
        did you forget to '#include <cstdint>'?
       31 | #include <iostream>
      +++ |+#include <cstdint>
       32 | #include <sstream>