### PR TITLE
clang-format wants the main include on a separate line

### DIFF
--- a/src/ReaderImpl.cpp
+++ b/src/ReaderImpl.cpp
@@ -29,6 +29,7 @@
 #include <limits>
 
 #include "ReaderImpl.h"
+
 #include "Common.h"
 #include "StringFunctions.h"
 


### PR DESCRIPTION
Worked locally, but GitHub CI wasn't happy.