### PR TITLE
{cmake} Rewrite Tags.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@
 #
 # Use git blame to see all the changes and who has contributed.
 #
+# Copyright 2018-2023 Andy Maloney <asmaloney@gmail.com>
 # Original work Copyright 2010-2012 Roland Schwarz, Riegl LMS GmbH
-# Modified work Copyright 2018-2020 Andy Maloney <asmaloney@gmail.com>
 #
 # Permission is hereby granted, free of charge, to any person or organization
 # obtaining a copy of the software and accompanying documentation covered by
@@ -46,6 +46,8 @@ project( E57Format
 
 string( TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPERCASE )
 
+# Creates a build tag which is used in the REVISION_ID
+#	e.g. "x86_64-darwin-AppleClang140"
 include( Tags )
 
 # Check if we are building ourself or being included and use this to set some defaults
@@ -85,7 +87,7 @@ endif()
 # The extra code does not change the file contents.
 #	E57_VALIDATION_LEVEL=0	off
 #	E57_VALIDATION_LEVEL=1	basic
-#	E57_VALIDATION_LEVEL=2	deep (implies basic) - checks at the packet level, so it might be slower
+#	E57_VALIDATION_LEVEL=2	deep (implies basic) - checks at the packet level, so it will be slower
 set( E57_VALIDATION_LEVEL "1" CACHE STRING "Runtime validation level (0 = OFF, 1 = basic, 2 = deep)" )
 
 # Output detailed logging while processing.
@@ -237,7 +239,8 @@ endif()
 install(
     EXPORT
         E57Format-export
-    DESTINATION lib/cmake/E57Format
+    DESTINATION
+        lib/cmake/E57Format
 )
 
 install(

--- a/cmake/Tags.cmake
+++ b/cmake/Tags.cmake
@@ -1,41 +1,38 @@
 # This file defines the variables
 # ${PROJECT_NAME}_BUILD_TAG
 
-# calculate the tag
-set(T_ ${CMAKE_SYSTEM_PROCESSOR})
-if (CMAKE_CL_64)
-    set(T_ ${T_}_64)
-endif (CMAKE_CL_64)
-string(TOLOWER ${CMAKE_SYSTEM_NAME} T1_)
-set(T_ ${T_}-${T1_})
-if (MSVC90)
-    set(T1_ "-vc90")
-elseif (MSVC10)
-    set(T1_ "-vc100")
-elseif (MSVC80)
-    set(T1_ "-vc80")
-elseif (MSVC71)
-    set(T1_ "-vc711")
-elseif (MSVC70)
-    set(T1_ "-vc7")
-elseif (MINGW)
-    set(T1_ "-mgw")
-    exec_program(${CMAKE_CXX_COMPILER}
+set( T_ ${CMAKE_SYSTEM_PROCESSOR} )
+
+string( TOLOWER ${CMAKE_SYSTEM_NAME} T1_ )
+
+function( add_compiler_version )
+    exec_program( ${CMAKE_CXX_COMPILER}
         ARGS ${CMAKE_CXX_COMPILER_ARG1} -dumpversion
         OUTPUT_VARIABLE T2_
     )
-    string(REGEX REPLACE "([0-9])\\.([0-9])(\\.[0-9])?" "\\1\\2" T2_ ${T2_})
-    set(T1_ ${T1_}${T2_})
-elseif (CMAKE_COMPILER_IS_GNUCXX)
-    set(T1_ "-gcc")
-    exec_program(${CMAKE_CXX_COMPILER}
-        ARGS ${CMAKE_CXX_COMPILER_ARG1} -dumpversion
-        OUTPUT_VARIABLE T2_
-    )
-    string(REGEX REPLACE "([0-9])\\.([0-9])(\\.[0-9])?" "\\1\\2" T2_ ${T2_})
-    set(T1_ ${T1_}${T2_})
-else()
-    set(T1_)
+    string( REGEX REPLACE "([0-9])\\.([0-9])(\\.[0-9])?" "\\1\\2" T2_ ${T2_} )
+    set( T1_ ${T1_}${T2_} PARENT_SCOPE )
+endfunction()
+
+# default to just the CMake compiler ID
+set( T1_ ${CMAKE_CXX_COMPILER_ID} )
+
+# special cases to add versions and other info
+if ( MSVC )
+    if ( CMAKE_CL_64 )
+        set( T_ ${T_}_64 )
+    endif()
+
+    set( T1_ "vc${MSVC_VERSION}" )
+elseif ( MINGW )
+    set( T1_ "MinGW" )
+    add_compiler_version()
+elseif ( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" )
+    set( T1_ "gcc" )
+    add_compiler_version()
+elseif ( CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compiler_version()
 endif()
-set(T_ ${T_}${T1_})
-set(${PROJECT_NAME}_BUILD_TAG ${T_})
+
+set( T_ ${T_}-${T1_} )
+set( ${PROJECT_NAME}_BUILD_TAG ${T_} )

--- a/include/E57Version.h
+++ b/include/E57Version.h
@@ -36,7 +36,7 @@ namespace e57
       /*!
       @brief Get the version of libE57Format library.
 
-      @returns The version as a string (e.g. "E57Format-3.0.0-x86_64-darwin").
+      @returns The version as a string (e.g. "E57Format-3.0.0-x86_64-darwin-AppleClang140").
       */
       E57_DLL std::string library();
 


### PR DESCRIPTION
- include clang detection
- MSVC now uses CMake's MSVC_VERSION instead of trying to enumerate versions
- defaults to using the CMake compiler ID if we aren't special casing the complier info