### PR TITLE
The TEMPLATE_EXTERN define in the generated export header is not used.

### DIFF
--- a/cmake/E57ExportHeader.cmake
+++ b/cmake/E57ExportHeader.cmake
@@ -6,13 +6,6 @@
 include( GenerateExportHeader )
 
 set( comment "\r
-// Windows DLLs can't include the extern keyword when declaring templates \r
-#ifdef _MSC_VER                 \r
-#define TEMPLATE_EXTERN         \r
-#else                           \r
-#define TEMPLATE_EXTERN extern  \r
-#endif                          \r
-                                \r
 // NOTE: This is a generated file. Any changes will be overwritten."
 )
 


### PR DESCRIPTION
This must have been left over from some experiment with Windows.