### PR TITLE
Remove default arguments on implementation class constructors

### DIFF
--- a/src/FloatNodeImpl.h
+++ b/src/FloatNodeImpl.h
@@ -33,9 +33,8 @@ namespace e57
    class FloatNodeImpl : public NodeImpl
    {
    public:
-      explicit FloatNodeImpl( ImageFileImplWeakPtr destImageFile, double value = 0,
-                              bool validValue = true, FloatPrecision precision = PrecisionDouble,
-                              double minimum = DOUBLE_MIN, double maximum = DOUBLE_MAX );
+      FloatNodeImpl( ImageFileImplWeakPtr destImageFile, double value, bool validValue,
+                     FloatPrecision precision, double minimum, double maximum );
       ~FloatNodeImpl() override = default;
 
       NodeType type() const override

--- a/src/IntegerNodeImpl.h
+++ b/src/IntegerNodeImpl.h
@@ -33,8 +33,8 @@ namespace e57
    class IntegerNodeImpl : public NodeImpl
    {
    public:
-      explicit IntegerNodeImpl( ImageFileImplWeakPtr destImageFile, int64_t value = 0,
-                                int64_t minimum = 0, int64_t maximum = 0 );
+      IntegerNodeImpl( ImageFileImplWeakPtr destImageFile, int64_t value, int64_t minimum,
+                       int64_t maximum );
       ~IntegerNodeImpl() override = default;
 
       NodeType type() const override

--- a/src/ReaderImpl.h
+++ b/src/ReaderImpl.h
@@ -36,7 +36,7 @@ namespace e57
    class ReaderImpl
    {
    public:
-      explicit ReaderImpl( const ustring &filePath, const ReaderOptions &options );
+      ReaderImpl( const ustring &filePath, const ReaderOptions &options );
       ~ReaderImpl();
 
       // disallow copying a ReaderImpl

--- a/src/ScaledIntegerNodeImpl.h
+++ b/src/ScaledIntegerNodeImpl.h
@@ -33,13 +33,12 @@ namespace e57
    class ScaledIntegerNodeImpl : public NodeImpl
    {
    public:
-      explicit ScaledIntegerNodeImpl( ImageFileImplWeakPtr destImageFile, int64_t value = 0,
-                                      int64_t minimum = 0, int64_t maximum = 0, double scale = 1.0,
-                                      double offset = 0.0 );
+      ScaledIntegerNodeImpl( ImageFileImplWeakPtr destImageFile, int64_t value, int64_t minimum,
+                             int64_t maximum, double scale, double offset );
 
-      explicit ScaledIntegerNodeImpl( ImageFileImplWeakPtr destImageFile, double scaledValue = 0.,
-                                      double scaledMinimum = 0., double scaledMaximum = 0.,
-                                      double scale = 1.0, double offset = 0.0 );
+      ScaledIntegerNodeImpl( ImageFileImplWeakPtr destImageFile, double scaledValue,
+                             double scaledMinimum, double scaledMaximum, double scale,
+                             double offset );
 
       ~ScaledIntegerNodeImpl() override = default;
 

--- a/src/SourceDestBufferImpl.h
+++ b/src/SourceDestBufferImpl.h
@@ -37,7 +37,7 @@ namespace e57
    {
    public:
       SourceDestBufferImpl( ImageFileImplWeakPtr destImageFile, const ustring &pathName,
-                            size_t capacity, bool doConversion = false, bool doScaling = false );
+                            size_t capacity, bool doConversion, bool doScaling );
 
       template <typename T> void setTypeInfo( T *base, size_t stride = sizeof( T ) );
 

--- a/src/StringNodeImpl.h
+++ b/src/StringNodeImpl.h
@@ -33,7 +33,7 @@ namespace e57
    class StringNodeImpl : public NodeImpl
    {
    public:
-      explicit StringNodeImpl( ImageFileImplWeakPtr destImageFile, const ustring &value = "" );
+      StringNodeImpl( ImageFileImplWeakPtr destImageFile, const ustring &value );
       ~StringNodeImpl() override = default;
 
       NodeType type() const override

--- a/src/VectorNodeImpl.h
+++ b/src/VectorNodeImpl.h
@@ -33,7 +33,7 @@ namespace e57
    class VectorNodeImpl : public StructureNodeImpl
    {
    public:
-      explicit VectorNodeImpl( ImageFileImplWeakPtr destImageFile, bool allowHeteroChildren );
+      VectorNodeImpl( ImageFileImplWeakPtr destImageFile, bool allowHeteroChildren );
       ~VectorNodeImpl() override = default;
 
       NodeType type() const override


### PR DESCRIPTION
These defaults are never used since they are always constructed with all arguments.