### PR TITLE
{cmake} Allow external CRCpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,8 @@ if ( E57_BUILDING_SELF )
     endif()
 endif()
 
+option( E57_USE_EXTERNAL_CRCPP "Use an external CRCpp package" OFF )
+
 find_package( Threads REQUIRED )
 find_package( XercesC 3.2 REQUIRED )
 
@@ -136,7 +138,9 @@ include( E57ExportHeader )
 include( GitUpdate )
 
 # Main sources and includes
-add_subdirectory( extern/CRCpp )
+if ( NOT E57_USE_EXTERNAL_CRCPP )
+	add_subdirectory( extern/CRCpp )
+endif()
 add_subdirectory( include )
 add_subdirectory( src )
 


### PR DESCRIPTION
## Type

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation/formatting

## Summary

Adds a CMake option which disables the vendored CRCpp.

## Rationale

I am trying to package libE57Format for Fedora, where using the system's copy of CRCpp is a [requirement](https://docs.fedoraproject.org/en-US/packaging-guidelines/#bundling).

## Checklist

- [x] The included code and/or docs were written by a human
- [ ] If including code changes, clang-format was run on the code
