### PR TITLE
A Data3D section is allowed to have 0 points

### DIFF
--- a/src/E57SimpleData.cpp
+++ b/src/E57SimpleData.cpp
@@ -18,12 +18,6 @@ namespace e57
    /// Validates a Data3D and throws on error.
    void _validateData3D( const Data3D &inData3D )
    {
-      if ( inData3D.pointCount < 1 )
-      {
-         throw E57_EXCEPTION2( ErrorValueOutOfBounds,
-                               "pointCount=" + toString( inData3D.pointCount ) + " minimum=1" );
-      }
-
       if ( inData3D.pointFields.pointRangeNodeType == NumericalNodeType::Integer )
       {
          throw E57_EXCEPTION2( ErrorInvalidNodeType, "pointRangeNodeType cannot be Integer" );

--- a/test/src/test_SimpleData.cpp
+++ b/test/src/test_SimpleData.cpp
@@ -10,13 +10,6 @@
 #include "Helpers.h"
 #include "TestData.h"
 
-TEST( SimpleDataHeader, InvalidPointCount )
-{
-   e57::Data3D dataHeader;
-
-   E57_ASSERT_THROW( e57::Data3DPointsFloat pointsData( dataHeader ) );
-}
-
 TEST( SimpleDataHeader, InvalidPointRangeNodeType )
 {
    e57::Data3D dataHeader;


### PR DESCRIPTION
See ASTM standard Table 9: "recordCount" shall be in the interval [0, 2^63).

Part of #262