### PR TITLE
Improve version interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,7 @@ target_compile_features( ${PROJECT_NAME}
 # Target definitions
 target_compile_definitions( E57Format
     PRIVATE
-        REVISION_ID="${revision_id}"
+        REVISION_ID="${REVISION_ID}"
 )
 
 if ( E57_DEBUG )

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources( ${PROJECT_NAME}
 		${CMAKE_CURRENT_LIST_DIR}/E57SimpleData.h
 		${CMAKE_CURRENT_LIST_DIR}/E57SimpleReader.h
 		${CMAKE_CURRENT_LIST_DIR}/E57SimpleWriter.h
+		E57Version.h
 )
 
 install(

--- a/include/E57Exception.h
+++ b/include/E57Exception.h
@@ -332,9 +332,6 @@ namespace e57
 
    namespace Utilities
    {
-      // Get latest version of ASTM standard supported, and library id string
-      E57_DLL void getVersions( int &astmMajor, int &astmMinor, std::string &libraryId );
-
       E57_DLL std::string errorCodeToString( ErrorCode ecode ) noexcept;
    }
 }

--- a/include/E57Version.h
+++ b/include/E57Version.h
@@ -1,0 +1,72 @@
+#pragma once
+// Copyright © 2022 Andy Maloney <asmaloney@gmail.com>
+// SPDX-License-Identifier: MIT
+
+/// @file E57Version.h ASTM & libE57Format version information.
+
+#include <string>
+
+#include "E57Export.h"
+
+namespace e57
+{
+   namespace Version
+   {
+      /*!
+      @brief Get the version of the ASTM E57 standard that libE57Format supports.
+
+      @returns The version as a string (e.g. "1.0")
+      */
+      E57_DLL std::string astm();
+
+      /*!
+      @brief Get the major version of the ASTM E57 standard that libE57Format supports.
+
+      @returns The major version
+      */
+      E57_DLL uint32_t astmMajor();
+
+      /*!
+      @brief Get the minor version of the ASTM E57 standard that libE57Format supports.
+
+      @returns The minor version
+      */
+      E57_DLL uint32_t astmMinor();
+
+      /*!
+      @brief Get the version of libE57Format library.
+
+      @returns The version as a string (e.g. "E57Format-3.0.0-x86_64-darwin").
+      */
+      E57_DLL std::string library();
+
+      /*!
+      @brief Get the version of ASTM E57 standard that the API implementation supports, and library
+      id string.
+
+      @param [out] astmMajor The major version number of the ASTM E57 standard supported.
+      @param [out] astmMinor The minor version number of the ASTM E57 standard supported.
+      @param [out] libraryId A string identifying the implementation of the API.
+
+      @details
+      Since the E57 implementation may be dynamically linked underneath the API, the version string
+      for the implementation and the ASTM version that it supports can't be determined at
+      compile-time. This function returns these identifiers from the underlying implementation.
+
+      @throw No E57Exceptions.
+      */
+      E57_DLL void get( uint32_t &astmMajor, uint32_t &astmMinor, std::string &libraryId );
+   }
+
+   namespace Utilities
+   {
+      /*!
+      @copydetails Version::get()
+      @deprecated Will be removed in 4.0. Use Version::get() or other functions in the Version
+      namespace.
+      */
+      [[deprecated( "Will be removed in 4.0. Use Version::get() or other functions in the Version "
+                    "namespace." )]] E57_DLL void
+         getVersions( int &astmMajor, int &astmMinor, std::string &libraryId );
+   }
+}

--- a/src/ASTMVersion.h
+++ b/src/ASTMVersion.h
@@ -1,6 +1,6 @@
 #pragma once
+// Copyright © 2022 Andy Maloney <asmaloney@gmail.com>
 // SPDX-License-Identifier: MIT
-// Copyright 2020 Andy Maloney <asmaloney@gmail.com>
 
 #include <cstdint>
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 target_sources( E57Format
     PRIVATE
+        ASTMVersion.h
         ${CMAKE_CURRENT_LIST_DIR}/BlobNode.cpp
         ${CMAKE_CURRENT_LIST_DIR}/BlobNodeImpl.h
         ${CMAKE_CURRENT_LIST_DIR}/BlobNodeImpl.cpp
@@ -66,7 +67,7 @@ target_sources( E57Format
         ${CMAKE_CURRENT_LIST_DIR}/E57SimpleData.cpp
         ${CMAKE_CURRENT_LIST_DIR}/E57SimpleReader.cpp
         ${CMAKE_CURRENT_LIST_DIR}/E57SimpleWriter.cpp
-        ${CMAKE_CURRENT_LIST_DIR}/E57Version.h
+        E57Version.cpp
         ${CMAKE_CURRENT_LIST_DIR}/E57XmlParser.cpp
         ${CMAKE_CURRENT_LIST_DIR}/E57XmlParser.h
 )

--- a/src/E57Exception.cpp
+++ b/src/E57Exception.cpp
@@ -277,34 +277,6 @@ namespace e57
    //=====================================================================================
 
    /*!
-   @brief Get the version of ASTM E57 standard that the API implementation supports, and library id
-   string.
-
-   @param [out] astmMajor The major version number of the ASTM E57 standard supported.
-   @param [out] astmMinor The minor version number of the ASTM E57 standard supported.
-   @param [out] libraryId A string identifying the implementation of the API.
-
-   @details
-   Since the E57 implementation may be dynamically linked underneath the API, the version string for
-   the implementation and the ASTM version that it supports can't be determined at compile-time.
-   This function returns these identifiers from the underlying implementation.
-
-   @throw No E57Exceptions.
-   */
-   void Utilities::getVersions( int &astmMajor, int &astmMinor, std::string &libraryId )
-   {
-      // REVISION_ID should be passed from compiler command line
-
-#ifndef REVISION_ID
-#error "Need to specify REVISION_ID on command line"
-#endif
-
-      astmMajor = E57_FORMAT_MAJOR;
-      astmMinor = E57_FORMAT_MINOR;
-      libraryId = REVISION_ID;
-   }
-
-   /*!
    @brief Get short string description of an E57 ErrorCode.
 
    @param [in] ecode The numeric errorCode from an E57Exception.

--- a/src/E57Version.cpp
+++ b/src/E57Version.cpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2020 Andy Maloney <asmaloney@gmail.com>
+
+#include <sstream>
+
+#include "ASTMVersion.h"
+#include "E57Version.h"
+
+namespace e57
+{
+   // REVISION_ID should be passed from compiler command line
+#ifndef REVISION_ID
+#error "Need to specify REVISION_ID on command line"
+#endif
+
+   std::string Version::astm()
+   {
+      std::ostringstream stringStream;
+      stringStream << E57_FORMAT_MAJOR << "." << E57_FORMAT_MINOR;
+      return stringStream.str();
+   }
+
+   uint32_t Version::astmMajor()
+   {
+      return E57_FORMAT_MAJOR;
+   }
+
+   uint32_t Version::astmMinor()
+   {
+      return E57_FORMAT_MINOR;
+   }
+
+   std::string Version::library()
+   {
+      return REVISION_ID;
+   }
+
+   void Version::get( uint32_t &astmMajor, uint32_t &astmMinor, std::string &libraryId )
+   {
+      astmMajor = E57_FORMAT_MAJOR;
+      astmMinor = E57_FORMAT_MINOR;
+      libraryId = REVISION_ID;
+   }
+
+   namespace Utilities
+   {
+      void getVersions( int &astmMajor, int &astmMinor, std::string &libraryId )
+      {
+         astmMajor = E57_FORMAT_MAJOR;
+         astmMinor = E57_FORMAT_MINOR;
+         libraryId = REVISION_ID;
+      }
+   }
+
+}

--- a/src/ImageFileImpl.cpp
+++ b/src/ImageFileImpl.cpp
@@ -26,8 +26,8 @@
  */
 
 #include "ImageFileImpl.h"
+#include "ASTMVersion.h"
 #include "CheckedFile.h"
-#include "E57Version.h"
 #include "E57XmlParser.h"
 #include "StringFunctions.h"
 #include "StructureNodeImpl.h"

--- a/src/WriterImpl.cpp
+++ b/src/WriterImpl.cpp
@@ -26,10 +26,12 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+#include <cmath>
+
 #include "WriterImpl.h"
 
 #include "Common.h"
-#include <cmath>
+#include "E57Version.h"
 
 namespace e57
 {
@@ -105,15 +107,9 @@ namespace e57
          root_.set( "guid", StringNode( imf_, generateRandomGUID() ) );
       }
 
-      // Get ASTM version number supported by library, so can write it into file
-      int astmMajor;
-      int astmMinor;
-      ustring libraryId;
-      Utilities::getVersions( astmMajor, astmMinor, libraryId );
-
-      root_.set( "versionMajor", IntegerNode( imf_, astmMajor ) );
-      root_.set( "versionMinor", IntegerNode( imf_, astmMinor ) );
-      root_.set( "e57LibraryVersion", StringNode( imf_, libraryId ) );
+      root_.set( "versionMajor", IntegerNode( imf_, Version::astmMajor() ) );
+      root_.set( "versionMinor", IntegerNode( imf_, Version::astmMinor() ) );
+      root_.set( "e57LibraryVersion", StringNode( imf_, Version::library() ) );
 
       // Save a dummy string for coordinate system.
       // Really should be a valid WKT string identifying the coordinate reference system (CRS).

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -3,6 +3,8 @@
 
 #include "gtest/gtest.h"
 
+#include "E57Version.h"
+
 #include "RandomNum.h"
 #include "TestData.h"
 
@@ -18,6 +20,9 @@ int main( int argc, char **argv )
    {
       ::testing::GTEST_FLAG( filter ) = "-*Data.*";
    }
+
+   std::cout << "e57Format version: " << e57::Version::library() << std::endl;
+   std::cout << "ASTM version: " << e57::Version::astm() << std::endl;
 
    int result = RUN_ALL_TESTS();
 


### PR DESCRIPTION
- fix revision ID
- move version interface out of the exception header
- add better interface to get ASTM & library versions
- deprecate Utilities::getVersions()