### PR TITLE
Don't throw an exception in StructureNode::isDefined() when checking an extension field, even if extension is unregistered

### DIFF
--- a/src/ImageFileImpl.cpp
+++ b/src/ImageFileImpl.cpp
@@ -506,28 +506,6 @@ namespace e57
       return ( prefix.length() > 0 );
    }
 
-   bool ImageFileImpl::isElementNameLegal( const ustring &elementName, bool allowNumber )
-   {
-#ifdef E57_VERBOSE
-      // cout << "isElementNameLegal elementName=""" << elementName << """" <<
-      // std::endl;
-#endif
-      try
-      {
-         checkImageFileOpen( __FILE__, __LINE__, static_cast<const char *>( __FUNCTION__ ) );
-
-         // Throws if elementName bad
-         checkElementNameLegal( elementName, allowNumber );
-      }
-      catch ( E57Exception & /*ex*/ )
-      {
-         return false;
-      }
-
-      // If get here, the name was good
-      return true;
-   }
-
    bool ImageFileImpl::isPathNameLegal( const ustring &pathName )
    {
 #ifdef E57_VERBOSE
@@ -549,7 +527,7 @@ namespace e57
       return true;
    }
 
-   void ImageFileImpl::checkElementNameLegal( const ustring &elementName, bool allowNumber )
+   void ImageFileImpl::checkElementNameLegal( const ustring &elementName )
    {
       // no checkImageFileOpen(__FILE__, __LINE__, __FUNCTION__)
 
@@ -557,7 +535,7 @@ namespace e57
       ustring localPart;
 
       // Throws if bad elementName
-      elementNameParse( elementName, prefix, localPart, allowNumber );
+      elementNameParse( elementName, prefix, localPart, true );
 
       // If has prefix, it must be registered
       ustring uri;
@@ -618,13 +596,7 @@ namespace e57
          // Get element name from in between '/', check valid
          ustring elementName = pathName.substr( start, slash - start );
 
-         if ( !isElementNameLegal( elementName ) )
-         {
-            throw E57_EXCEPTION2( ErrorPathNameMalformed, std::string( "pathName=" )
-                                                             .append( pathName )
-                                                             .append( " elementName=" )
-                                                             .append( elementName ) );
-         }
+         checkElementNameLegal( elementName ); // throws if elementName bad
 
          // Add to list
          fields.push_back( elementName );

--- a/src/ImageFileImpl.h
+++ b/src/ImageFileImpl.h
@@ -70,9 +70,8 @@ namespace e57
 
       /// Utility functions:
       bool isElementNameExtended( const ustring &elementName );
-      bool isElementNameLegal( const ustring &elementName, bool allowNumber = true );
       bool isPathNameLegal( const ustring &pathName );
-      void checkElementNameLegal( const ustring &elementName, bool allowNumber = true );
+      void checkElementNameLegal( const ustring &elementName );
 
       void pathNameCheckWellFormed( const ustring &pathName );
       void pathNameParse( const ustring &pathName, bool &isRelative, StringList &fields );

--- a/src/StructureNode.cpp
+++ b/src/StructureNode.cpp
@@ -226,7 +226,6 @@ absolute path name is the root of the tree that contains this StructureNode.
 
 @throw ::ErrorPathNameEmpty (n/c)
 @throw ::ErrorPathNameMalformed (n/c)
-@throw ::ErrorPathNameExtensionNotRegistered (n/c)
 @throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
@@ -234,7 +233,23 @@ absolute path name is the root of the tree that contains this StructureNode.
 */
 bool StructureNode::isDefined( const ustring &pathName ) const
 {
-   return impl_->isDefined( pathName );
+   try
+   {
+      bool defined = impl_->isDefined( pathName );
+
+      return defined;
+   }
+   catch ( const e57::E57Exception &e )
+   {
+      // Explicitly ignore the exception caused by requesting an extension field (e.g.
+      // "nor:normalX") when the extension is not yet registered.
+      if ( e.errorCode() == ErrorPathNameExtensionNotRegistered )
+      {
+         return false;
+      }
+
+      throw( e );
+   }
 }
 
 /*!

--- a/src/VectorNode.cpp
+++ b/src/VectorNode.cpp
@@ -269,7 +269,6 @@ The element names of child elements of VectorNodes are numbers, encoded as strin
 
 @throw ::ErrorPathNameEmpty (n/c)
 @throw ::ErrorPathNameMalformed (n/c)
-@throw ::ErrorPathNameExtensionNotRegistered (n/c)
 @throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
@@ -277,7 +276,23 @@ The element names of child elements of VectorNodes are numbers, encoded as strin
 */
 bool VectorNode::isDefined( const ustring &pathName ) const
 {
-   return impl_->isDefined( pathName );
+   try
+   {
+      bool defined = impl_->isDefined( pathName );
+
+      return defined;
+   }
+   catch ( const e57::E57Exception &e )
+   {
+      // Explicitly ignore the exception caused by requesting an extension field (e.g.
+      // "nor:normalX") when the extension is not yet registered.
+      if ( e.errorCode() == ErrorPathNameExtensionNotRegistered )
+      {
+         return false;
+      }
+
+      throw( e );
+   }
 }
 
 /*!

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources( ${PROJECT_NAME}
         main.cpp
         RandomNum.cpp
         TestData.cpp
+        test_ImageFile.cpp
         test_SimpleData.cpp
         test_SimpleReader.cpp
         test_SimpleWriter.cpp

--- a/test/src/test_ImageFile.cpp
+++ b/test/src/test_ImageFile.cpp
@@ -1,0 +1,111 @@
+// libE57Format testing Copyright © 2025 Andy Maloney <asmaloney@gmail.com>
+// SPDX-License-Identifier: BSL-1.0
+
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "E57Format.h"
+
+#include "Helpers.h"
+#include "TestData.h"
+
+namespace
+{
+   // Checks that Data3D exists and is the correct type
+   // outVectorNode contains the data3D vector node if successful
+   void CheckData3DExists( const e57::StructureNode &inRootNode, e57::VectorNode &outVectorNode )
+   {
+      SCOPED_TRACE( __func__ );
+
+      ASSERT_TRUE( inRootNode.isDefined( "data3D" ) ) << "root should contain 'data3D'";
+
+      e57::Node data3DNode = inRootNode.get( "data3D" );
+      ASSERT_EQ( data3DNode.type(), e57::TypeVector ) << "'data3D' should be a VectorNode";
+
+      outVectorNode = static_cast<e57::VectorNode>( data3DNode );
+   }
+
+   // Checks that at least one scan exists
+   // outScan0 contains the first scan if successful
+   void CheckDataFirstScan( const e57::VectorNode &inData3DNode, e57::StructureNode &outScan0 )
+   {
+      SCOPED_TRACE( __func__ );
+
+      ASSERT_GT( inData3DNode.childCount(), 0 ) << "'data3D' vector should not be empty";
+
+      e57::Node scanNode = inData3DNode.get( 0 );
+      ASSERT_EQ( scanNode.type(), e57::TypeStructure ) << "data3D[0] should be a StructureNode";
+
+      outScan0 = static_cast<e57::StructureNode>( scanNode );
+
+      ASSERT_TRUE( outScan0.isDefined( "points" ) ) << "Scan 0 should have 'points' defined";
+   }
+
+   // Checks that the scan's point structure has the correct types
+   // outPrototype contains the scan's point prototype structure
+   void CheckScanPoints( const e57::StructureNode &inScanNode, e57::StructureNode &outPrototype )
+   {
+      SCOPED_TRACE( __func__ );
+
+      e57::Node pointsNode = inScanNode.get( "points" );
+      ASSERT_EQ( pointsNode.type(), e57::TypeCompressedVector )
+         << "'points' should be a CompressedVectorNode";
+
+      e57::CompressedVectorNode points = static_cast<e57::CompressedVectorNode>( pointsNode );
+
+      e57::Node prototypeNode = points.prototype();
+      ASSERT_EQ( prototypeNode.type(), e57::TypeStructure )
+         << "Prototype should be a StructureNode";
+
+      outPrototype = static_cast<e57::StructureNode>( prototypeNode );
+   }
+}
+
+// Checks StructureNode::isDefined() return values & exception handling
+// See: https://github.com/asmaloney/libE57Format/issues/330
+TEST( ImageFile, StructureNodeIsDefined )
+{
+   std::unique_ptr<e57::ImageFile> imf;
+
+   const std::string cFileName = TestData::Path() + "/reference/bunnyDouble.e57";
+   E57_ASSERT_NO_THROW( imf = std::make_unique<e57::ImageFile>( cFileName, "r" ) );
+   ASSERT_TRUE( imf->isOpen() ) << "Failed to open: " << cFileName;
+
+   e57::VectorNode data3D( *imf );
+
+   bool defined = false;
+
+   // 1. Check that a request before we have done anything with the ImageFile returns false
+   SCOPED_TRACE( "(1)" );
+   defined = data3D.isDefined( "/foo/bar" );
+   EXPECT_FALSE( defined );
+
+   e57::StructureNode root = imf->root();
+   e57::StructureNode scan0( *imf );
+   e57::StructureNode prototype( *imf );
+
+   SCOPED_TRACE( "(setup)" );
+   CheckData3DExists( root, data3D );
+   CheckDataFirstScan( data3D, scan0 );
+   CheckScanPoints( scan0, prototype );
+
+   // 2. Check that a request for a non-existent path returns false
+   SCOPED_TRACE( "(2)" );
+   defined = data3D.isDefined( "/foo/blat" );
+   EXPECT_FALSE( defined );
+
+   // 3. Check that a request for a non-existent path using an extension does not throw & returns
+   // false
+   SCOPED_TRACE( "(3)" );
+   E57_ASSERT_NO_THROW( defined = prototype.isDefined( "nor:normalX" ) );
+   EXPECT_FALSE( defined );
+
+   // 4. Check that an empty path throws an exception
+   SCOPED_TRACE( "(4)" );
+   E57_ASSERT_THROW( defined = prototype.isDefined( "" ) );
+
+   // 5. Check that a malformed path throws an exception
+   SCOPED_TRACE( "(5)" );
+   E57_ASSERT_THROW( defined = prototype.isDefined( "a:b:c:d" ) );
+}


### PR DESCRIPTION
Before this change:

• isDefined( "foo" ) returns true OR false
• isDefined( "nor:normalX" ) returns true OR false (if the extension is registered) OR causes an exception (if the extension is unregistered)

This is counterintuitive, so get rid of the exception case and just return false even if the extension is unregistered.

Fixes #330