### PR TITLE
Fix warnings

### DIFF
--- a/include/E57SimpleData.h
+++ b/include/E57SimpleData.h
@@ -742,11 +742,11 @@ namespace e57
    using Data3DPointsData_d [[deprecated( "Will be removed in 4.0. Use Data3DPointsDouble." )]] =
       Data3DPointsData_t<double>;
 
-   extern template Data3DPointsFloat::Data3DPointsData_t( Data3D &data3D );
-   extern template Data3DPointsDouble::Data3DPointsData_t( Data3D &data3D );
+   extern template Data3DPointsData_t<float>::Data3DPointsData_t( Data3D &data3D );
+   extern template Data3DPointsData_t<double>::Data3DPointsData_t( Data3D &data3D );
 
-   extern template Data3DPointsFloat::~Data3DPointsData_t();
-   extern template Data3DPointsDouble::~Data3DPointsData_t();
+   extern template Data3DPointsData_t<float>::~Data3DPointsData_t();
+   extern template Data3DPointsData_t<double>::~Data3DPointsData_t();
 
    /// @brief Stores an image that is to be used only as a visual reference.
    struct E57_DLL VisualReferenceRepresentation

--- a/include/E57SimpleWriter.h
+++ b/include/E57SimpleWriter.h
@@ -163,13 +163,13 @@ namespace e57
       [[deprecated( "Will be removed in 4.0. Use WriteData3DData()." )]] // TODO Remove in 4.0
       CompressedVectorWriter
          SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
-                                const Data3DPointsData &buffers );
+                                const Data3DPointsFloat &buffers );
 
       /// @overload
       [[deprecated( "Will be removed in 4.0. Use WriteData3DData()." )]] // TODO Remove in 4.0
       CompressedVectorWriter
          SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
-                                const Data3DPointsData_d &buffers );
+                                const Data3DPointsDouble &buffers );
 
       /// @brief Writes out the group data
       /// @param [in] dataIndex data block index given by the NewData3D

--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -235,10 +235,16 @@ int CheckedFile::open64( const ustring &fileName, int flags, int mode )
    errno_t err = _wsopen_s( &handle, widePath.c_str(), flags, _SH_DENYNO, mode );
    if ( err != 0 )
    {
+// MSVC doesn't implement strerrorlen_s for some unknown reason, so just disable the warning
+#pragma warning( push )
+#pragma warning( disable : 4996 )
+
       throw E57_EXCEPTION2( ErrorOpenFailed, "errno=" + toString( errno ) + " error='" +
                                                 strerror( errno ) + "' fileName=" + fileName +
                                                 " flags=" + toString( flags ) +
                                                 " mode=" + toString( mode ) );
+
+#pragma warning( pop )
    }
    return handle;
 #elif defined( __GNUC__ )

--- a/src/CompressedVectorReaderImpl.cpp
+++ b/src/CompressedVectorReaderImpl.cpp
@@ -577,6 +577,9 @@ namespace e57
                                                         const char *srcFunctionName ) const
    {
       // unimplemented...
+      UNUSED( srcFileName );
+      UNUSED( srcLineNumber );
+      UNUSED( srcFunctionName );
    }
 
    void CompressedVectorReaderImpl::checkReaderOpen( const char *srcFileName, int srcLineNumber,

--- a/src/CompressedVectorWriterImpl.cpp
+++ b/src/CompressedVectorWriterImpl.cpp
@@ -621,6 +621,9 @@ namespace e57
                                                         const char *srcFunctionName ) const
    {
       // unimplemented...
+      UNUSED( srcFileName );
+      UNUSED( srcLineNumber );
+      UNUSED( srcFunctionName );
    }
 
    void CompressedVectorWriterImpl::checkWriterOpen( const char *srcFileName, int srcLineNumber,

--- a/src/E57SimpleData.cpp
+++ b/src/E57SimpleData.cpp
@@ -247,9 +247,9 @@ namespace e57
       *this = Data3DPointsData_t<COORDTYPE>();
    }
 
-   template Data3DPointsFloat::Data3DPointsData_t( Data3D &data3D );
-   template Data3DPointsDouble::Data3DPointsData_t( Data3D &data3D );
+   template Data3DPointsData_t<float>::Data3DPointsData_t( Data3D &data3D );
+   template Data3DPointsData_t<double>::Data3DPointsData_t( Data3D &data3D );
 
-   template Data3DPointsFloat::~Data3DPointsData_t();
-   template Data3DPointsDouble::~Data3DPointsData_t();
+   template Data3DPointsData_t<float>::~Data3DPointsData_t();
+   template Data3DPointsData_t<double>::~Data3DPointsData_t();
 } // end namespace e57

--- a/src/E57SimpleWriter.cpp
+++ b/src/E57SimpleWriter.cpp
@@ -159,9 +159,9 @@ namespace
       }
    }
    template void _fillMinMaxData( e57::Data3D &ioData3DHeader,
-                                  const e57::Data3DPointsData &inBuffers );
+                                  const e57::Data3DPointsFloat &inBuffers );
    template void _fillMinMaxData( e57::Data3D &ioData3DHeader,
-                                  const e57::Data3DPointsData_d &inBuffers );
+                                  const e57::Data3DPointsDouble &inBuffers );
 }
 
 namespace e57
@@ -256,13 +256,13 @@ namespace e57
    };
 
    CompressedVectorWriter Writer::SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
-                                                         const Data3DPointsData &buffers )
+                                                         const Data3DPointsFloat &buffers )
    {
       return impl_->SetUpData3DPointsData( dataIndex, pointCount, buffers );
    }
 
    CompressedVectorWriter Writer::SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
-                                                         const Data3DPointsData_d &buffers )
+                                                         const Data3DPointsDouble &buffers )
    {
       return impl_->SetUpData3DPointsData( dataIndex, pointCount, buffers );
    }

--- a/src/WriterImpl.cpp
+++ b/src/WriterImpl.cpp
@@ -33,6 +33,46 @@
 #include "Common.h"
 #include "E57Version.h"
 
+namespace
+{
+   /*!
+   @brief Convert e57::NumericalNodeType into human-readable string.
+
+   @param inNodeType node type to convert
+
+   @return human-readable representation of node type or "Unknown: <node type int>".
+   */
+   std::string _numericalNodeTypeStr( e57::NumericalNodeType inNodeType )
+   {
+      switch ( inNodeType )
+      {
+         case e57::NumericalNodeType::Integer:
+         {
+            return "Integer";
+         }
+
+         case e57::NumericalNodeType::ScaledInteger:
+         {
+            return "ScaledInteger";
+         }
+
+         case e57::NumericalNodeType::Float:
+         {
+            return "Float";
+         }
+
+         case e57::NumericalNodeType::Double:
+         {
+            return "Double";
+         }
+
+         default:
+            return std::string( "Unknown: " )
+               .append( std::to_string( static_cast<int>( inNodeType ) ) );
+      }
+   }
+}
+
 namespace e57
 {
    /*!
@@ -829,6 +869,11 @@ namespace e57
                return FloatNode( imf_, 0.0, PrecisionDouble, pointRangeMin, pointRangeMax );
             }
          }
+
+         throw E57_EXCEPTION2(
+            ErrorInvalidNodeType,
+            std::string( "Invalid pointRangeNodeType type: " )
+               .append( _numericalNodeTypeStr( data3DHeader.pointFields.pointRangeNodeType ) ) );
       };
 
       if ( data3DHeader.pointFields.cartesianXField )
@@ -885,6 +930,11 @@ namespace e57
                return FloatNode( imf_, 0.0, PrecisionDouble, angleMin, angleMax );
             }
          }
+
+         throw E57_EXCEPTION2(
+            ErrorInvalidNodeType,
+            std::string( "Invalid angleNodeType type: " )
+               .append( _numericalNodeTypeStr( data3DHeader.pointFields.angleNodeType ) ) );
       };
 
       if ( data3DHeader.pointFields.sphericalAzimuthField )

--- a/test/src/RandomNum.cpp
+++ b/test/src/RandomNum.cpp
@@ -15,8 +15,8 @@ namespace
    // Use a uniform distribution [0, 1].
    // For explanation of second param, see:
    //    https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution
-   static std::uniform_real_distribution<> dis(
-      0, std::nextafter( 1, std::numeric_limits<float>::max() ) );
+   static std::uniform_real_distribution<float> dis(
+      0.0f, std::nextafter( 1.0f, std::numeric_limits<float>::max() ) );
 }
 
 namespace Random


### PR DESCRIPTION
- internal use of deprecated type was not showing up with clang...
- mark parameters as UNUSED
- throw exception if switch not satisfied in WriterImpl
- add type to std::uniform_real_distribution
- use pragma to disable warning on Windows (since it doesn’t implement the standard for some reason)