### PR TITLE
{cmake} Split diagnostic output from E57_DEBUG to E57_ENABLE_DIAGNOSTIC_OUTPUT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,11 @@ endif()
 option( E57_DEBUG      "Compile library with minimal debug checking" ON )
 option( E57_MAX_DEBUG  "Compile library with maximum debug checking" OFF )
 
+# Enable/disable code which dumps detailed node info to std::ostream. (See NodeImpl::dump())
+# Instead of always including this code, it is an option for backwards compatibility.
+# The only real reason to turn this off would be for slightly smaller binaries.
+option( E57_ENABLE_DIAGNOSTIC_OUTPUT  "Include code for diagnostic output using dump() on nodes" ON )
+
 # Various levels of printing to the console of what is going on in the code.
 # Optional
 option( E57_VERBOSE      "Compile library with verbose logging" OFF )
@@ -148,27 +153,13 @@ endif()
 target_compile_definitions( E57Format
     PRIVATE
         REVISION_ID="${REVISION_ID}"
+        $<$<BOOL:${E57_DEBUG}>:E57_DEBUG>
+        $<$<BOOL:${E57_MAX_DEBUG}>:E57_MAX_DEBUG>
+        $<$<BOOL:${E57_ENABLE_DIAGNOSTIC_OUTPUT}>:E57_ENABLE_DIAGNOSTIC_OUTPUT>
+        $<$<BOOL:${E57_VERBOSE}>:E57_VERBOSE>
+        $<$<BOOL:${E57_MAX_VERBOSE}>:E57_MAX_VERBOSE>
+        $<$<BOOL:${E57_WRITE_CRAZY_PACKET_MODE}>:E57_WRITE_CRAZY_PACKET_MODE>
 )
-
-if ( E57_DEBUG )
-    target_compile_definitions( E57Format PRIVATE E57_DEBUG )
-endif()
-
-if ( E57_MAX_DEBUG )
-    target_compile_definitions( E57Format PRIVATE E57_MAX_DEBUG )
-endif()
-
-if ( E57_VERBOSE )
-    target_compile_definitions( E57Format PRIVATE E57_VERBOSE )
-endif()
-
-if ( E57_MAX_VERBOSE )
-    target_compile_definitions( E57Format PRIVATE E57_MAX_VERBOSE )
-endif()
-
-if ( E57_WRITE_CRAZY_PACKET_MODE )
-    target_compile_definitions( E57Format PRIVATE E57_WRITE_CRAZY_PACKET_MODE )
-endif()
 
 if ( E57_VISIBILITY_HIDDEN )
 	set_target_properties( E57Format

--- a/include/E57Exception.h
+++ b/include/E57Exception.h
@@ -35,7 +35,7 @@
 
 #include "E57Export.h"
 
-#ifndef E57_DEBUG
+#ifndef E57_ENABLE_DIAGNOSTIC_OUTPUT
 // Used to mark unused parameters to indicate intent and supress warnings.
 #define UNUSED( expr ) (void)( expr )
 #endif
@@ -311,7 +311,7 @@ namespace e57
       {
          os << "**** Got an e57 exception: " << errorStr() << std::endl;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
          os << "  Debug info: " << std::endl;
          os << "    context: " << context_ << std::endl;
          os << "    sourceFunctionName: " << sourceFunctionName_ << std::endl;

--- a/src/BlobNode.cpp
+++ b/src/BlobNode.cpp
@@ -297,7 +297,7 @@ void BlobNode::write( uint8_t *buf, int64_t start, size_t count )
 @brief Diagnostic function to print internal state of object to output stream in an indented format.
 @copydetails Node::dump()
 */
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void BlobNode::dump( int indent, std::ostream &os ) const
 {
    impl_->dump( indent, os );

--- a/src/BlobNodeImpl.cpp
+++ b/src/BlobNodeImpl.cpp
@@ -206,7 +206,7 @@ namespace e57
          << "\" length=\"" << blobLogicalLength_ << "\"/>\n";
    }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
    void BlobNodeImpl::dump( int indent, std::ostream &os ) const
    {
       // don't checkImageFileOpen

--- a/src/BlobNodeImpl.h
+++ b/src/BlobNodeImpl.h
@@ -54,7 +54,7 @@ namespace e57
       void writeXml( ImageFileImplSharedPtr imf, CheckedFile &cf, int indent,
                      const char *forcedFieldName = nullptr ) override;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
 

--- a/src/CompressedVectorNode.cpp
+++ b/src/CompressedVectorNode.cpp
@@ -328,7 +328,7 @@ VectorNode CompressedVectorNode::codecs() const
 @brief Diagnostic function to print internal state of object to output stream in an indented format.
 @copydetails Node::dump()
 */
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void CompressedVectorNode::dump( int indent, std::ostream &os ) const
 {
    impl_->dump( indent, os );

--- a/src/CompressedVectorNodeImpl.cpp
+++ b/src/CompressedVectorNodeImpl.cpp
@@ -235,7 +235,7 @@ namespace e57
       cf << space( indent ) << "</" << fieldName << ">\n";
    }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
    void CompressedVectorNodeImpl::dump( int indent, std::ostream &os ) const
    {
       os << space( indent ) << "type:        CompressedVector"

--- a/src/CompressedVectorNodeImpl.h
+++ b/src/CompressedVectorNodeImpl.h
@@ -81,7 +81,7 @@ namespace e57
          binarySectionLogicalStart_ = binarySectionLogicalStart;
       }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
 

--- a/src/CompressedVectorReader.cpp
+++ b/src/CompressedVectorReader.cpp
@@ -342,7 +342,7 @@ CompressedVectorNode CompressedVectorReader::compressedVectorNode() const
 @brief Diagnostic function to print internal state of object to output stream in an indented format.
 @copydetails Node::dump()
 */
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void CompressedVectorReader::dump( int indent, std::ostream &os ) const
 {
    impl_->dump( indent, os );

--- a/src/CompressedVectorReaderImpl.cpp
+++ b/src/CompressedVectorReaderImpl.cpp
@@ -594,7 +594,7 @@ namespace e57
       }
    }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
    void CompressedVectorReaderImpl::dump( int indent, std::ostream &os )
    {
       os << space( indent ) << "isOpen:" << isOpen_ << std::endl;

--- a/src/CompressedVectorReaderImpl.h
+++ b/src/CompressedVectorReaderImpl.h
@@ -47,7 +47,7 @@ namespace e57
       std::shared_ptr<CompressedVectorNodeImpl> compressedVectorNode() const;
       void close();
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout );
 #endif
 

--- a/src/CompressedVectorWriter.cpp
+++ b/src/CompressedVectorWriter.cpp
@@ -319,7 +319,7 @@ CompressedVectorNode CompressedVectorWriter::compressedVectorNode() const
 @brief Diagnostic function to print internal state of object to output stream in an indented format.
 @copydetails Node::dump()
 */
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void CompressedVectorWriter::dump( int indent, std::ostream &os ) const
 {
    impl_->dump( indent, os );

--- a/src/CompressedVectorWriterImpl.cpp
+++ b/src/CompressedVectorWriterImpl.cpp
@@ -638,7 +638,7 @@ namespace e57
       }
    }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
    void CompressedVectorWriterImpl::dump( int indent, std::ostream &os )
    {
       os << space( indent ) << "isOpen:" << isOpen_ << std::endl;

--- a/src/CompressedVectorWriterImpl.h
+++ b/src/CompressedVectorWriterImpl.h
@@ -44,7 +44,7 @@ namespace e57
       std::shared_ptr<CompressedVectorNodeImpl> compressedVectorNode() const;
       void close();
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout );
 #endif
 

--- a/src/DecodeChannel.cpp
+++ b/src/DecodeChannel.cpp
@@ -67,7 +67,7 @@ namespace e57
       return ( currentBytestreamBufferIndex == currentBytestreamBufferLength );
    }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
    void DecodeChannel::dump( int indent, std::ostream &os ) const
    {
       os << space( indent ) << "dbuf" << std::endl;

--- a/src/DecodeChannel.h
+++ b/src/DecodeChannel.h
@@ -48,7 +48,8 @@ namespace e57
 
       bool isOutputBlocked() const;
       bool isInputBlocked() const; /// has exhausted data in the current packet
-#ifdef E57_DEBUG
+
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
 #endif
    };

--- a/src/Decoder.cpp
+++ b/src/Decoder.cpp
@@ -334,7 +334,7 @@ void BitpackDecoder::inBufferShiftDown()
    inBufferFirstBit_ = inBufferFirstBit_ % bitsPerWord_;
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void BitpackDecoder::dump( int indent, std::ostream &os )
 {
    os << space( indent ) << "bytestreamNumber:         " << bytestreamNumber_ << std::endl;
@@ -466,7 +466,7 @@ size_t BitpackFloatDecoder::inputProcessAligned( const char *inbuf, const size_t
    return ( n * 8 * typeSize );
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void BitpackFloatDecoder::dump( int indent, std::ostream &os )
 {
    BitpackDecoder::dump( indent, os );
@@ -634,7 +634,7 @@ size_t BitpackStringDecoder::inputProcessAligned( const char *inbuf, const size_
    return ( nBytesRead * 8 );
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void BitpackStringDecoder::dump( int indent, std::ostream &os )
 {
    BitpackDecoder::dump( indent, os );
@@ -832,7 +832,7 @@ size_t BitpackIntegerDecoder<RegisterT>::inputProcessAligned( const char *inbuf,
    return ( recordCount * bitsPerRecord_ );
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 template <typename RegisterT>
 void BitpackIntegerDecoder<RegisterT>::dump( int indent, std::ostream &os )
 {
@@ -913,7 +913,7 @@ void ConstantIntegerDecoder::stateReset()
 {
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void ConstantIntegerDecoder::dump( int indent, std::ostream &os )
 {
    os << space( indent ) << "bytestreamNumber:   " << bytestreamNumber_ << std::endl;

--- a/src/Decoder.h
+++ b/src/Decoder.h
@@ -51,7 +51,7 @@ namespace e57
          return bytestreamNumber_;
       }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       virtual void dump( int indent = 0, std::ostream &os = std::cout ) = 0;
 #endif
 
@@ -76,7 +76,7 @@ namespace e57
 
       void stateReset() override;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) override;
 #endif
 
@@ -107,7 +107,7 @@ namespace e57
 
       size_t inputProcessAligned( const char *inbuf, size_t firstBit, size_t endBit ) override;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) override;
 #endif
 
@@ -123,7 +123,7 @@ namespace e57
 
       size_t inputProcessAligned( const char *inbuf, size_t firstBit, size_t endBit ) override;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) override;
 #endif
 
@@ -146,7 +146,7 @@ namespace e57
 
       size_t inputProcessAligned( const char *inbuf, size_t firstBit, size_t endBit ) override;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) override;
 #endif
 
@@ -177,7 +177,7 @@ namespace e57
       size_t inputProcess( const char *source, size_t availableByteCount ) override;
       void stateReset() override;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) override;
 #endif
 

--- a/src/Encoder.cpp
+++ b/src/Encoder.cpp
@@ -203,7 +203,7 @@ Encoder::Encoder( unsigned bytestreamNumber ) : bytestreamNumber_( bytestreamNum
 {
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void Encoder::dump( int indent, std::ostream &os ) const
 {
    os << space( indent ) << "bytestreamNumber:       " << bytestreamNumber_ << std::endl;
@@ -359,7 +359,7 @@ void BitpackEncoder::outBufferShiftDown()
    outBufferEnd_ = newEnd;
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void BitpackEncoder::dump( int indent, std::ostream &os ) const
 {
    Encoder::dump( indent, os );
@@ -477,7 +477,7 @@ float BitpackFloatEncoder::bitsPerRecord()
    return ( ( precision_ == PrecisionSingle ) ? 32.0F : 64.0F );
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void BitpackFloatEncoder::dump( int indent, std::ostream &os ) const
 {
    BitpackEncoder::dump( indent, os );
@@ -639,7 +639,7 @@ float BitpackStringEncoder::bitsPerRecord()
    return 100 * 8.0f;
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void BitpackStringEncoder::dump( int indent, std::ostream &os ) const
 {
    BitpackEncoder::dump( indent, os );
@@ -872,7 +872,7 @@ template <typename RegisterT> float BitpackIntegerEncoder<RegisterT>::bitsPerRec
    return ( static_cast<float>( bitsPerRecord_ ) );
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 template <typename RegisterT>
 void BitpackIntegerEncoder<RegisterT>::dump( int indent, std::ostream &os ) const
 {
@@ -987,7 +987,7 @@ void ConstantIntegerEncoder::outputSetMaxSize( unsigned /*byteCount*/ )
    // Ignore, since don't produce any output
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void ConstantIntegerEncoder::dump( int indent, std::ostream &os ) const
 {
    Encoder::dump( indent, os );

--- a/src/Encoder.h
+++ b/src/Encoder.h
@@ -59,7 +59,7 @@ namespace e57
          return bytestreamNumber_;
       }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       virtual void dump( int indent = 0, std::ostream &os = std::cout ) const;
 #endif
 
@@ -86,7 +86,7 @@ namespace e57
       size_t outputGetMaxSize() override;
       void outputSetMaxSize( unsigned byteCount ) override;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
 
@@ -116,7 +116,7 @@ namespace e57
       bool registerFlushToOutput() override;
       float bitsPerRecord() override;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
 
@@ -134,7 +134,7 @@ namespace e57
       bool registerFlushToOutput() override;
       float bitsPerRecord() override;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
 
@@ -157,7 +157,7 @@ namespace e57
       bool registerFlushToOutput() override;
       float bitsPerRecord() override;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
 
@@ -191,7 +191,7 @@ namespace e57
       size_t outputGetMaxSize() override;
       void outputSetMaxSize( unsigned byteCount ) override;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
 

--- a/src/FloatNode.cpp
+++ b/src/FloatNode.cpp
@@ -298,7 +298,7 @@ double FloatNode::maximum() const
 @brief Diagnostic function to print internal state of object to output stream in an indented format.
 @copydetails Node::dump()
 */
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void FloatNode::dump( int indent, std::ostream &os ) const
 {
    impl_->dump( indent, os );

--- a/src/FloatNodeImpl.cpp
+++ b/src/FloatNodeImpl.cpp
@@ -209,7 +209,7 @@ namespace e57
       }
    }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
    void FloatNodeImpl::dump( int indent, std::ostream &os ) const
    {
       // don't checkImageFileOpen

--- a/src/FloatNodeImpl.h
+++ b/src/FloatNodeImpl.h
@@ -56,7 +56,7 @@ namespace e57
       void writeXml( ImageFileImplSharedPtr imf, CheckedFile &cf, int indent,
                      const char *forcedFieldName = nullptr ) override;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
 

--- a/src/ImageFile.cpp
+++ b/src/ImageFile.cpp
@@ -719,7 +719,7 @@ void ImageFile::elementNameParse( const ustring &elementName, ustring &prefix,
 @brief Diagnostic function to print internal state of object to output stream in an indented format.
 @copydetails Node::dump()
 */
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void ImageFile::dump( int indent, std::ostream &os ) const
 {
    impl_->dump( indent, os );

--- a/src/ImageFileImpl.cpp
+++ b/src/ImageFileImpl.cpp
@@ -54,12 +54,12 @@ namespace e57
       uint64_t xmlLogicalLength = 0;
       uint64_t pageSize = 0;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
 #endif
    };
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
    void E57FileHeader::dump( int indent, std::ostream &os ) const
    {
       os << space( indent ) << "fileSignature:      ";
@@ -859,7 +859,7 @@ namespace e57
       return log2;
    }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
    void ImageFileImpl::dump( int indent, std::ostream &os ) const
    {
       // no checkImageFileOpen(__FILE__, __LINE__, __FUNCTION__)

--- a/src/ImageFileImpl.h
+++ b/src/ImageFileImpl.h
@@ -89,7 +89,7 @@ namespace e57
 
       static unsigned bitsNeeded( int64_t minimum, int64_t maximum );
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
 #endif
 

--- a/src/IntegerNode.cpp
+++ b/src/IntegerNode.cpp
@@ -257,7 +257,7 @@ int64_t IntegerNode::maximum() const
 @brief Diagnostic function to print internal state of object to output stream in an indented format.
 @copydetails Node::dump()
 */
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void IntegerNode::dump( int indent, std::ostream &os ) const
 {
    impl_->dump( indent, os );

--- a/src/IntegerNodeImpl.cpp
+++ b/src/IntegerNodeImpl.cpp
@@ -154,7 +154,7 @@ namespace e57
       }
    }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
    void IntegerNodeImpl::dump( int indent, std::ostream &os ) const
    {
       // don't checkImageFileOpen

--- a/src/IntegerNodeImpl.h
+++ b/src/IntegerNodeImpl.h
@@ -54,7 +54,7 @@ namespace e57
       void writeXml( ImageFileImplSharedPtr imf, CheckedFile &cf, int indent,
                      const char *forcedFieldName = nullptr ) override;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
 

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -552,7 +552,7 @@ still be defined). The output format may change from version to version.
 
 @throw No E57Exceptions
 */
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void Node::dump( int indent, std::ostream &os ) const
 {
    impl_->dump( indent, os );

--- a/src/NodeImpl.cpp
+++ b/src/NodeImpl.cpp
@@ -381,7 +381,7 @@ bool NodeImpl::findTerminalPosition( const NodeImplSharedPtr &target, uint64_t &
    return ( false );
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void NodeImpl::dump( int indent, std::ostream &os ) const
 {
    // don't checkImageFileOpen
@@ -389,7 +389,9 @@ void NodeImpl::dump( int indent, std::ostream &os ) const
    os << space( indent ) << "isAttached:  " << isAttached_ << std::endl;
    os << space( indent ) << "path:        " << pathName() << std::endl;
 }
+#endif
 
+#ifdef E57_DEBUG
 bool NodeImpl::_verifyPathNameAbsolute( const ustring &inPathName )
 {
    checkImageFileOpen( __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) );

--- a/src/NodeImpl.h
+++ b/src/NodeImpl.h
@@ -72,7 +72,7 @@ namespace e57
 
       virtual ~NodeImpl() = default;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       virtual void dump( int indent = 0, std::ostream &os = std::cout ) const;
 #endif
 

--- a/src/Packet.cpp
+++ b/src/Packet.cpp
@@ -54,7 +54,7 @@ struct IndexPacket
    void verify( unsigned bufferLength = 0, uint64_t totalRecordCount = 0,
                 uint64_t fileSize = 0 ) const;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
    void dump( int indent = 0, std::ostream &os = std::cout ) const;
 #endif
 };
@@ -68,7 +68,7 @@ struct EmptyPacketHeader
 
    void verify( unsigned bufferLength = 0 ) const; //???use
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
    void dump( int indent = 0, std::ostream &os = std::cout ) const;
 #endif
 };
@@ -258,7 +258,7 @@ void PacketReadCache::readPacket( unsigned oldestEntry, uint64_t packetLogicalOf
    entry.lastUsed_ = ++useCount_;
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void PacketReadCache::dump( int indent, std::ostream &os )
 {
    os << space( indent ) << "lockCount: " << lockCount_ << std::endl;
@@ -392,7 +392,7 @@ void DataPacketHeader::verify( unsigned bufferLength ) const
    }
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void DataPacketHeader::dump( int indent, std::ostream &os ) const
 {
    os << space( indent ) << "packetType:                " << static_cast<unsigned>( packetType )
@@ -514,7 +514,7 @@ unsigned DataPacket::getBytestreamBufferLength( unsigned bytestreamNumber )
    return ( byteCount );
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void DataPacket::dump( int indent, std::ostream &os ) const
 {
    if ( header.packetType != DATA_PACKET )
@@ -688,7 +688,7 @@ void IndexPacket::verify( unsigned bufferLength, uint64_t totalRecordCount,
 #endif
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void IndexPacket::dump( int indent, std::ostream &os ) const
 {
    os << space( indent ) << "packetType:                " << static_cast<unsigned>( packetType )
@@ -746,7 +746,7 @@ void EmptyPacketHeader::verify( unsigned bufferLength ) const
    }
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void EmptyPacketHeader::dump( int indent, std::ostream &os ) const
 {
    os << space( indent ) << "packetType:                " << static_cast<unsigned>( packetType )

--- a/src/Packet.h
+++ b/src/Packet.h
@@ -56,7 +56,7 @@ namespace e57
       std::unique_ptr<PacketLock> lock( uint64_t packetLogicalOffset,
                                         char *&pkt ); //??? pkt could be const
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout );
 #endif
 
@@ -109,7 +109,7 @@ namespace e57
 
       void verify( unsigned bufferLength = 0 ) const; //???use
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
 #endif
 
@@ -129,7 +129,7 @@ namespace e57
       char *getBytestream( unsigned bytestreamNumber, unsigned &byteCount );
       unsigned getBytestreamBufferLength( unsigned bytestreamNumber );
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
 #endif
 

--- a/src/ScaledIntegerNode.cpp
+++ b/src/ScaledIntegerNode.cpp
@@ -416,7 +416,7 @@ double ScaledIntegerNode::offset() const
 @brief Diagnostic function to print internal state of object to output stream in an indented format.
 @copydetails Node::dump()
 */
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void ScaledIntegerNode::dump( int indent, std::ostream &os ) const
 {
    impl_->dump( indent, os );

--- a/src/ScaledIntegerNodeImpl.cpp
+++ b/src/ScaledIntegerNodeImpl.cpp
@@ -233,7 +233,7 @@ namespace e57
       }
    }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
    void ScaledIntegerNodeImpl::dump( int indent, std::ostream &os ) const
    {
       // don't checkImageFileOpen

--- a/src/ScaledIntegerNodeImpl.h
+++ b/src/ScaledIntegerNodeImpl.h
@@ -65,7 +65,7 @@ namespace e57
       void writeXml( ImageFileImplSharedPtr imf, CheckedFile &cf, int indent,
                      const char *forcedFieldName = nullptr ) override;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
 

--- a/src/SectionHeaders.cpp
+++ b/src/SectionHeaders.cpp
@@ -30,7 +30,7 @@
 
 namespace e57
 {
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
    void BlobSectionHeader::dump( int indent, std::ostream &os ) const
    {
       os << space( indent ) << "sectionId:            " << sectionId << std::endl;
@@ -89,7 +89,7 @@ namespace e57
       }
    }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
    void CompressedVectorSectionHeader::dump( int indent, std::ostream &os ) const
    {
       os << space( indent ) << "sectionId:            " << static_cast<unsigned>( sectionId )

--- a/src/SectionHeaders.h
+++ b/src/SectionHeaders.h
@@ -43,7 +43,7 @@ namespace e57
       uint8_t reserved1[7] = {};         // must be zero
       uint64_t sectionLogicalLength = 0; // byte length of whole section
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
 #endif
    };
@@ -61,7 +61,7 @@ namespace e57
 
       void verify( uint64_t filePhysicalSize = 0 );
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const;
 #endif
    };

--- a/src/SourceDestBuffer.cpp
+++ b/src/SourceDestBuffer.cpp
@@ -464,7 +464,7 @@ size_t SourceDestBuffer::stride() const
 @brief Diagnostic function to print internal state of object to output stream in an indented format.
 @copydetails Node::dump()
 */
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void SourceDestBuffer::dump( int indent, std::ostream &os ) const
 {
    impl_->dump( indent, os );

--- a/src/SourceDestBufferImpl.cpp
+++ b/src/SourceDestBufferImpl.cpp
@@ -1003,7 +1003,7 @@ void SourceDestBufferImpl::checkCompatible(
    }
 }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void SourceDestBufferImpl::dump( int indent, std::ostream &os )
 {
    /// don't checkImageFileOpen

--- a/src/SourceDestBufferImpl.h
+++ b/src/SourceDestBufferImpl.h
@@ -112,7 +112,7 @@ namespace e57
 
       void checkCompatible( const std::shared_ptr<SourceDestBufferImpl> &newBuf ) const;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout );
 #endif
 

--- a/src/StringNode.cpp
+++ b/src/StringNode.cpp
@@ -189,7 +189,7 @@ ustring StringNode::value() const
 @brief Diagnostic function to print internal state of object to output stream in an indented format.
 @copydetails Node::dump()
 */
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void StringNode::dump( int indent, std::ostream &os ) const
 {
    impl_->dump( indent, os );

--- a/src/StringNodeImpl.cpp
+++ b/src/StringNodeImpl.cpp
@@ -134,7 +134,7 @@ namespace e57
       }
    }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
    void StringNodeImpl::dump( int indent, std::ostream &os ) const
    {
       os << space( indent ) << "type:        String"

--- a/src/StringNodeImpl.h
+++ b/src/StringNodeImpl.h
@@ -51,7 +51,7 @@ namespace e57
       void writeXml( ImageFileImplSharedPtr imf, CheckedFile &cf, int indent,
                      const char *forcedFieldName = nullptr ) override;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
 

--- a/src/StructureNode.cpp
+++ b/src/StructureNode.cpp
@@ -342,7 +342,7 @@ void StructureNode::set( const ustring &pathName, const Node &n )
 @brief Diagnostic function to print internal state of object to output stream in an indented format.
 @copydetails Node::dump()
 */
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void StructureNode::dump( int indent, std::ostream &os ) const
 {
    impl_->dump( indent, os );

--- a/src/StructureNodeImpl.cpp
+++ b/src/StructureNodeImpl.cpp
@@ -450,7 +450,7 @@ void StructureNodeImpl::writeXml( ImageFileImplSharedPtr imf, CheckedFile &cf, i
 }
 
 //??? use visitor?
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void StructureNodeImpl::dump( int indent, std::ostream &os ) const
 {
    // don't checkImageFileOpen

--- a/src/StructureNodeImpl.h
+++ b/src/StructureNodeImpl.h
@@ -60,7 +60,7 @@ namespace e57
       void writeXml( ImageFileImplSharedPtr imf, CheckedFile &cf, int indent,
                      const char *forcedFieldName = nullptr ) override;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
 

--- a/src/VectorNode.cpp
+++ b/src/VectorNode.cpp
@@ -370,7 +370,7 @@ void VectorNode::append( const Node &n )
 @brief Diagnostic function to print internal state of object to output stream in an indented format.
 @copydetails Node::dump()
 */
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
 void VectorNode::dump( int indent, std::ostream &os ) const
 {
    impl_->dump( indent, os );

--- a/src/VectorNodeImpl.cpp
+++ b/src/VectorNodeImpl.cpp
@@ -124,7 +124,7 @@ namespace e57
       cf << space( indent ) << "</" << fieldName << ">\n";
    }
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
    void VectorNodeImpl::dump( int indent, std::ostream &os ) const
    {
       // don't checkImageFileOpen

--- a/src/VectorNodeImpl.h
+++ b/src/VectorNodeImpl.h
@@ -49,7 +49,7 @@ namespace e57
       void writeXml( ImageFileImplSharedPtr imf, CheckedFile &cf, int indent,
                      const char *forcedFieldName = nullptr ) override;
 
-#ifdef E57_DEBUG
+#ifdef E57_ENABLE_DIAGNOSTIC_OUTPUT
       void dump( int indent = 0, std::ostream &os = std::cout ) const override;
 #endif
 


### PR DESCRIPTION
In an effort to clean up all these compile options, isolate the diagnostic output (dump() functions).

Instead of always including this code, it is an option (`E57_ENABLE_DIAGNOSTIC_OUTPUT`) for backwards compatibility. The only real reason to turn this off would be for slightly smaller binaries.