### PR TITLE
Fix compilation with GCC <= 10

### DIFF
--- a/src/E57SimpleReader.cpp
+++ b/src/E57SimpleReader.cpp
@@ -44,27 +44,27 @@ namespace e57
    bool Reader::IsOpen() const
    {
       return impl_->IsOpen();
-   };
+   }
 
    bool Reader::Close()
    {
       return impl_->Close();
-   };
+   }
 
    bool Reader::GetE57Root( E57Root &fileHeader ) const
    {
       return impl_->GetE57Root( fileHeader );
-   };
+   }
 
    int64_t Reader::GetImage2DCount() const
    {
       return impl_->GetImage2DCount();
-   };
+   }
 
    bool Reader::ReadImage2D( int64_t imageIndex, Image2D &image2DHeader ) const
    {
       return impl_->ReadImage2D( imageIndex, image2DHeader );
-   };
+   }
 
    bool Reader::GetImage2DSizes( int64_t imageIndex, Image2DProjection &imageProjection,
                                  Image2DType &imageType, int64_t &imageWidth, int64_t &imageHeight,
@@ -73,7 +73,7 @@ namespace e57
    {
       return impl_->GetImage2DSizes( imageIndex, imageProjection, imageType, imageWidth,
                                      imageHeight, imageSize, imageMaskType, imageVisualType );
-   };
+   }
 
    int64_t Reader::ReadImage2DData( int64_t imageIndex, Image2DProjection imageProjection,
                                     Image2DType imageType, void *pBuffer, int64_t start,
@@ -86,12 +86,12 @@ namespace e57
          impl_->ReadImage2DData( imageIndex, imageProjection, imageType, buffer, start, size );
 
       return static_cast<int64_t>( read );
-   };
+   }
 
    int64_t Reader::GetData3DCount() const
    {
       return impl_->GetData3DCount();
-   };
+   }
 
    ImageFile Reader::GetRawIMF() const
    {
@@ -101,17 +101,17 @@ namespace e57
    StructureNode Reader::GetRawE57Root() const
    {
       return impl_->GetRawE57Root();
-   };
+   }
 
    VectorNode Reader::GetRawData3D() const
    {
       return impl_->GetRawData3D();
-   };
+   }
 
    VectorNode Reader::GetRawImages2D() const
    {
       return impl_->GetRawImages2D();
-   };
+   }
 
    bool Reader::ReadData3D( int64_t dataIndex, Data3D &data3DHeader ) const
    {

--- a/src/E57SimpleWriter.cpp
+++ b/src/E57SimpleWriter.cpp
@@ -180,7 +180,7 @@ namespace e57
    bool Writer::IsOpen() const
    {
       return impl_->IsOpen();
-   };
+   }
 
    bool Writer::Close()
    {
@@ -200,12 +200,12 @@ namespace e57
                                                       buffer, startPos, sizeInBytes );
 
       return static_cast<int64_t>( written );
-   };
+   }
 
    int64_t Writer::NewImage2D( Image2D &image2DHeader )
    {
       return impl_->NewImage2D( image2DHeader );
-   };
+   }
 
    int64_t Writer::WriteImage2DData( int64_t imageIndex, Image2DType imageType,
                                      Image2DProjection imageProjection, void *pBuffer,
@@ -253,7 +253,7 @@ namespace e57
    int64_t Writer::NewData3D( Data3D &data3DHeader )
    {
       return impl_->NewData3D( data3DHeader );
-   };
+   }
 
    CompressedVectorWriter Writer::SetUpData3DPointsData( int64_t dataIndex, size_t pointCount,
                                                          const Data3DPointsFloat &buffers )
@@ -283,15 +283,15 @@ namespace e57
    StructureNode Writer::GetRawE57Root()
    {
       return impl_->GetRawE57Root();
-   };
+   }
 
    VectorNode Writer::GetRawData3D()
    {
       return impl_->GetRawData3D();
-   };
+   }
 
    VectorNode Writer::GetRawImages2D()
    {
       return impl_->GetRawImages2D();
-   };
+   }
 } // end namespace e57

--- a/src/NodeImpl.cpp
+++ b/src/NodeImpl.cpp
@@ -58,7 +58,7 @@ bool NodeImpl::isRoot() const
    checkImageFileOpen( __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) );
 
    return parent_.expired();
-};
+}
 
 NodeImplSharedPtr NodeImpl::parent()
 {


### PR DESCRIPTION
Hi,

libE57Format currently doesn't compile with GCC <= 10 because of some unnecessary semicolons after function definitions which cause the following warnings that are treated as errors:
```
src/NodeImpl.cpp:61:2: error: extra ‘;’ [-Werror=pedantic]
   61 | };
      |  ^
[...]
src/E57SimpleReader.cpp:47:5: error: extra ‘;’ [-Werror=pedantic]
   47 |    };
      |     ^
[...]
src/E57SimpleWriter.cpp:183:5: error: extra ‘;’ [-Werror=pedantic]
  183 |    };
      |     ^
```
This MR fixes the issue by removing the unnecessary semicolons.