### PR TITLE
Remove #pragmas around CRCpp include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 
+- Update CRCpp to fix MSVC and MinGW warnings. ([#302](https://github.com/asmaloney/libE57Format/pull/302))
 - Fix warnings about redefinition of `_LARGEFILE64_SOURCE` and `__LARGE64_FILES` ([#301](https://github.com/asmaloney/libE57Format/pull/301)) (Thanks Niklas!)
 - Fix building with emscripten. (Note that the project doesn't officially support emscripten.) ([#288](https://github.com/asmaloney/libE57Format/pull/288))
 - {standard conformance} CompressedVectors always write an index packet. This is required by the standard (9.3.5). ([#295](https://github.com/asmaloney/libE57Format/pull/295))

--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -73,18 +73,7 @@
 #include <cstring>
 #include <fcntl.h>
 
-// This is fixed in a newer version of CRCpp.
-//    https://github.com/d-bahr/CRCpp/issues/17
-// TODO: Remove when new CRCpp is released.
-#if defined( _MSC_VER )
-// Disable warning about "conditional expression is constant".
-#pragma warning( push )
-#pragma warning( disable : 4127 )
-#endif
 #include "CRC.h"
-#if defined( _MSC_VER )
-#pragma warning( pop )
-#endif
 
 #include "CheckedFile.h"
 #include "StringFunctions.h"


### PR DESCRIPTION
Now that the CRCpp code itself is fixed, these are no longer required.