### PR TITLE
Add allowParallel flag to allow multiple readers to be created

### DIFF
--- a/include/E57Format.h
+++ b/include/E57Format.h
@@ -485,7 +485,7 @@ public:                                                                         
 
       // Iterators
       CompressedVectorWriter writer( std::vector<SourceDestBuffer> &sbufs );
-      CompressedVectorReader reader( const std::vector<SourceDestBuffer> &dbufs );
+      CompressedVectorReader reader( const std::vector<SourceDestBuffer> &dbufs, bool allowParallel = false );
 
       // Up/Down cast conversion
       operator Node() const;

--- a/src/CompressedVectorNode.cpp
+++ b/src/CompressedVectorNode.cpp
@@ -474,7 +474,7 @@ prototype. It is not an error to create a CompressedVectorReader for an empty Co
 @see CompressedVectorReader, SourceDestBuffer, CompressedVectorNode::CompressedVectorNode,
 CompressedVectorNode::prototype
 */
-CompressedVectorReader CompressedVectorNode::reader( const std::vector<SourceDestBuffer> &dbufs )
+CompressedVectorReader CompressedVectorNode::reader( const std::vector<SourceDestBuffer> &dbufs, bool allowParallel )
 {
-   return CompressedVectorReader( impl_->reader( dbufs ) );
+   return CompressedVectorReader( impl_->reader( dbufs, allowParallel ) );
 }

--- a/src/CompressedVectorNodeImpl.cpp
+++ b/src/CompressedVectorNodeImpl.cpp
@@ -318,7 +318,8 @@ namespace e57
    }
 
    std::shared_ptr<CompressedVectorReaderImpl> CompressedVectorNodeImpl::reader(
-      std::vector<SourceDestBuffer> dbufs )
+      std::vector<SourceDestBuffer> dbufs,
+      bool allowParallel )
    {
       checkImageFileOpen( __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) );
 
@@ -332,7 +333,7 @@ namespace e57
                                   " writerCount=" + toString( destImageFile->writerCount() ) +
                                   " readerCount=" + toString( destImageFile->readerCount() ) );
       }
-      if ( destImageFile->readerCount() > 0 )
+      if ( !allowParallel && destImageFile->readerCount() > 0 )
       {
          throw E57_EXCEPTION2( ErrorTooManyReaders,
                                "fileName=" + destImageFile->fileName() +

--- a/src/CompressedVectorNodeImpl.h
+++ b/src/CompressedVectorNodeImpl.h
@@ -59,7 +59,7 @@ namespace e57
 
       /// Iterator constructors
       std::shared_ptr<CompressedVectorWriterImpl> writer( std::vector<SourceDestBuffer> sbufs );
-      std::shared_ptr<CompressedVectorReaderImpl> reader( std::vector<SourceDestBuffer> dbufs );
+      std::shared_ptr<CompressedVectorReaderImpl> reader( std::vector<SourceDestBuffer> dbufs, bool allowParallel );
 
       int64_t getRecordCount() const
       {


### PR DESCRIPTION
Handy for multithreaded work, we also use it in an extension of `pye57`:

https://github.com/davidcaron/pye57/commit/7d2dd716b5574063559e1fc7d355355ed68f38a4

CC @chpatrick 