### PR TITLE
Make the default value of E57_RELEASE_LTO dependent on E57_BUILD_SHARED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,13 @@ option( E57_WRITE_CRAZY_PACKET_MODE "Compile library to enable reader-stressing 
 # CMake forces "thin" LTO (see https://gitlab.kitware.com/cmake/cmake/-/issues/23136)
 # which is a problem if compiling statically for distribution (e.g. in a package manager).
 # Generally you will only want to turn this off for distributing static release builds.
-option( E57_RELEASE_LTO "Compile release library with link-time optimization" ON )
+option( E57_RELEASE_LTO "Compile release library with link-time optimization" ${E57_BUILD_SHARED} )
+
+if ( E57_RELEASE_LTO AND NOT E57_BUILD_SHARED )
+    message( WARNING "E57_RELEASE_LTO is set to ON, but ${PROJECT_NAME} will be build as static library. This may lead to linker issues!" )
+elseif ( NOT E57_RELEASE_LTO AND E57_BUILD_SHARED )
+	message( WARNING "E57_RELEASE_LTO is set to OFF, but ${PROJECT_NAME} will be build as dynamic library. This may lead issues if compiling statically for distribution!" )
+endif()
 
 #########################################################################################
 


### PR DESCRIPTION
By default [`BUILD_SHARED_LIBS`](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html) is not defined, therefore the default of `E57_BUILD_SHARED` is also `OFF`. Therefore this lib will be build as static library by default. This leads by default to linker issues later:

```
/usr/bin/ld: /home/sunblack/dev/dependencies/libE57Format/lib/libE57Format.a(BlobNode.cpp.o): plugin needed to handle lto object
```

As the comment about `E57_RELEASE_LTO` says, this option should be OFF when building a static library. Therefore the default value is now adjusted accordingly. As changing `E57_BUILD_SHARED` later will not change the default value of `E57_RELEASE_LTO` I have added a warning so that there is a hint that the combination may cause issues.

GDAL has IPO disabled by default:
https://github.com/OSGeo/gdal/blob/305b23f5a90bf6d86c7fb895dfc745321def0aab/gdal.cmake#L27

Qt seems to also [not set this value](https://github.com/search?q=repo%3Aqt%2Fqtbase%20INTERPROCEDURAL_OPTIMIZATION&type=code), but in case `CMAKE_INTERPROCEDURAL_OPTIMIZATION` is set they enforce it to `OFF` for MSVC 3rd party:
https://github.com/qt/qtbase/blob/dev/cmake/Qt3rdPartyLibraryHelpers.cmake#L334-L338
Reason see [here](https://github.com/qt/qtbase/commit/0d708a9aad8fa7f44e94f5bc9093a6c93d6140b).

So basically I would argue that `E57_RELEASE_LTO` should be always `OFF` or removed and in case someone needs this, he can build it by passing `CMAKE_INTERPROCEDURAL_OPTIMIZATION` (in case canon has an issue with it, they can add it to their build script as it seems it was not necessary for vcpkg when checking the port scripts from before libE57Format 3.1.0 release)
