### PR TITLE
{cmake} Turn on all warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,10 +28,12 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-cmake_minimum_required( VERSION 3.13 )
+cmake_minimum_required( VERSION 3.15 )
 
 # Set a private module find path
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/" )
+
+message( STATUS "Using CMake ${CMAKE_VERSION}" )
 
 project( E57Format
 	DESCRIPTION
@@ -121,6 +123,7 @@ set_target_properties( E57Format
 	PROPERTIES
 	    CXX_EXTENSIONS NO
 		DEBUG_POSTFIX "-d"
+		EXPORT_COMPILE_COMMANDS ON
 		POSITION_INDEPENDENT_CODE ON
 		INTERPROCEDURAL_OPTIMIZATION ON
 )
@@ -129,6 +132,30 @@ target_compile_features( ${PROJECT_NAME}
     PRIVATE
         cxx_std_14
 )
+
+# Turn on All The Warnings
+target_compile_options( E57Format
+    PRIVATE
+        $<$<CXX_COMPILER_ID:MSVC>:/W4>
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
+)
+
+# Treat warnings as errors if we are building ourself.
+if ( E57_BUILDING_SELF )
+    if ( CMAKE_VERSION VERSION_GREATER_EQUAL "3.24" )
+        set_target_properties( E57Format
+            PROPERTIES
+                COMPILE_WARNING_AS_ERROR ON
+        )
+    else()
+        # This might fail on compilers other than MSVC, gcc (and related), & clang?
+        target_compile_options( E57Format
+            PRIVATE
+                $<$<CXX_COMPILER_ID:MSVC>:/WX>
+                $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Werror>
+        )
+    endif()
+endif()
 
 # Target definitions
 target_compile_definitions( E57Format

--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -65,7 +65,15 @@
 #include <cstring>
 #include <fcntl.h>
 
+#if defined( WIN32 ) || defined( _WIN32 ) || defined( WINCE )
+// Disable warning about "conditional expression is constant".
+#pragma warning( push )
+#pragma warning( disable : 4127 )
+#endif
 #include "CRC.h"
+#if defined( WIN32 ) || defined( _WIN32 ) || defined( WINCE )
+#pragma warning( pop )
+#endif
 
 #include "CheckedFile.h"
 #include "StringFunctions.h"

--- a/src/E57XmlParser.cpp
+++ b/src/E57XmlParser.cpp
@@ -177,7 +177,11 @@ XMLSize_t E57FileInputStream::readBytes( XMLByte *const toFill, const XMLSize_t 
 
    // Be careful if size_t is smaller than int64_t
    size_t available_size;
-   if ( sizeof( size_t ) >= sizeof( int64_t ) )
+
+   // Assign to var to avoid MSVC warning
+   // This section can be simplified in C++17 using a "constexpr if".
+   constexpr bool cSizeCheck = ( sizeof( size_t ) >= sizeof( int64_t ) );
+   if ( cSizeCheck )
    {
       // size_t is at least as big as int64_t
       available_size = static_cast<size_t>( available );


### PR DESCRIPTION
Also:
- treat warnings as errors if we are building ourself
- bump required CMake to 3.15 to avoid compiler option shenanigans (CMP0092)
- explicitly turn off the "conditional expression is constant" warning when including CRCpp