### PR TITLE
{standard} Always write a CV index packet

### DIFF
--- a/src/CompressedVectorWriterImpl.h
+++ b/src/CompressedVectorWriterImpl.h
@@ -58,6 +58,7 @@ namespace e57
       size_t currentPacketSize() const;
       uint64_t packetWrite();
       void packetWriteZeroRecords();
+      void packetWriteIndex();
 
       void flush();
 


### PR DESCRIPTION
This is required by the standard.

9.3.5: "A CompressedVector shall contain at least one index packet and at least one data packet."

To satisfy this requirement, we write one index packet containing one entry which points to the first data packet.