### PR TITLE
Make Windows CI working again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,7 @@ jobs:
         shell: bash -el {0}
         run: |
           conda install conda-forge::xerces-c
+          echo "CMAKE_PREFIX_PATH=${CONDA_PREFIX}/Library" >> "$GITHUB_ENV"
           choco upgrade ccache ninja
           ccache --version | head -n 1
           echo "ninja $(ninja --version)"


### PR DESCRIPTION
Hi,

Having env variable **CMAKE_PREFIX_PATH** pointing to **${CONDA_PREFIX}/Library** (_windows platform only_) solves the issue.

**PS**: CI doesn't work for MacOS on my repository, due to multiple :
```
error: empty paragraph passed to '@throw' command [-Werror,-Wdocumentation]
  129 | @throw ::ErrorBadAPIArgument
```

