### PR TITLE
FTBFS on 32 bit archs - missing include on "limits"

### DIFF
--- a/src/ReaderImpl.cpp
+++ b/src/ReaderImpl.cpp
@@ -30,6 +30,8 @@
 #include "Common.h"
 #include "StringFunctions.h"
 
+#include <limits>
+
 namespace e57
 {
    /*!

--- a/src/ReaderImpl.cpp
+++ b/src/ReaderImpl.cpp
@@ -26,11 +26,11 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+#include <limits>
+
 #include "ReaderImpl.h"
 #include "Common.h"
 #include "StringFunctions.h"
-
-#include <limits>
 
 namespace e57
 {


### PR DESCRIPTION
## Type

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation/formatting

## Summary

This is a fix for an compilation issue on i386 and likely also other 32bit archs.
Example build log showing the issue:
https://salsa.debian.org/debian/libe57format/-/jobs/9322389#L1166

## Checklist

- [x] The included code and/or docs were written by a human
