### PR TITLE
XML library initialisation is not thread safe

### DIFF
--- a/src/E57XmlParser.cpp
+++ b/src/E57XmlParser.cpp
@@ -285,6 +285,8 @@ void E57XmlParser::init()
    // Initialize the XML4C2 system
    try
    {
+      // NOTE: This is not thread safe for multiple simulaneous E57 readers.
+      //       Ideally we'd do this once, not once per reader
       XMLPlatformUtils::Initialize();
    }
    catch ( const XMLException &ex )


### PR DESCRIPTION
Came across this problem trying to read more than one E57 at a time, in seperate threads.
Making a note here that while SimpleReader is convenient, it makes certain assumptions.
