### PR TITLE
FreeCAD can use libE57Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ This _Simple API_ has evolved since this original port to fix some problems and 
 - [CloudCompare](https://github.com/CloudCompare/CloudCompare)
 - [MeshLab](https://github.com/cnr-isti-vclab/meshlab)
 - [pye57](https://github.com/davidcaron/pye57)
+- [FreeCAD](https://github.com/FreeCAD/FreeCAD)
 
 These projects use hard forks of libE57Format:
 
-- [FreeCAD](https://github.com/FreeCAD/FreeCAD)
 - [MicMac](https://github.com/micmacIGN/micmac)
 - [PDAL](https://github.com/PDAL/PDAL)
 


### PR DESCRIPTION
## Type

- [ ] New feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation/formatting

## Summary

FreeCAD can use either its own bundled version of libE57Format or this particular library.

## Rationale

https://github.com/FreeCAD/FreeCAD/blob/main/cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake#L13

## Additional Notes

(Any additional information or context relevant to this PR.)

## Checklist

- [x] The included code and/or docs were written by a human
- [ ] If including code changes, clang-format was run on the code
