### PR TITLE
{standard} Fix invalid range exception in FloatNode implementation

### DIFF
--- a/src/E57XmlParser.cpp
+++ b/src/E57XmlParser.cpp
@@ -745,18 +745,18 @@ void E57XmlParser::endElement( const XMLCh *const uri, const XMLCh *const localN
       break;
       case TypeFloat:
       {
-         // Convert child text (if any) to value, else default to 0.0
-         double floatValue;
+         // Convert child text (if any) to value
+         double floatValue = 0.0;
+         bool validValue = false;
+
          if ( pi.childText.length() > 0 )
          {
             floatValue = strToDouble( pi.childText );
+            validValue = true;
          }
-         else
-         {
-            floatValue = 0.0;
-         }
-         std::shared_ptr<FloatNodeImpl> f_ni(
-            new FloatNodeImpl( imf_, floatValue, pi.precision, pi.floatMinimum, pi.floatMaximum ) );
+
+         std::shared_ptr<FloatNodeImpl> f_ni( new FloatNodeImpl(
+            imf_, floatValue, validValue, pi.precision, pi.floatMinimum, pi.floatMaximum ) );
          current_ni = f_ni;
       }
       break;

--- a/src/FloatNode.cpp
+++ b/src/FloatNode.cpp
@@ -151,7 +151,7 @@ be true).
 */
 FloatNode::FloatNode( const ImageFile &destImageFile, double value, FloatPrecision precision,
                       double minimum, double maximum ) :
-   impl_( new FloatNodeImpl( destImageFile.impl(), value, precision, minimum, maximum ) )
+   impl_( new FloatNodeImpl( destImageFile.impl(), value, true, precision, minimum, maximum ) )
 {
 }
 

--- a/src/FloatNodeImpl.cpp
+++ b/src/FloatNodeImpl.cpp
@@ -31,7 +31,7 @@
 
 namespace e57
 {
-   FloatNodeImpl::FloatNodeImpl( ImageFileImplWeakPtr destImageFile, double value,
+   FloatNodeImpl::FloatNodeImpl( ImageFileImplWeakPtr destImageFile, double value, bool validValue,
                                  FloatPrecision precision, double minimum, double maximum ) :
       NodeImpl( destImageFile ),
       value_( value ), precision_( precision ), minimum_( minimum ), maximum_( maximum )
@@ -52,8 +52,8 @@ namespace e57
          }
       }
 
-      // Enforce the given bounds on raw value
-      if ( value < minimum || maximum < value )
+      // Enforce the given bounds on raw value if it is valid
+      if ( validValue && ( value < minimum || value > maximum ) )
       {
          throw E57_EXCEPTION2( ErrorValueOutOfBounds, "this->pathName=" + this->pathName() +
                                                          " value=" + toString( value ) +

--- a/src/FloatNodeImpl.h
+++ b/src/FloatNodeImpl.h
@@ -34,7 +34,7 @@ namespace e57
    {
    public:
       explicit FloatNodeImpl( ImageFileImplWeakPtr destImageFile, double value = 0,
-                              FloatPrecision precision = PrecisionDouble,
+                              bool validValue = true, FloatPrecision precision = PrecisionDouble,
                               double minimum = DOUBLE_MIN, double maximum = DOUBLE_MAX );
       ~FloatNodeImpl() override = default;
 


### PR DESCRIPTION
A prototype field like this would throw an exception because it was checking the default value (0.0) against the range:

```xml
<cartesianY type="Float" minimum="0.040010999888181686" maximum="0.1873210072517395" />
```

Instead, only perform the check if we have explicitly set the value.

This fix follows the standard (E57 Standard 8.3.9.3 (1)) which allows this form:

> The values of the prototype elements and sub-elements are ignored, and need not be specified.

Fixes #246