### PR TITLE
Fix 32-bit build issues

### DIFF
--- a/include/E57SimpleData.h
+++ b/include/E57SimpleData.h
@@ -611,7 +611,9 @@ namespace e57
       PointStandardizedFieldsAvailable pointFields;
 
       /// The number of points in the Data3D.
-      int64_t pointCount = 0;
+      /// On 32-bit systems size_t will allow for 4,294,967,295 points per scan which seems
+      /// reasonable...
+      size_t pointCount = 0;
    };
 
    /// @brief Stores pointers to user-provided buffers

--- a/include/E57SimpleReader.h
+++ b/include/E57SimpleReader.h
@@ -164,7 +164,7 @@ namespace e57
       /// "points" data vector for the groups
       /// @param [out] pointCount pointer to the buffer holding size of the groups given
       /// @return Return true if successful, false otherwise
-      bool ReadData3DGroupsData( int64_t dataIndex, int64_t groupCount, int64_t *idElementValue,
+      bool ReadData3DGroupsData( int64_t dataIndex, size_t groupCount, int64_t *idElementValue,
                                  int64_t *startPointIndex, int64_t *pointCount ) const;
 
       /// @brief Use this to read the actual 3D data

--- a/include/E57SimpleWriter.h
+++ b/include/E57SimpleWriter.h
@@ -177,7 +177,7 @@ namespace e57
       /// for the groups
       /// @param [in] pointCount buffer with sizes of the groups given
       /// @return Return true if successful, false otherwise
-      bool WriteData3DGroupsData( int64_t dataIndex, int64_t groupCount, int64_t *idElementValue,
+      bool WriteData3DGroupsData( int64_t dataIndex, size_t groupCount, int64_t *idElementValue,
                                   int64_t *startPointIndex, int64_t *pointCount );
 
       ///@}

--- a/src/Common.h
+++ b/src/Common.h
@@ -53,6 +53,13 @@
 #define VALIDATE_BASIC ( E57_VALIDATION_LEVEL > VALIDATION_OFF )
 #define VALIDATE_DEEP ( E57_VALIDATION_LEVEL > VALIDATION_BASIC )
 
+// Determine if we are building 32 or 64 bit
+#if SIZE_MAX == UINT32_MAX
+#define E57_32_BIT
+#elif SIZE_MAX == UINT64_MAX
+#define E57_64_BIT
+#endif
+
 namespace e57
 {
 #define E57_EXCEPTION1( ecode )                                                                    \

--- a/src/E57SimpleReader.cpp
+++ b/src/E57SimpleReader.cpp
@@ -126,9 +126,8 @@ namespace e57
                                     bColumnIndex );
    }
 
-   bool Reader::ReadData3DGroupsData( int64_t dataIndex, int64_t groupCount,
-                                      int64_t *idElementValue, int64_t *startPointIndex,
-                                      int64_t *pointCount ) const
+   bool Reader::ReadData3DGroupsData( int64_t dataIndex, size_t groupCount, int64_t *idElementValue,
+                                      int64_t *startPointIndex, int64_t *pointCount ) const
    {
       return impl_->ReadData3DGroupsData( dataIndex, groupCount, idElementValue, startPointIndex,
                                           pointCount );

--- a/src/E57SimpleWriter.cpp
+++ b/src/E57SimpleWriter.cpp
@@ -90,7 +90,7 @@ namespace
          ( pointFields.timeMinimum == cMin ) && ( pointFields.timeMaximum == cMax );
 
       // Now run through the points and set the things we need to
-      for ( int64_t i = 0; i < ioData3DHeader.pointCount; ++i )
+      for ( size_t i = 0; i < ioData3DHeader.pointCount; ++i )
       {
          if ( writePointRange && pointFields.cartesianXField )
          {
@@ -267,7 +267,7 @@ namespace e57
       return impl_->SetUpData3DPointsData( dataIndex, pointCount, buffers );
    }
 
-   bool Writer::WriteData3DGroupsData( int64_t dataIndex, int64_t groupCount,
+   bool Writer::WriteData3DGroupsData( int64_t dataIndex, size_t groupCount,
                                        int64_t *idElementValue, int64_t *startPointIndex,
                                        int64_t *pointCount )
    {

--- a/src/ReaderImpl.h
+++ b/src/ReaderImpl.h
@@ -72,7 +72,7 @@ namespace e57
                            int64_t &pointsSize, int64_t &groupsSize, int64_t &countSize,
                            bool &bColumnIndex ) const;
 
-      bool ReadData3DGroupsData( int64_t dataIndex, int64_t groupCount, int64_t *idElementValue,
+      bool ReadData3DGroupsData( int64_t dataIndex, size_t groupCount, int64_t *idElementValue,
                                  int64_t *startPointIndex, int64_t *pointCount ) const;
 
       template <typename COORDTYPE>

--- a/src/WriterImpl.cpp
+++ b/src/WriterImpl.cpp
@@ -1308,7 +1308,7 @@ namespace e57
       int64_t dataIndex, size_t pointCount, const Data3DPointsData_t<double> &buffers );
 
    // This function writes out the group data
-   bool WriterImpl::WriteData3DGroupsData( int64_t dataIndex, int64_t groupCount,
+   bool WriterImpl::WriteData3DGroupsData( int64_t dataIndex, size_t groupCount,
                                            int64_t *idElementValue, int64_t *startPointIndex,
                                            int64_t *pointCount )
    {

--- a/src/WriterImpl.h
+++ b/src/WriterImpl.h
@@ -61,7 +61,7 @@ namespace e57
       CompressedVectorWriter SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
                                                     const Data3DPointsData_t<COORDTYPE> &buffers );
 
-      bool WriteData3DGroupsData( int64_t dataIndex, int64_t groupCount, int64_t *idElementValue,
+      bool WriteData3DGroupsData( int64_t dataIndex, size_t groupCount, int64_t *idElementValue,
                                   int64_t *startPointIndex, int64_t *pointCount );
 
       StructureNode GetRawE57Root();


### PR DESCRIPTION
- I haven't got the 32-bit CI to build properly because of xerces-c link problems.
- I realize that the 32-bit check I have in `ReaderImpl.cpp` will ~~silently~~ drop points if there are more than `4,294,967,295` in a single scan and output a warning to the console. This seems unlikely (impossible?). There is no mechanism to return partial success, so instead of throwing an exception I decided to just drop them since it's such an extreme edge case.

Fixes #232