### PR TITLE
Fix include to avoid MSVC compilation error

### DIFF
--- a/src/E57SimpleWriter.cpp
+++ b/src/E57SimpleWriter.cpp
@@ -26,6 +26,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+#include <algorithm>
 #include <limits>
 
 #include "E57SimpleWriter.h"


### PR DESCRIPTION
Avoid MSVC compilation error C2039: "min": is not a member of "std" of Visual Studio 2017.