### PR TITLE
Splits the ErrorBadPathName exception into three separate exceptions (empty, malformed, & extension not registered)

### DIFF
--- a/include/E57Exception.h
+++ b/include/E57Exception.h
@@ -114,7 +114,10 @@ namespace e57
       /// conversion required to assign element value, but not requested
       ErrorConversionRequired = 36,
 
-      ErrorBadPathName = 37,            ///< E57 path name is not well formed
+      /// @deprecated Will be removed in 4.0. Use e57::ErrorPathNameEmpty,
+      /// e57::ErrorPathNameMalformed, or e57::ErrorPathNameExtensionNotRegistered.
+      ErrorBadPathName = 37, ///< E57 path name is not well formed
+
       ErrorNotImplemented = 38,         ///< functionality not implemented
       ErrorBadNodeDowncast = 39,        ///< bad downcast from Node to specific node type
       ErrorWriterNotOpen = 40,          ///< CompressedVectorWriter is no longer open
@@ -141,6 +144,11 @@ namespace e57
       /// Older versions of this library (and E57RefImpl) incorrectly set the "fileOffset" to 0
       /// when "recordCount" is 0. "fileOffset" must be greater than 0 (Table 9 in the standard).
       ErrorData3DReadInvalidZeroRecords = 53,
+
+      // These refine ErrorBadPathName
+      ErrorPathNameEmpty,                  ///< E57 path name is empty
+      ErrorPathNameMalformed,              ///< E57 path name is not well formed
+      ErrorPathNameExtensionNotRegistered, ///< E57 path name uses an unregistered extension
 
       /// @deprecated Will be removed in 4.0. Use e57::Success.
       E57_SUCCESS E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use Success." ) = Success,
@@ -257,7 +265,8 @@ namespace e57
          "Will be removed in 4.0. Use ErrorConversionRequired." ) = ErrorConversionRequired,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadPathName.
       E57_ERROR_BAD_PATH_NAME E57_DEPRECATED_ENUM(
-         "Will be removed in 4.0. Use ErrorBadPathName." ) = ErrorBadPathName,
+         "Will be removed in 4.0. Use ErrorPathNameEmpty, ErrorPathNameMalformed, or "
+         "ErrorPathNameExtensionNotRegistered." ) = ErrorBadPathName,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorNotImplemented.
       E57_ERROR_NOT_IMPLEMENTED E57_DEPRECATED_ENUM(
          "Will be removed in 4.0. Use ErrorNotImplemented." ) = ErrorNotImplemented,

--- a/src/E57Exception.cpp
+++ b/src/E57Exception.cpp
@@ -362,6 +362,14 @@ namespace e57
             return "trying to read an invalid Data3D with zero records - check for zero records "
                    "before trying to read this Data3D section (ErrorInvalidZeroRecordsData3D)";
 
+         case ErrorPathNameEmpty:
+            return "E57 path name is empty (ErrorPathNameEmpty)";
+         case ErrorPathNameMalformed:
+            return "E57 path name is not well formed (ErrorPathNameMalformed)";
+         case ErrorPathNameExtensionNotRegistered:
+            return "E57 path name uses an unregistered extension "
+                   "(ErrorPathNameExtensionNotRegistered)";
+
          default:
             return "unknown error (" + std::to_string( ecode ) + ")";
       }

--- a/src/ImageFile.cpp
+++ b/src/ImageFile.cpp
@@ -704,7 +704,8 @@ prefixed form, the prefix does not have to be declared in the ImageFile.
 
 @post No visible state is modified.
 
-@throw ::ErrorBadPathName (n/c)
+@throw ::ErrorPathNameEmpty (n/c)
+@throw ::ErrorPathNameMalformed (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ImageFile::isElementNameExtended

--- a/src/ImageFileImpl.cpp
+++ b/src/ImageFileImpl.cpp
@@ -564,7 +564,7 @@ namespace e57
 
       if ( prefix.length() > 0 && !extensionsLookupPrefix( prefix, uri ) )
       {
-         throw E57_EXCEPTION2( ErrorBadPathName,
+         throw E57_EXCEPTION2( ErrorPathNameExtensionNotRegistered,
                                "elementName=" + elementName + " prefix=" + prefix );
       }
    }
@@ -620,10 +620,10 @@ namespace e57
 
          if ( !isElementNameLegal( elementName ) )
          {
-            throw E57_EXCEPTION2( ErrorBadPathName, std::string( "pathName=" )
-                                                       .append( pathName )
-                                                       .append( " elementName=" )
-                                                       .append( elementName ) );
+            throw E57_EXCEPTION2( ErrorPathNameMalformed, std::string( "pathName=" )
+                                                             .append( pathName )
+                                                             .append( " elementName=" )
+                                                             .append( elementName ) );
          }
 
          // Add to list
@@ -648,7 +648,7 @@ namespace e57
       // Empty relative path is not allowed
       if ( isRelative && fields.empty() )
       {
-         throw E57_EXCEPTION2( ErrorBadPathName, "pathName=" + pathName );
+         throw E57_EXCEPTION1( ErrorPathNameEmpty );
       }
 
 #ifdef E57_VERBOSE
@@ -712,7 +712,7 @@ namespace e57
       // Empty name is bad
       if ( len == 0 )
       {
-         throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName );
+         throw E57_EXCEPTION1( ErrorPathNameEmpty );
       }
 
       unsigned char c = elementName[0];
@@ -727,7 +727,7 @@ namespace e57
 
             if ( c < '0' || c > '9' )
             {
-               throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName );
+               throw E57_EXCEPTION2( ErrorPathNameMalformed, "elementName=" + elementName );
             }
          }
 
@@ -739,7 +739,7 @@ namespace e57
       // Don't allow ':' as first char.
       if ( c < 128 && !( ( 'a' <= c && c <= 'z' ) || ( 'A' <= c && c <= 'Z' ) || c == '_' ) )
       {
-         throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName );
+         throw E57_EXCEPTION2( ErrorPathNameMalformed, "elementName=" + elementName );
       }
 
       // If each following char is ASCII (<128), check for legality
@@ -751,7 +751,7 @@ namespace e57
          if ( c < 128 && !( ( 'a' <= c && c <= 'z' ) || ( 'A' <= c && c <= 'Z' ) || c == '_' ||
                             c == ':' || ( '0' <= c && c <= '9' ) || c == '-' || c == '.' ) )
          {
-            throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName );
+            throw E57_EXCEPTION2( ErrorPathNameMalformed, "elementName=" + elementName );
          }
       }
 
@@ -763,7 +763,7 @@ namespace e57
          // Check doesn't have two colons
          if ( elementName.find_first_of( ':', found + 1 ) != std::string::npos )
          {
-            throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName );
+            throw E57_EXCEPTION2( ErrorPathNameMalformed, "elementName=" + elementName );
          }
 
          // Split element name at the colon
@@ -773,8 +773,9 @@ namespace e57
 
          if ( prefix.length() == 0 || localPart.length() == 0 )
          {
-            throw E57_EXCEPTION2( ErrorBadPathName, "elementName=" + elementName + " prefix=" +
-                                                       prefix + " localPart=" + localPart );
+            throw E57_EXCEPTION2( ErrorPathNameMalformed, "elementName=" + elementName +
+                                                             " prefix=" + prefix +
+                                                             " localPart=" + localPart );
          }
       }
       else

--- a/src/NodeImpl.cpp
+++ b/src/NodeImpl.cpp
@@ -273,9 +273,9 @@ void NodeImpl::set( const ustring &pathName, NodeImplSharedPtr ni, bool autoPath
 void NodeImpl::set( const StringList & /*fields*/, unsigned /*level*/, NodeImplSharedPtr /*ni*/,
                     bool /*autoPathCreate*/ )
 {
-   // If get here, then tried to call set(fields...) on NodeImpl that wasn't a  StructureNodeImpl,
+   // If get here, then tried to call set(fields...) on NodeImpl that wasn't a StructureNodeImpl,
    // so that's an error
-   throw E57_EXCEPTION1( ErrorBadPathName ); //???
+   throw E57_EXCEPTION2( ErrorInternal, "Trying to set a path name on a non-structured node" );
 }
 
 void NodeImpl::checkBuffers( const std::vector<SourceDestBuffer> &sdbufs,
@@ -407,7 +407,7 @@ bool NodeImpl::_verifyPathNameAbsolute( const ustring &inPathName )
    // If not an absolute path name, have error
    if ( isRelative )
    {
-      throw E57_EXCEPTION2( ErrorBadPathName,
+      throw E57_EXCEPTION2( ErrorPathNameMalformed,
                             "this->pathName=" + this->pathName() + " pathName=" + inPathName );
    }
 

--- a/src/SourceDestBuffer.cpp
+++ b/src/SourceDestBuffer.cpp
@@ -149,8 +149,8 @@ transfer with a CompressedVectorNode.
 @pre The @a destImageFile must be open (i.e. destImageFile.isOpen() must be true).
 @pre The stride must be >= sizeof(*b)
 
-@throw ::ErrorBadAPIArgument (n/c)
-@throw ::ErrorBadPathName (n/c)
+@throw ::ErrorPathNameEmpty (n/c)
+@throw ::ErrorPathNameMalformed (n/c)
 @throw ::ErrorBadBuffer (n/c)
 @throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
@@ -287,8 +287,8 @@ destroyed).
 @pre b.size() must be > 0.
 @pre The @a destImageFile must be open (i.e. destImageFile.isOpen() must be true).
 
-@throw ::ErrorBadAPIArgument (n/c)
-@throw ::ErrorBadPathName (n/c)
+@throw ::ErrorPathNameEmpty (n/c)
+@throw ::ErrorPathNameMalformed (n/c)
 @throw ::ErrorBadBuffer (n/c)
 @throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state

--- a/src/StructureNode.cpp
+++ b/src/StructureNode.cpp
@@ -225,7 +225,9 @@ is not attached to an ImageFile, the @a pathName origin root will not the root n
 
 @return true if pathName is currently defined.
 
-@throw ::ErrorBadPathName (n/c)
+@throw ::ErrorPathNameEmpty (n/c)
+@throw ::ErrorPathNameMalformed (n/c)
+@throw ::ErrorPathNameExtensionNotRegistered (n/c)
 @throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
@@ -278,7 +280,9 @@ an ImageFile.
 
 @return A smart Node handle referencing the child node.
 
-@throw ::ErrorBadPathName (n/c)
+@throw ::ErrorPathNameEmpty (n/c)
+@throw ::ErrorPathNameMalformed (n/c)
+@throw ::ErrorPathNameExtensionNotRegistered (n/c)
 @throw ::ErrorPathUndefined (n/c)
 @throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
@@ -322,7 +326,9 @@ destImageFile() == n.destImageFile()).
 @post The @a pathName will be defined (i.e. isDefined(pathName)).
 
 @throw ::ErrorImageFileNotOpen (n/c)
-@throw ::ErrorBadPathName (n/c)
+@throw ::ErrorPathNameEmpty (n/c)
+@throw ::ErrorPathNameMalformed (n/c)
+@throw ::ErrorPathNameExtensionNotRegistered (n/c)
 @throw ::ErrorPathUndefined (n/c)
 @throw ::ErrorSetTwice (n/c)
 @throw ::ErrorAlreadyHasParent (n/c)

--- a/src/VectorNode.cpp
+++ b/src/VectorNode.cpp
@@ -268,7 +268,9 @@ The element names of child elements of VectorNodes are numbers, encoded as strin
 
 @return true if pathName is currently defined.
 
-@throw ::ErrorBadPathName (n/c)
+@throw ::ErrorPathNameEmpty (n/c)
+@throw ::ErrorPathNameMalformed (n/c)
+@throw ::ErrorPathNameExtensionNotRegistered (n/c)
 @throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
@@ -319,7 +321,9 @@ The element names of child elements of VectorNodes are numbers, encoded as strin
 
 @return A smart Node handle referencing the child node.
 
-@throw ::ErrorBadPathName (n/c)
+@throw ::ErrorPathNameEmpty (n/c)
+@throw ::ErrorPathNameMalformed (n/c)
+@throw ::ErrorPathNameExtensionNotRegistered (n/c)
 @throw ::ErrorPathUndefined (n/c)
 @throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state


### PR DESCRIPTION
This level of detail would have helped make what happened in https://github.com/asmaloney/libE57Format/issues/330 obvious.

Deprecates _ErrorBadPathName_ in favour of _ErrorPathNameEmpty_, _ErrorPathNameMalformed_, and _ErrorPathNameExtensionNotRegistered_.

Note that _ErrorPathUndefined_ is another case that can happen (valid path, not defined).