### PR TITLE
{test} Disable internal tests on Windows when building with shared libs

### DIFF
--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -9,5 +9,13 @@ target_sources( ${PROJECT_NAME}
         test_SimpleData.cpp
         test_SimpleReader.cpp
         test_SimpleWriter.cpp
-        test_StringFunctions.cpp
 )
+
+# Include internal tests if not building shared lib on Windows.
+# The functions aren't exported in the Windows DLLs.
+if ( (NOT WIN32) OR (WIN32 AND NOT E57_BUILD_SHARED) )
+    target_sources( ${PROJECT_NAME}
+        PRIVATE
+           test_StringFunctions.cpp
+    )
+endif()


### PR DESCRIPTION
Instead of exposing all the functions, just don't include these tests.