### PR TITLE
{cmake} Don't force install locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,9 +199,6 @@ install(
         E57Format
     EXPORT
         E57Format-export
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin
 )
 
 # ccache


### PR DESCRIPTION
These are the default locations and this prevents overriding them using CMAKE_INSTALL_BINDIR & CMAKE_INSTALL_LIBDIR.