### PR TITLE
Export version for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,9 +254,17 @@ install(
         "${E57_INSTALL_CMAKEDIR}"
 )
 
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file (
+    e57format-config-version.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
 install(
     FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/cmake/e57format-config.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/e57format-config-version.cmake
     DESTINATION
         "${E57_INSTALL_CMAKEDIR}"
 )


### PR DESCRIPTION
This allows requesting a minimum version.

E.g. when you have in your CMake:
```cmake
find_package(E57Format 3.2.1 CONFIG REQUIRED)
```

And you have build this lib with this PR but the version number is still 3.2.0, you are getting
```
CMake Error at CMakeLists.txt:5 (find_package):
  Could not find a configuration file for package "E57Format" that is
  compatible with requested version "3.2.1".

  The following configuration files were considered but not accepted:

    .../lib/cmake/E57Format/e57format-config.cmake, version: 3.2.0
```

As there is a note that the changes to the legacy enums (which were changed in 2.x => 3.x) will only be removed with 4.x, I assume that `SameMajorVersion` is the best choice. For details see [documentation](https://cmake.org/cmake/help/v3.15/module/CMakePackageConfigHelpers.html#generating-a-package-version-file) (and example below)