### PR TITLE
Add ASan and UBSan sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,10 @@ if ( E57_VISIBILITY_HIDDEN )
 	)
 endif()
 
+# sanitizers
+include( Sanitizers )
+
+# xerces
 if ( WIN32 )
     option( USING_STATIC_XERCES "Turn on if you are linking with Xerces as a static lib" OFF )
     if ( USING_STATIC_XERCES )
@@ -220,6 +224,9 @@ if ( E57_BUILD_TEST )
             CXX_VISIBILITY_PRESET default
             CMAKE_VISIBILITY_INLINES_HIDDEN OFF
         )
+
+    # Turn on all available sanitizers for E57Format
+    enable_all_sanitizers( ${PROJECT_NAME} )
 
     enable_testing()
 

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2023 Andy Maloney <asmaloney@gmail.com>
+
+# Note: In theory address sanitization should work on MSVC, but I could not get it working.
+# If you know how to fix it, please submit a PR:
+#   https://github.com/asmaloney/libE57Format/pulls
+
+string( TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPERCASE )
+
+set( compiler_is_clang "$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>" )
+set( compiler_is_gnu "$<CXX_COMPILER_ID:GNU>" )
+set( compiler_is_msvc "$<CXX_COMPILER_ID:MSVC>" )
+set( compiler_is_not_msvc "$<NOT:${compiler_is_msvc}>" )
+
+if ( NOT MSVC )
+    option( ${PROJECT_NAME_UPPERCASE}_SANITIZE_ADDRESS "Enable address sanitizer (ASan) if available." OFF )
+    option( ${PROJECT_NAME_UPPERCASE}_SANITIZE_UNDEFINED "Enable memory sanitizer (UBSan) if available." OFF )
+endif()
+
+function( enable_address_sanitizer target )
+    message( STATUS "[${target}] Enabling address sanitizer (ASan)" )
+
+    target_compile_options( ${target}
+        PRIVATE
+            $<${compiler_is_not_msvc}:
+                -fno-omit-frame-pointer
+                -fsanitize=address
+            >
+
+            $<${compiler_is_msvc}:
+                /fsanitize=address
+                /INCREMENTAL:NO
+                /Zi
+            >
+    )
+    target_link_options( ${target}
+        PUBLIC
+            $<${compiler_is_not_msvc}:
+                -fno-omit-frame-pointer
+                -fsanitize=address
+            >
+
+            $<${compiler_is_msvc}:
+                /DEBUG
+                /INCREMENTAL:NO
+            >
+    )
+endfunction()
+
+function( enable_undefined_sanitizer target )
+    if ( MSVC )
+        message( WARNING "[${target}] Undefined behaviour sanitizer (UBSan) not avaiable for MSVC" )
+        return()
+    endif()
+
+    message( STATUS "[${target}] Enabling undefined behaviour sanitizer (UBSan)" )
+
+    target_compile_options( ${target}
+        PRIVATE
+            -fsanitize=undefined
+    )
+    target_link_options( ${target}
+        PUBLIC
+            -fsanitize=undefined
+    )
+endfunction()
+
+function( enable_all_sanitizers target )
+    if ( MSVC )
+        return()
+    endif()
+
+    unset( ${PROJECT_NAME_UPPERCASE}_SANITIZE_ADDRESS CACHE )
+    unset( ${PROJECT_NAME_UPPERCASE}_SANITIZE_UNDEFINED CACHE )
+
+    enable_address_sanitizer( ${target} )
+    enable_undefined_sanitizer( ${target} )
+endfunction()
+
+if ( NOT MSVC )
+    if ( ${PROJECT_NAME_UPPERCASE}_SANITIZE_ADDRESS )
+        enable_address_sanitizer( ${PROJECT_NAME} )
+    endif()
+
+    if ( ${PROJECT_NAME_UPPERCASE}_SANITIZE_UNDEFINED )
+        enable_undefined_sanitizer( ${PROJECT_NAME} )
+    endif()
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,12 +23,12 @@ set_target_properties( testE57
 add_subdirectory( include )
 add_subdirectory( src )
 
+# Turn on sanitizers
+include( Sanitizers )
+enable_all_sanitizers( ${PROJECT_NAME} )
+
 # Set helper variables for readability
-set( compiler_is_clang "$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>" )
-set( compiler_is_gnu "$<CXX_COMPILER_ID:GNU>" )
 set( compiler_is_msvc "$<CXX_COMPILER_ID:MSVC>" )
-set( compiler_is_not_msvc "$<NOT:${compiler_is_msvc}>" )
-set( is_debug "$<CONFIG:DEBUG>" )
 
 target_compile_options( testE57
 	PUBLIC
@@ -44,22 +44,6 @@ target_include_directories( testE57
 target_link_libraries( testE57
     PRIVATE
         E57Format
-)
-
-# Turn on ASAN
-target_compile_options( testE57
-    PRIVATE
-        $<$<AND:${is_debug},${compiler_is_not_msvc}>:
-            -fno-omit-frame-pointer
-            -fsanitize=address
-        >
-)
-target_link_options( testE57
-    PRIVATE
-        $<$<AND:${is_debug},${compiler_is_not_msvc}>:
-            -fno-omit-frame-pointer
-            -fsanitize=address
-        >
 )
 
 # ccache
@@ -103,8 +87,8 @@ if ( NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/extern/googletest/CMakeLists.txt" )
     message( FATAL_ERROR "[E57 Test] The GoogleTest submodule was not downloaded. E57_GIT_SUBMODULE_UPDATE was turned off or failed. Please update submodules and try again." )
 endif()
 
-set( BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject" )
-set( INSTALL_GTEST OFF CACHE BOOL "Enable installation of googletest. (Projects embedding googletest may want to turn this OFF.)" )
+set( BUILD_GMOCK OFF CACHE BOOL "" FORCE )
+set( INSTALL_GTEST OFF CACHE BOOL "" FORCE )
 
 if ( MSVC )
     # Prevent overriding the parent project's compiler/linker settings on Windows
@@ -113,7 +97,15 @@ endif()
 
 add_subdirectory( extern/googletest )
 
+set_target_properties( gtest_main
+	PROPERTIES
+	    EXPORT_COMPILE_COMMANDS ON
+)
+
+enable_all_sanitizers( gtest_main )
+
 unset( BUILD_GMOCK CACHE )
+unset( GTEST_HAS_ABSL CACHE )
 unset( INSTALL_GTEST CACHE )
 
 target_include_directories( testE57

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -8,6 +8,15 @@
 #include "RandomNum.h"
 #include "TestData.h"
 
+// Address Sanitizer
+// There seems to be a false positive with std::vector, so turn off container overflow detection.
+//   https://github.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow#false-positives
+//   https://github.com/google/sanitizers/wiki/AddressSanitizerFlags#run-time-flags
+extern "C" const char *__asan_default_options()
+{
+   return "detect_container_overflow=false";
+}
+
 int main( int argc, char **argv )
 {
    Random::seed( 42 );


### PR DESCRIPTION
- always on when building tests (Linux & macOS*)
- can be enabled/disabled individually otherwise

Ignores container-overflow (ASan). This is a false positive and there’s no good way to fix it, so turn off the feature.

*I gave up trying to get the address sanitizer working for MSVC (and UBSan isn’t supported), so it’s disabled on MSVC.