### PR TITLE
Add "E57_" to macros in E57Exception.h

### DIFF
--- a/include/E57Exception.h
+++ b/include/E57Exception.h
@@ -37,15 +37,15 @@
 
 #ifndef E57_ENABLE_DIAGNOSTIC_OUTPUT
 // Used to mark unused parameters to indicate intent and suppress warnings.
-#define UNUSED( expr ) (void)( expr )
+#define E57_UNUSED( expr ) (void)( expr )
 #endif
 
 // C++14 does not support the [[deprecated]] attribute on enumerators.
 // Turn on enumerator deprecation notices if we are compiling with C++17 or later.
 #if ( ( defined( _MSVC_LANG ) && _MSVC_LANG >= 201703L ) || __cplusplus >= 201703L )
-#define DEPRECATED_ENUM( str ) [[deprecated( str )]]
+#define E57_DEPRECATED_ENUM( str ) [[deprecated( str )]]
 #else
-#define DEPRECATED_ENUM( str )
+#define E57_DEPRECATED_ENUM( str )
 #endif
 
 namespace e57
@@ -143,159 +143,159 @@ namespace e57
       ErrorData3DReadInvalidZeroRecords = 53,
 
       /// @deprecated Will be removed in 4.0. Use e57::Success.
-      E57_SUCCESS DEPRECATED_ENUM( "Will be removed in 4.0. Use Success." ) = Success,
+      E57_SUCCESS E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use Success." ) = Success,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadCVHeader.
-      E57_ERROR_BAD_CV_HEADER DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorBadCVHeader." ) =
-         ErrorBadCVHeader,
+      E57_ERROR_BAD_CV_HEADER E57_DEPRECATED_ENUM(
+         "Will be removed in 4.0. Use ErrorBadCVHeader." ) = ErrorBadCVHeader,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadCVPacket.
-      E57_ERROR_BAD_CV_PACKET DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorBadCVPacket." ) =
-         ErrorBadCVPacket,
+      E57_ERROR_BAD_CV_PACKET E57_DEPRECATED_ENUM(
+         "Will be removed in 4.0. Use ErrorBadCVPacket." ) = ErrorBadCVPacket,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorChildIndexOutOfBounds.
-      E57_ERROR_CHILD_INDEX_OUT_OF_BOUNDS DEPRECATED_ENUM(
+      E57_ERROR_CHILD_INDEX_OUT_OF_BOUNDS E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorChildIndexOutOfBounds." ) = ErrorChildIndexOutOfBounds,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorSetTwice.
-      E57_ERROR_SET_TWICE DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorSetTwice." ) =
+      E57_ERROR_SET_TWICE E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorSetTwice." ) =
          ErrorSetTwice,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorHomogeneousViolation.
-      E57_ERROR_HOMOGENEOUS_VIOLATION DEPRECATED_ENUM(
+      E57_ERROR_HOMOGENEOUS_VIOLATION E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorHomogeneousViolation." ) = ErrorHomogeneousViolation,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorValueNotRepresentable.
-      E57_ERROR_VALUE_NOT_REPRESENTABLE DEPRECATED_ENUM(
+      E57_ERROR_VALUE_NOT_REPRESENTABLE E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorValueNotRepresentable." ) = ErrorValueNotRepresentable,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorScaledValueNotRepresentable.
-      E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE DEPRECATED_ENUM(
+      E57_ERROR_SCALED_VALUE_NOT_REPRESENTABLE E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorScaledValueNotRepresentable." ) =
          ErrorScaledValueNotRepresentable,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorReal64TooLarge.
-      E57_ERROR_REAL64_TOO_LARGE DEPRECATED_ENUM(
+      E57_ERROR_REAL64_TOO_LARGE E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorReal64TooLarge." ) = ErrorReal64TooLarge,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorExpectingNumeric.
-      E57_ERROR_EXPECTING_NUMERIC DEPRECATED_ENUM(
+      E57_ERROR_EXPECTING_NUMERIC E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorExpectingNumeric." ) = ErrorExpectingNumeric,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorExpectingUString.
-      E57_ERROR_EXPECTING_USTRING DEPRECATED_ENUM(
+      E57_ERROR_EXPECTING_USTRING E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorExpectingUString." ) = ErrorExpectingUString,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorInternal.
-      E57_ERROR_INTERNAL DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorInternal." ) =
+      E57_ERROR_INTERNAL E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorInternal." ) =
          ErrorInternal,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadXMLFormat.
-      E57_ERROR_BAD_XML_FORMAT DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorBadXMLFormat." ) =
-         ErrorBadXMLFormat,
+      E57_ERROR_BAD_XML_FORMAT E57_DEPRECATED_ENUM(
+         "Will be removed in 4.0. Use ErrorBadXMLFormat." ) = ErrorBadXMLFormat,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorXMLParser.
-      E57_ERROR_XML_PARSER DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorXMLParser." ) =
+      E57_ERROR_XML_PARSER E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorXMLParser." ) =
          ErrorXMLParser,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadAPIArgument.
-      E57_ERROR_BAD_API_ARGUMENT DEPRECATED_ENUM(
+      E57_ERROR_BAD_API_ARGUMENT E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorBadAPIArgument." ) = ErrorBadAPIArgument,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorFileReadOnly.
-      E57_ERROR_FILE_IS_READ_ONLY DEPRECATED_ENUM(
+      E57_ERROR_FILE_IS_READ_ONLY E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorFileReadOnly." ) = ErrorFileReadOnly,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadChecksum.
-      E57_ERROR_BAD_CHECKSUM DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorBadChecksum." ) =
-         ErrorBadChecksum,
+      E57_ERROR_BAD_CHECKSUM E57_DEPRECATED_ENUM(
+         "Will be removed in 4.0. Use ErrorBadChecksum." ) = ErrorBadChecksum,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorOpenFailed.
-      E57_ERROR_OPEN_FAILED DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorOpenFailed." ) =
+      E57_ERROR_OPEN_FAILED E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorOpenFailed." ) =
          ErrorOpenFailed,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorCloseFailed.
-      E57_ERROR_CLOSE_FAILED DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorCloseFailed." ) =
-         ErrorCloseFailed,
+      E57_ERROR_CLOSE_FAILED E57_DEPRECATED_ENUM(
+         "Will be removed in 4.0. Use ErrorCloseFailed." ) = ErrorCloseFailed,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorReadFailed.
-      E57_ERROR_READ_FAILED DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorReadFailed." ) =
+      E57_ERROR_READ_FAILED E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorReadFailed." ) =
          ErrorReadFailed,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorWriteFailed.
-      E57_ERROR_WRITE_FAILED DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorWriteFailed." ) =
-         ErrorWriteFailed,
+      E57_ERROR_WRITE_FAILED E57_DEPRECATED_ENUM(
+         "Will be removed in 4.0. Use ErrorWriteFailed." ) = ErrorWriteFailed,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorSeekFailed.
-      E57_ERROR_LSEEK_FAILED DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorSeekFailed." ) =
+      E57_ERROR_LSEEK_FAILED E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorSeekFailed." ) =
          ErrorSeekFailed,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorPathUndefined.
-      E57_ERROR_PATH_UNDEFINED DEPRECATED_ENUM(
+      E57_ERROR_PATH_UNDEFINED E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorPathUndefined." ) = ErrorPathUndefined,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadBuffer.
-      E57_ERROR_BAD_BUFFER DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorBadBuffer." ) =
+      E57_ERROR_BAD_BUFFER E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorBadBuffer." ) =
          ErrorBadBuffer,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorNoBufferForElement.
-      E57_ERROR_NO_BUFFER_FOR_ELEMENT DEPRECATED_ENUM(
+      E57_ERROR_NO_BUFFER_FOR_ELEMENT E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorNoBufferForElement." ) = ErrorNoBufferForElement,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBufferSizeMismatch.
-      E57_ERROR_BUFFER_SIZE_MISMATCH DEPRECATED_ENUM(
+      E57_ERROR_BUFFER_SIZE_MISMATCH E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorBufferSizeMismatch." ) = ErrorBufferSizeMismatch,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBufferDuplicatePathName.
-      E57_ERROR_BUFFER_DUPLICATE_PATHNAME DEPRECATED_ENUM(
+      E57_ERROR_BUFFER_DUPLICATE_PATHNAME E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorBufferDuplicatePathName." ) =
          ErrorBufferDuplicatePathName,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadFileSignature.
-      E57_ERROR_BAD_FILE_SIGNATURE DEPRECATED_ENUM(
+      E57_ERROR_BAD_FILE_SIGNATURE E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorBadFileSignature." ) = ErrorBadFileSignature,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorUnknownFileVersion.
-      E57_ERROR_UNKNOWN_FILE_VERSION DEPRECATED_ENUM(
+      E57_ERROR_UNKNOWN_FILE_VERSION E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorUnknownFileVersion." ) = ErrorUnknownFileVersion,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadFileLength.
-      E57_ERROR_BAD_FILE_LENGTH DEPRECATED_ENUM(
+      E57_ERROR_BAD_FILE_LENGTH E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorBadFileLength." ) = ErrorBadFileLength,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorXMLParserInit.
-      E57_ERROR_XML_PARSER_INIT DEPRECATED_ENUM(
+      E57_ERROR_XML_PARSER_INIT E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorXMLParserInit." ) = ErrorXMLParserInit,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorDuplicateNamespacePrefix.
-      E57_ERROR_DUPLICATE_NAMESPACE_PREFIX DEPRECATED_ENUM(
+      E57_ERROR_DUPLICATE_NAMESPACE_PREFIX E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorDuplicateNamespacePrefix." ) =
          ErrorDuplicateNamespacePrefix,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorDuplicateNamespaceURI.
-      E57_ERROR_DUPLICATE_NAMESPACE_URI DEPRECATED_ENUM(
+      E57_ERROR_DUPLICATE_NAMESPACE_URI E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorDuplicateNamespaceURI." ) = ErrorDuplicateNamespaceURI,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadPrototype.
-      E57_ERROR_BAD_PROTOTYPE DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorBadPrototype." ) =
-         ErrorBadPrototype,
+      E57_ERROR_BAD_PROTOTYPE E57_DEPRECATED_ENUM(
+         "Will be removed in 4.0. Use ErrorBadPrototype." ) = ErrorBadPrototype,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadCodecs.
-      E57_ERROR_BAD_CODECS DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorBadCodecs." ) =
+      E57_ERROR_BAD_CODECS E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorBadCodecs." ) =
          ErrorBadCodecs,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorValueOutOfBounds.
-      E57_ERROR_VALUE_OUT_OF_BOUNDS DEPRECATED_ENUM(
+      E57_ERROR_VALUE_OUT_OF_BOUNDS E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorValueOutOfBounds." ) = ErrorValueOutOfBounds,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorConversionRequired.
-      E57_ERROR_CONVERSION_REQUIRED DEPRECATED_ENUM(
+      E57_ERROR_CONVERSION_REQUIRED E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorConversionRequired." ) = ErrorConversionRequired,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadPathName.
-      E57_ERROR_BAD_PATH_NAME DEPRECATED_ENUM( "Will be removed in 4.0. Use ErrorBadPathName." ) =
-         ErrorBadPathName,
+      E57_ERROR_BAD_PATH_NAME E57_DEPRECATED_ENUM(
+         "Will be removed in 4.0. Use ErrorBadPathName." ) = ErrorBadPathName,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorNotImplemented.
-      E57_ERROR_NOT_IMPLEMENTED DEPRECATED_ENUM(
+      E57_ERROR_NOT_IMPLEMENTED E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorNotImplemented." ) = ErrorNotImplemented,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadNodeDowncast.
-      E57_ERROR_BAD_NODE_DOWNCAST DEPRECATED_ENUM(
+      E57_ERROR_BAD_NODE_DOWNCAST E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorBadNodeDowncast." ) = ErrorBadNodeDowncast,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorWriterNotOpen.
-      E57_ERROR_WRITER_NOT_OPEN DEPRECATED_ENUM(
+      E57_ERROR_WRITER_NOT_OPEN E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorWriterNotOpen." ) = ErrorWriterNotOpen,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorReaderNotOpen.
-      E57_ERROR_READER_NOT_OPEN DEPRECATED_ENUM(
+      E57_ERROR_READER_NOT_OPEN E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorReaderNotOpen." ) = ErrorReaderNotOpen,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorNodeUnattached.
-      E57_ERROR_NODE_UNATTACHED DEPRECATED_ENUM(
+      E57_ERROR_NODE_UNATTACHED E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorNodeUnattached." ) = ErrorNodeUnattached,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorAlreadyHasParent.
-      E57_ERROR_ALREADY_HAS_PARENT DEPRECATED_ENUM(
+      E57_ERROR_ALREADY_HAS_PARENT E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorAlreadyHasParent." ) = ErrorAlreadyHasParent,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorDifferentDestImageFile.
-      E57_ERROR_DIFFERENT_DEST_IMAGEFILE DEPRECATED_ENUM(
+      E57_ERROR_DIFFERENT_DEST_IMAGEFILE E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorDifferentDestImageFile." ) = ErrorDifferentDestImageFile,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorImageFileNotOpen.
-      E57_ERROR_IMAGEFILE_NOT_OPEN DEPRECATED_ENUM(
+      E57_ERROR_IMAGEFILE_NOT_OPEN E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorImageFileNotOpen." ) = ErrorImageFileNotOpen,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBuffersNotCompatible.
-      E57_ERROR_BUFFERS_NOT_COMPATIBLE DEPRECATED_ENUM(
+      E57_ERROR_BUFFERS_NOT_COMPATIBLE E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorBuffersNotCompatible." ) = ErrorBuffersNotCompatible,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorTooManyWriters.
-      E57_ERROR_TOO_MANY_WRITERS DEPRECATED_ENUM(
+      E57_ERROR_TOO_MANY_WRITERS E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorTooManyWriters." ) = ErrorTooManyWriters,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorTooManyReaders.
-      E57_ERROR_TOO_MANY_READERS DEPRECATED_ENUM(
+      E57_ERROR_TOO_MANY_READERS E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorTooManyReaders." ) = ErrorTooManyReaders,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadConfiguration.
-      E57_ERROR_BAD_CONFIGURATION DEPRECATED_ENUM(
+      E57_ERROR_BAD_CONFIGURATION E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorBadConfiguration." ) = ErrorBadConfiguration,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorInvarianceViolation.
-      E57_ERROR_INVARIANCE_VIOLATION DEPRECATED_ENUM(
+      E57_ERROR_INVARIANCE_VIOLATION E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorInvarianceViolation." ) = ErrorInvarianceViolation,
    };
 
@@ -337,9 +337,9 @@ namespace e57
                << ") : error C0:  <--- reported on" << std::endl;
          }
 #else
-         UNUSED( reportingFileName );
-         UNUSED( reportingLineNumber );
-         UNUSED( reportingFunctionName );
+         E57_UNUSED( reportingFileName );
+         E57_UNUSED( reportingLineNumber );
+         E57_UNUSED( reportingFunctionName );
 #endif
       }
 

--- a/include/E57Format.h
+++ b/include/E57Format.h
@@ -66,23 +66,24 @@ namespace e57
       TypeBlob = 8,             ///< BlobNode class
 
       /// @deprecated Will be removed in 4.0. Use e57::TypeStructure.
-      E57_STRUCTURE DEPRECATED_ENUM( "Will be removed in 4.0. Use TypeStructure." ) = TypeStructure,
+      E57_STRUCTURE E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use TypeStructure." ) =
+         TypeStructure,
       /// @deprecated Will be removed in 4.0. Use e57::TypeVector.
-      E57_VECTOR DEPRECATED_ENUM( "Will be removed in 4.0. Use TypeVector." ) = TypeVector,
+      E57_VECTOR E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use TypeVector." ) = TypeVector,
       /// @deprecated Will be removed in 4.0. Use e57::TypeCompressedVector.
-      E57_COMPRESSED_VECTOR DEPRECATED_ENUM( "Will be removed in 4.0. Use TypeCompressedVector." ) =
-         TypeCompressedVector,
+      E57_COMPRESSED_VECTOR E57_DEPRECATED_ENUM(
+         "Will be removed in 4.0. Use TypeCompressedVector." ) = TypeCompressedVector,
       /// @deprecated Will be removed in 4.0. Use e57::TypeInteger.
-      E57_INTEGER DEPRECATED_ENUM( "Will be removed in 4.0. Use TypeInteger." ) = TypeInteger,
+      E57_INTEGER E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use TypeInteger." ) = TypeInteger,
       /// @deprecated Will be removed in 4.0. Use e57::TypeScaledInteger.
-      E57_SCALED_INTEGER DEPRECATED_ENUM( "Will be removed in 4.0. Use TypeScaledInteger." ) =
+      E57_SCALED_INTEGER E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use TypeScaledInteger." ) =
          TypeScaledInteger,
       /// @deprecated Will be removed in 4.0. Use e57::TypeFloat.
-      E57_FLOAT DEPRECATED_ENUM( "Will be removed in 4.0. Use TypeFloat." ) = TypeFloat,
+      E57_FLOAT E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use TypeFloat." ) = TypeFloat,
       /// @deprecated Will be removed in 4.0. Use e57::TypeString.
-      E57_STRING DEPRECATED_ENUM( "Will be removed in 4.0. Use TypeString." ) = TypeString,
+      E57_STRING E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use TypeString." ) = TypeString,
       /// @deprecated Will be removed in 4.0. Use e57::TypeBlob.
-      E57_BLOB DEPRECATED_ENUM( "Will be removed in 4.0. Use TypeBlob." ) = TypeBlob
+      E57_BLOB E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use TypeBlob." ) = TypeBlob
    };
 
    /// @brief The IEEE floating point number precisions supported
@@ -92,10 +93,11 @@ namespace e57
       PrecisionDouble = 2, ///< 64 bit IEEE floating point number format
 
       /// @deprecated Will be removed in 4.0. Use e57::PrecisionSingle.
-      E57_SINGLE DEPRECATED_ENUM( "Will be removed in 4.0. Use PrecisionSingle." ) =
+      E57_SINGLE E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use PrecisionSingle." ) =
          PrecisionSingle,
       /// @deprecated Will be removed in 4.0. Use e57::PrecisionDouble.
-      E57_DOUBLE DEPRECATED_ENUM( "Will be removed in 4.0. Use PrecisionDouble." ) = PrecisionDouble
+      E57_DOUBLE E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use PrecisionDouble." ) =
+         PrecisionDouble
    };
 
    /// @brief Identifies the representations of memory elements API can transfer data to/from
@@ -114,27 +116,27 @@ namespace e57
       UString = 11, ///< Unicode UTF-8 std::string
 
       /// @deprecated Will be removed in 4.0. Use e57::Int8.
-      E57_INT8 DEPRECATED_ENUM( "Will be removed in 4.0. Use Int8." ) = Int8,
+      E57_INT8 E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use Int8." ) = Int8,
       /// @deprecated Will be removed in 4.0. Use e57::UInt8.
-      E57_UINT8 DEPRECATED_ENUM( "Will be removed in 4.0. Use UInt8." ) = UInt8,
+      E57_UINT8 E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use UInt8." ) = UInt8,
       /// @deprecated Will be removed in 4.0. Use e57::Int16.
-      E57_INT16 DEPRECATED_ENUM( "Will be removed in 4.0. Use Int16." ) = Int16,
+      E57_INT16 E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use Int16." ) = Int16,
       /// @deprecated Will be removed in 4.0. Use e57::UInt16.
-      E57_UINT16 DEPRECATED_ENUM( "Will be removed in 4.0. Use UInt16." ) = UInt16,
+      E57_UINT16 E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use UInt16." ) = UInt16,
       /// @deprecated Will be removed in 4.0. Use e57::Int32.
-      E57_INT32 DEPRECATED_ENUM( "Will be removed in 4.0. Use Int32." ) = Int32,
+      E57_INT32 E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use Int32." ) = Int32,
       /// @deprecated Will be removed in 4.0. Use e57::UInt32.
-      E57_UINT32 DEPRECATED_ENUM( "Will be removed in 4.0. Use UInt32." ) = UInt32,
+      E57_UINT32 E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use UInt32." ) = UInt32,
       /// @deprecated Will be removed in 4.0. Use e57::Int64.
-      E57_INT64 DEPRECATED_ENUM( "Will be removed in 4.0. Use Int64." ) = Int64,
+      E57_INT64 E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use Int64." ) = Int64,
       /// @deprecated Will be removed in 4.0. Use e57::Bool.
-      E57_BOOL DEPRECATED_ENUM( "Will be removed in 4.0. Use Bool." ) = Bool,
+      E57_BOOL E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use Bool." ) = Bool,
       /// @deprecated Will be removed in 4.0. Use e57::Real32.
-      E57_REAL32 DEPRECATED_ENUM( "Will be removed in 4.0. Use Real32." ) = Real32,
+      E57_REAL32 E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use Real32." ) = Real32,
       /// @deprecated Will be removed in 4.0. Use e57::Real64.
-      E57_REAL64 DEPRECATED_ENUM( "Will be removed in 4.0. Use Real64." ) = Real64,
+      E57_REAL64 E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use Real64." ) = Real64,
       /// @deprecated Will be removed in 4.0. Use e57::UString.
-      E57_USTRING DEPRECATED_ENUM( "Will be removed in 4.0. Use UString." ) = UString
+      E57_USTRING E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use UString." ) = UString
    };
 
    /// @brief Default checksum policies for e57::ReadChecksumPolicy

--- a/include/E57SimpleData.h
+++ b/include/E57SimpleData.h
@@ -961,13 +961,13 @@ namespace e57
       ImageMaskPNG = 3, ///< PNG format image mask.
 
       /// @deprecated Will be removed in 4.0. Use e57::ImageNone.
-      E57_NO_IMAGE DEPRECATED_ENUM( "Will be removed in 4.0. Use ImageNone." ) = ImageNone,
+      E57_NO_IMAGE E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use ImageNone." ) = ImageNone,
       /// @deprecated Will be removed in 4.0. Use e57::ImageJPEG.
-      E57_JPEG_IMAGE DEPRECATED_ENUM( "Will be removed in 4.0. Use ImageJPEG." ) = ImageJPEG,
+      E57_JPEG_IMAGE E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use ImageJPEG." ) = ImageJPEG,
       /// @deprecated Will be removed in 4.0. Use e57::ImagePNG.
-      E57_PNG_IMAGE DEPRECATED_ENUM( "Will be removed in 4.0. Use ImagePNG." ) = ImagePNG,
+      E57_PNG_IMAGE E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use ImagePNG." ) = ImagePNG,
       /// @deprecated Will be removed in 4.0. Use e57::ImageMaskPNG.
-      E57_PNG_IMAGE_MASK DEPRECATED_ENUM( "Will be removed in 4.0. Use ImageMaskPNG." ) =
+      E57_PNG_IMAGE_MASK E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use ImageMaskPNG." ) =
          ImageMaskPNG,
    };
 
@@ -981,19 +981,19 @@ namespace e57
       ProjectionCylindrical = 4, ///< CylindricalRepresentation for the image data
 
       /// @deprecated Will be removed in 4.0. Use e57::ProjectionNone.
-      E57_NO_PROJECTION DEPRECATED_ENUM( "Will be removed in 4.0. Use ProjectionNone." ) =
+      E57_NO_PROJECTION E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use ProjectionNone." ) =
          ProjectionNone,
       /// @deprecated Will be removed in 4.0. Use e57::ProjectionVisual.
-      E57_VISUAL DEPRECATED_ENUM( "Will be removed in 4.0. Use ProjectionVisual." ) =
+      E57_VISUAL E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use ProjectionVisual." ) =
          ProjectionVisual,
       /// @deprecated Will be removed in 4.0. Use e57::ProjectionPinhole.
-      E57_PINHOLE DEPRECATED_ENUM( "Will be removed in 4.0. Use ProjectionPinhole." ) =
+      E57_PINHOLE E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use ProjectionPinhole." ) =
          ProjectionPinhole,
       /// @deprecated Will be removed in 4.0. Use e57::ProjectionSpherical.
-      E57_SPHERICAL DEPRECATED_ENUM( "Will be removed in 4.0. Use ProjectionSpherical." ) =
+      E57_SPHERICAL E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use ProjectionSpherical." ) =
          ProjectionSpherical,
       /// @deprecated Will be removed in 4.0. Use e57::ProjectionCylindrical.
-      E57_CYLINDRICAL DEPRECATED_ENUM( "Will be removed in 4.0. Use ProjectionCylindrical." ) =
+      E57_CYLINDRICAL E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use ProjectionCylindrical." ) =
          ProjectionCylindrical,
    };
 } // end namespace e57

--- a/src/BlobNode.cpp
+++ b/src/BlobNode.cpp
@@ -305,8 +305,8 @@ void BlobNode::dump( int indent, std::ostream &os ) const
 #else
 void BlobNode::dump( int indent, std::ostream &os ) const
 {
-   UNUSED( indent );
-   UNUSED( os );
+   E57_UNUSED( indent );
+   E57_UNUSED( os );
 }
 #endif
 

--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -682,7 +682,7 @@ void CheckedFile::unlink()
       std::cout << "std::remove() failed, result=" << result << std::endl;
    }
 #else
-   UNUSED( result );
+   E57_UNUSED( result );
 #endif
 }
 

--- a/src/Common.h
+++ b/src/Common.h
@@ -43,7 +43,7 @@
 #endif
 
 // Used to mark unused parameters to indicate intent and suppress warnings.
-#define UNUSED( expr ) (void)( expr )
+#define E57_UNUSED( expr ) (void)( expr )
 
 // For readability of preprocessor using E57_VALIDATION_LEVEL
 #define VALIDATION_OFF 0

--- a/src/CompressedVectorNode.cpp
+++ b/src/CompressedVectorNode.cpp
@@ -336,8 +336,8 @@ void CompressedVectorNode::dump( int indent, std::ostream &os ) const
 #else
 void CompressedVectorNode::dump( int indent, std::ostream &os ) const
 {
-   UNUSED( indent );
-   UNUSED( os );
+   E57_UNUSED( indent );
+   E57_UNUSED( os );
 }
 #endif
 

--- a/src/CompressedVectorReader.cpp
+++ b/src/CompressedVectorReader.cpp
@@ -350,7 +350,7 @@ void CompressedVectorReader::dump( int indent, std::ostream &os ) const
 #else
 void CompressedVectorReader::dump( int indent, std::ostream &os ) const
 {
-   UNUSED( indent );
-   UNUSED( os );
+   E57_UNUSED( indent );
+   E57_UNUSED( os );
 }
 #endif

--- a/src/CompressedVectorReaderImpl.cpp
+++ b/src/CompressedVectorReaderImpl.cpp
@@ -590,9 +590,9 @@ namespace e57
                                                         const char *srcFunctionName ) const
    {
       // unimplemented...
-      UNUSED( srcFileName );
-      UNUSED( srcLineNumber );
-      UNUSED( srcFunctionName );
+      E57_UNUSED( srcFileName );
+      E57_UNUSED( srcLineNumber );
+      E57_UNUSED( srcFunctionName );
    }
 
    void CompressedVectorReaderImpl::checkReaderOpen( const char *srcFileName, int srcLineNumber,

--- a/src/CompressedVectorWriter.cpp
+++ b/src/CompressedVectorWriter.cpp
@@ -327,7 +327,7 @@ void CompressedVectorWriter::dump( int indent, std::ostream &os ) const
 #else
 void CompressedVectorWriter::dump( int indent, std::ostream &os ) const
 {
-   UNUSED( indent );
-   UNUSED( os );
+   E57_UNUSED( indent );
+   E57_UNUSED( os );
 }
 #endif

--- a/src/CompressedVectorWriterImpl.cpp
+++ b/src/CompressedVectorWriterImpl.cpp
@@ -672,9 +672,9 @@ namespace e57
                                                         const char *srcFunctionName ) const
    {
       // unimplemented...
-      UNUSED( srcFileName );
-      UNUSED( srcLineNumber );
-      UNUSED( srcFunctionName );
+      E57_UNUSED( srcFileName );
+      E57_UNUSED( srcLineNumber );
+      E57_UNUSED( srcFunctionName );
    }
 
    void CompressedVectorWriterImpl::checkWriterOpen( const char *srcFileName, int srcLineNumber,

--- a/src/Decoder.cpp
+++ b/src/Decoder.cpp
@@ -876,8 +876,8 @@ size_t ConstantIntegerDecoder::inputProcess( const char *source, const size_t av
    std::cout << "ConstantIntegerDecoder::inputprocess() called, source=" << (void *)( source )
              << " availableByteCount=" << availableByteCount << std::endl;
 #else
-   UNUSED( source );
-   UNUSED( availableByteCount );
+   E57_UNUSED( source );
+   E57_UNUSED( availableByteCount );
 #endif
 
    // We don't need any input bytes to produce output, so ignore source and

--- a/src/E57XmlParser.cpp
+++ b/src/E57XmlParser.cpp
@@ -912,7 +912,7 @@ void E57XmlParser::characters( const XMLCh *const chars, const XMLSize_t length 
 #ifdef E57_VERBOSE
    std::cout << "characters, chars=\"" << toUString( chars ) << "\" length=" << length << std::endl;
 #else
-   UNUSED( length );
+   E57_UNUSED( length );
 #endif
 
    // Get active element

--- a/src/FloatNode.cpp
+++ b/src/FloatNode.cpp
@@ -307,8 +307,8 @@ void FloatNode::dump( int indent, std::ostream &os ) const
 #else
 void FloatNode::dump( int indent, std::ostream &os ) const
 {
-   UNUSED( indent );
-   UNUSED( os );
+   E57_UNUSED( indent );
+   E57_UNUSED( os );
 }
 #endif
 

--- a/src/ImageFile.cpp
+++ b/src/ImageFile.cpp
@@ -727,8 +727,8 @@ void ImageFile::dump( int indent, std::ostream &os ) const
 #else
 void ImageFile::dump( int indent, std::ostream &os ) const
 {
-   UNUSED( indent );
-   UNUSED( os );
+   E57_UNUSED( indent );
+   E57_UNUSED( os );
 }
 #endif
 

--- a/src/IntegerNode.cpp
+++ b/src/IntegerNode.cpp
@@ -56,7 +56,7 @@ judiciously, in debug versions of the application.
 */
 void IntegerNode::checkInvariant( bool doRecurse, bool doUpcast ) const
 {
-   UNUSED( doRecurse );
+   E57_UNUSED( doRecurse );
 
    // If destImageFile not open, can't test invariant (almost every call would throw)
    if ( !destImageFile().isOpen() )
@@ -269,8 +269,8 @@ void IntegerNode::dump( int indent, std::ostream &os ) const
 #else
 void IntegerNode::dump( int indent, std::ostream &os ) const
 {
-   UNUSED( indent );
-   UNUSED( os );
+   E57_UNUSED( indent );
+   E57_UNUSED( os );
 }
 #endif
 

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -560,8 +560,8 @@ void Node::dump( int indent, std::ostream &os ) const
 #else
 void Node::dump( int indent, std::ostream &os ) const
 {
-   UNUSED( indent );
-   UNUSED( os );
+   E57_UNUSED( indent );
+   E57_UNUSED( os );
 }
 #endif
 

--- a/src/Packet.cpp
+++ b/src/Packet.cpp
@@ -176,7 +176,7 @@ void PacketReadCache::unlock( unsigned cacheIndex )
 #ifdef E57_VERBOSE
    std::cout << "PacketReadCache::unlock() called, cacheIndex=" << cacheIndex << std::endl;
 #else
-   UNUSED( cacheIndex );
+   E57_UNUSED( cacheIndex );
 #endif
 
    if ( lockCount_ != 1 )
@@ -563,8 +563,8 @@ void IndexPacket::verify( unsigned bufferLength, uint64_t totalRecordCount,
                           uint64_t fileSize ) const
 {
 #if ( E57_VALIDATION_LEVEL < VALIDATION_DEEP )
-   UNUSED( totalRecordCount );
-   UNUSED( fileSize );
+   E57_UNUSED( totalRecordCount );
+   E57_UNUSED( fileSize );
 #endif
 
    //??? do all packets need versions?  how extend without breaking older

--- a/src/ScaledIntegerNode.cpp
+++ b/src/ScaledIntegerNode.cpp
@@ -428,8 +428,8 @@ void ScaledIntegerNode::dump( int indent, std::ostream &os ) const
 #else
 void ScaledIntegerNode::dump( int indent, std::ostream &os ) const
 {
-   UNUSED( indent );
-   UNUSED( os );
+   E57_UNUSED( indent );
+   E57_UNUSED( os );
 }
 #endif
 

--- a/src/SourceDestBuffer.cpp
+++ b/src/SourceDestBuffer.cpp
@@ -472,7 +472,7 @@ void SourceDestBuffer::dump( int indent, std::ostream &os ) const
 #else
 void SourceDestBuffer::dump( int indent, std::ostream &os ) const
 {
-   UNUSED( indent );
-   UNUSED( os );
+   E57_UNUSED( indent );
+   E57_UNUSED( os );
 }
 #endif

--- a/src/StringNode.cpp
+++ b/src/StringNode.cpp
@@ -197,8 +197,8 @@ void StringNode::dump( int indent, std::ostream &os ) const
 #else
 void StringNode::dump( int indent, std::ostream &os ) const
 {
-   UNUSED( indent );
-   UNUSED( os );
+   E57_UNUSED( indent );
+   E57_UNUSED( os );
 }
 #endif
 

--- a/src/StructureNode.cpp
+++ b/src/StructureNode.cpp
@@ -350,8 +350,8 @@ void StructureNode::dump( int indent, std::ostream &os ) const
 #else
 void StructureNode::dump( int indent, std::ostream &os ) const
 {
-   UNUSED( indent );
-   UNUSED( os );
+   E57_UNUSED( indent );
+   E57_UNUSED( os );
 }
 #endif
 

--- a/src/VectorNode.cpp
+++ b/src/VectorNode.cpp
@@ -378,8 +378,8 @@ void VectorNode::dump( int indent, std::ostream &os ) const
 #else
 void VectorNode::dump( int indent, std::ostream &os ) const
 {
-   UNUSED( indent );
-   UNUSED( os );
+   E57_UNUSED( indent );
+   E57_UNUSED( os );
 }
 #endif
 


### PR DESCRIPTION
These were intended for library use only, but they are in a public header, so rename to avoid potential conflict with user code.