### PR TITLE
{cmake} Added missing include for GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,7 @@ if ( E57_BUILD_TEST )
 endif()
 
 # CMake package files
+include( GNUInstallDirs )
 set( E57_INSTALL_CMAKEDIR
     "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
      CACHE STRING


### PR DESCRIPTION
The definition of `E57_INSTALL_CMAKEDIR` uses `CMAKE_INSTALL_LIBDIR` which is set by the `GNUInstallDirs` module. This module however is not directly included. It is included from `googletest`, and therefore made transitively available if tests are enabled. If tests are disabled, the module is never loaded, and so `CMAKE_INSTALL_LIBDIR` is never defined, which leads to an unexpected expansion.
This PR fixes #314 by including the module before using the variable.