### PR TITLE
Allow external GTest to be used

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -87,7 +87,7 @@ else()
 endif()
 
 # GoogleTest from here: https://github.com/google/googletest
-if ( USE_EXTERNAL_GTEST )
+if ( USE_PACKAGED_GTEST )
  find_package( GTest REQUIRED)
 else()
     if ( NOT TARGET GTest::gtest AND NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/extern/googletest/CMakeLists.txt" )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -87,38 +87,37 @@ else()
 endif()
 
 # GoogleTest from here: https://github.com/google/googletest
+if ( USE_EXTERNAL_GTEST )
+ find_package( GTest REQUIRED)
+else()
+    if ( NOT TARGET GTest::gtest AND NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/extern/googletest/CMakeLists.txt" )
+        message( FATAL_ERROR "[E57 Test] The GoogleTest submodule was not downloaded. E57_GIT_SUBMODULE_UPDATE was turned off or failed. Please update submodules and try again." )
+    endif()
 
-if ( NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/extern/googletest/CMakeLists.txt" )
-    message( FATAL_ERROR "[E57 Test] The GoogleTest submodule was not downloaded. E57_GIT_SUBMODULE_UPDATE was turned off or failed. Please update submodules and try again." )
+    set( BUILD_GMOCK OFF CACHE BOOL "" FORCE )
+    set( INSTALL_GTEST OFF CACHE BOOL "" FORCE )
+
+    if ( MSVC )
+        # Prevent overriding the parent project's compiler/linker settings on Windows
+        set( gtest_force_shared_crt ON CACHE BOOL "" FORCE )
+    endif()
+
+    add_subdirectory( extern/googletest )
+
+    set_target_properties( gtest_main
+	    PROPERTIES
+	        EXPORT_COMPILE_COMMANDS ON
+    )
+
+    enable_all_sanitizers( gtest_main )
+
+    unset( BUILD_GMOCK CACHE )
+    unset( GTEST_HAS_ABSL CACHE )
+    unset( INSTALL_GTEST CACHE )
+
 endif()
-
-set( BUILD_GMOCK OFF CACHE BOOL "" FORCE )
-set( INSTALL_GTEST OFF CACHE BOOL "" FORCE )
-
-if ( MSVC )
-    # Prevent overriding the parent project's compiler/linker settings on Windows
-    set( gtest_force_shared_crt ON CACHE BOOL "" FORCE )
-endif()
-
-add_subdirectory( extern/googletest )
-
-set_target_properties( gtest_main
-	PROPERTIES
-	    EXPORT_COMPILE_COMMANDS ON
-)
-
-enable_all_sanitizers( gtest_main )
-
-unset( BUILD_GMOCK CACHE )
-unset( GTEST_HAS_ABSL CACHE )
-unset( INSTALL_GTEST CACHE )
-
-target_include_directories( testE57
-    PRIVATE
-        "${gtest_SOURCE_DIR}/include"
-)
 
 target_link_libraries( testE57
     PRIVATE
-        gtest_main
+        GTest::gtest
 )


### PR DESCRIPTION
## Type

- [x] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation/formatting

## Summary

This allows to use a packaged version of gtest, which is e.g important for distributions (e.g) Debian.

The gtest submodule already defines CMake targets (GTest::gtest), so it is sufficient to declare target_link_libaries with that target, and it will automatically pick up the include dir as well.

## Rationale

This is to make it easier to package for Debian - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1132004

## Checklist

- [x] The included code and/or docs were written by a human
