### PR TITLE
Fix emscripten support (WebAssembly)

### DIFF
--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -43,7 +43,7 @@
 #else
 #error "no supported compiler defined"
 #endif
-#elif defined( __linux__ )
+#elif defined( __linux__ ) || defined( __EMSCRIPTEN__ )
 #define _LARGEFILE64_SOURCE
 #define __LARGE64_FILES
 #include <sys/stat.h>
@@ -53,12 +53,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 #elif defined( __BSD )
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
-#elif defined( __EMSCRIPTEN__ )
-#define _LARGEFILE64_SOURCE
-#define __LARGE64_FILES
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -56,6 +56,12 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#elif defined( __EMSCRIPTEN__ )
+#define _LARGEFILE64_SOURCE
+#define __LARGE64_FILES
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 #else
 #error "no supported OS platform defined"
 #endif
@@ -487,7 +493,7 @@ uint64_t CheckedFile::lseek64( int64_t offset, int whence )
 
 #if defined( _WIN32 )
    __int64 result = _lseeki64( fd_, offset, whence );
-#elif defined( __linux__ )
+#elif defined( __linux__ ) || defined( __EMSCRIPTEN__ )
    int64_t result = ::lseek64( fd_, offset, whence );
 #elif defined( __APPLE__ ) || defined( __BSD )
    int64_t result = ::lseek( fd_, offset, whence );


### PR DESCRIPTION
Fix emscripten support
- Tested to compile with vcpkg (using wasm32-emscripten triplet)
- Tested to work with chrome