### PR TITLE
Static analysis fixes

### DIFF
--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -656,12 +656,13 @@ void CheckedFile::unlink()
 
    // Try to remove the file, don't report a failure
    int result = std::remove( fileName_.c_str() ); //??? unicode support here
-   (void)result;                                  // this maybe unused
 #ifdef E57_MAX_VERBOSE
    if ( result < 0 )
    {
       std::cout << "std::remove() failed, result=" << result << std::endl;
    }
+#else
+   UNUSED( result );
 #endif
 }
 

--- a/src/CheckedFile.h
+++ b/src/CheckedFile.h
@@ -122,7 +122,7 @@ namespace e57
    inline uint64_t CheckedFile::physicalToLogical( uint64_t physicalOffset )
    {
       const uint64_t page = physicalOffset >> physicalPageSizeLog2;
-      const size_t remainder = static_cast<size_t>( physicalOffset & physicalPageSizeMask );
+      const auto remainder = static_cast<size_t>( physicalOffset & physicalPageSizeMask );
 
       return page * logicalPageSize + std::min( remainder, logicalPageSize );
    }

--- a/src/Common.h
+++ b/src/Common.h
@@ -42,6 +42,9 @@
 #pragma warning( disable : 4224 )
 #endif
 
+// Used to mark unused parameters to indicate intent and supress warnings.
+#define UNUSED( expr ) (void)( expr )
+
 namespace e57
 {
 #define E57_EXCEPTION1( ecode )                                                                    \

--- a/src/Decoder.cpp
+++ b/src/Decoder.cpp
@@ -875,6 +875,9 @@ size_t ConstantIntegerDecoder::inputProcess( const char *source, const size_t av
 #ifdef E57_MAX_VERBOSE
    std::cout << "ConstantIntegerDecoder::inputprocess() called, source=" << (void *)( source )
              << " availableByteCount=" << availableByteCount << std::endl;
+#else
+   UNUSED( source );
+   UNUSED( availableByteCount );
 #endif
 
    // We don't need any input bytes to produce output, so ignore source and

--- a/src/E57SimpleData.cpp
+++ b/src/E57SimpleData.cpp
@@ -4,6 +4,7 @@
 
 // For M_PI. This needs to be first, otherwise we might already include math header without M_PI and
 // we would get nothing because of the header guards.
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c)
 #define _USE_MATH_DEFINES
 #include <cmath>
 

--- a/src/E57XmlParser.cpp
+++ b/src/E57XmlParser.cpp
@@ -96,7 +96,7 @@ namespace
    ustring toUString( const XMLCh *const xml_str )
    {
       ustring u_str;
-      if ( xml_str && *xml_str )
+      if ( ( xml_str != nullptr ) && *xml_str )
       {
          TranscodeToStr UTF8Transcoder( xml_str, "UTF-8" );
          u_str = ustring( reinterpret_cast<const char *>( UTF8Transcoder.str() ) );
@@ -887,7 +887,10 @@ void E57XmlParser::characters( const XMLCh *const chars, const XMLSize_t length 
 //??? use length to make ustring
 #ifdef E57_MAX_VERBOSE
    std::cout << "characters, chars=\"" << toUString( chars ) << "\" length=" << length << std::endl;
+#else
+   UNUSED( length );
 #endif
+
    // Get active element
    ParseInfo &pi = stack_.top();
 

--- a/src/ImageFileImpl.h
+++ b/src/ImageFileImpl.h
@@ -73,18 +73,21 @@ namespace e57
       bool isElementNameLegal( const ustring &elementName, bool allowNumber = true );
       bool isPathNameLegal( const ustring &pathName );
       void checkElementNameLegal( const ustring &elementName, bool allowNumber = true );
-      void elementNameParse( const ustring &elementName, ustring &prefix, ustring &localPart,
-                             bool allowNumber = true );
 
       void pathNameCheckWellFormed( const ustring &pathName );
       void pathNameParse( const ustring &pathName, bool &isRelative, StringList &fields );
-      ustring pathNameUnparse( bool isRelative, const StringList &fields );
 
-      unsigned bitsNeeded( int64_t minimum, int64_t maximum );
       void incrWriterCount();
       void decrWriterCount();
       void incrReaderCount();
       void decrReaderCount();
+
+      static void elementNameParse( const ustring &elementName, ustring &prefix, ustring &localPart,
+                                    bool allowNumber = true );
+
+      static ustring pathNameUnparse( bool isRelative, const StringList &fields );
+
+      static unsigned bitsNeeded( int64_t minimum, int64_t maximum );
 
 #ifdef E57_DEBUG
       void dump( int indent = 0, std::ostream &os = std::cout ) const;

--- a/src/NodeImpl.h
+++ b/src/NodeImpl.h
@@ -90,11 +90,10 @@ namespace e57
       friend class Encoder;
 
       explicit NodeImpl( ImageFileImplWeakPtr destImageFile );
-      NodeImpl &operator=( NodeImpl &n );
 
       virtual NodeImplSharedPtr lookup( const ustring & /*pathName*/ )
       {
-         return NodeImplSharedPtr();
+         return {};
       }
 
       NodeImplSharedPtr getRoot();

--- a/src/Packet.cpp
+++ b/src/Packet.cpp
@@ -170,6 +170,8 @@ void PacketReadCache::unlock( unsigned cacheIndex )
    //??? why lockedEntry not used?
 #ifdef E57_MAX_VERBOSE
    std::cout << "PacketReadCache::unlock() called, cacheIndex=" << cacheIndex << std::endl;
+#else
+   UNUSED( cacheIndex );
 #endif
 
    if ( lockCount_ != 1 )
@@ -382,7 +384,7 @@ void DataPacketHeader::verify( unsigned bufferLength ) const
    }
 
    // Check packet is at least long enough to hold bytestreamBufferLength array
-   if ( sizeof( DataPacketHeader ) + 2 * bytestreamCount > packetLength )
+   if ( ( sizeof( DataPacketHeader ) + 2 * bytestreamCount ) > packetLength )
    {
       throw E57_EXCEPTION2( ErrorBadCVPacket,
                             "packetLength=" + toString( packetLength ) +
@@ -408,7 +410,7 @@ void DataPacketHeader::dump( int indent, std::ostream &os ) const
 DataPacket::DataPacket()
 {
    // Double check that packet struct is correct length.  Watch out for RTTI increasing the size.
-   static_assert( sizeof( DataPacket ) == 64 * 1024, "Unexpected size of DataPacket" );
+   static_assert( sizeof( DataPacket ) == ( 64 * 1024 ), "Unexpected size of DataPacket" );
 }
 
 void DataPacket::verify( unsigned bufferLength ) const
@@ -490,7 +492,7 @@ char *DataPacket::getBytestream( unsigned bytestreamNumber, unsigned &byteCount 
    byteCount = bsbLength[bytestreamNumber];
 
    // Double check buffer is completely within packet
-   if ( sizeof( DataPacketHeader ) + 2 * header.bytestreamCount + totalPreceeding + byteCount >
+   if ( ( sizeof( DataPacketHeader ) + 2 * header.bytestreamCount + totalPreceeding + byteCount ) >
         header.packetLogicalLengthMinus1 + 1U )
    {
       throw E57_EXCEPTION2( ErrorInternal, "bytestreamCount=" + toString( header.bytestreamCount ) +
@@ -508,7 +510,7 @@ unsigned DataPacket::getBytestreamBufferLength( unsigned bytestreamNumber )
 {
    //??? for now:
    unsigned byteCount;
-   (void)getBytestream( bytestreamNumber, byteCount );
+   getBytestream( bytestreamNumber, byteCount );
    return ( byteCount );
 }
 
@@ -552,6 +554,11 @@ void DataPacket::dump( int indent, std::ostream &os ) const
 void IndexPacket::verify( unsigned bufferLength, uint64_t totalRecordCount,
                           uint64_t fileSize ) const
 {
+#ifndef E57_MAX_DEBUG
+   UNUSED( totalRecordCount );
+   UNUSED( fileSize );
+#endif
+
    //??? do all packets need versions?  how extend without breaking older
    // checking?  need to check
    // file version#?

--- a/src/StructureNodeImpl.cpp
+++ b/src/StructureNodeImpl.cpp
@@ -162,7 +162,7 @@ NodeImplSharedPtr StructureNodeImpl::lookup( const ustring &pathName )
       {
          if ( isRelative )
          {
-            return NodeImplSharedPtr(); // empty pointer
+            return {}; // empty pointer
          }
 
          NodeImplSharedPtr root( getRoot() );
@@ -180,7 +180,7 @@ NodeImplSharedPtr StructureNodeImpl::lookup( const ustring &pathName )
       }
       if ( i == children_.size() )
       {
-         return NodeImplSharedPtr(); // empty pointer
+         return {}; // empty pointer
       }
 
       if ( fields.size() == 1 )

--- a/src/VectorNodeImpl.cpp
+++ b/src/VectorNodeImpl.cpp
@@ -130,7 +130,7 @@ namespace e57
       // don't checkImageFileOpen
       os << space( indent ) << "type:        Vector"
          << " (" << type() << ")" << std::endl;
-      NodeImpl::dump( indent, os );
+      NodeImpl::dump( indent, os ); // NOLINT(bugprone-parent-virtual-call)
       os << space( indent ) << "allowHeteroChildren: " << allowHeteroChildren() << std::endl;
       for ( unsigned i = 0; i < children_.size(); i++ )
       {


### PR DESCRIPTION
- mark parameters as UNUSED
- use auto to avoid repetition
- suppress some clang-tidy warnings explicitly
- compare with nullptr
- make some functions static (and reorder functions in code to match header order)
- use brace-style returns