### PR TITLE
Add option to allow use of system CRCpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,20 @@ option( E57_BUILD_SHARED
 	"Compile E57Format as a shared library"
 	OFF
 )
+option( SYSTEM_CRCpp
+	"Use system crcpp rather than bundled version"
+	OFF
+)
 
+if( SYSTEM_CRCpp )
+	find_path(crcpp_INCLUDE_PATH crc.h
+		${CMAKE_INCLUDE_PATH}
+		$ENV{include})
+	# Use bundled crcpp if not found
+	if ( NOT crcpp_INCLUDE_PATH )
+		set( SYSTEM_CRCpp OFF )
+	endif()
+endif()
 if( BUILD_SHARED_LIBS )
 	set( E57_BUILD_SHARED ON )
 endif()
@@ -136,7 +149,9 @@ include( E57ExportHeader )
 include( GitUpdate )
 
 # Main sources and includes
-add_subdirectory( extern/CRCpp )
+if ( NOT SYSTEM_CRCpp )
+	add_subdirectory( extern/CRCpp )
+endif()
 add_subdirectory( include )
 add_subdirectory( src )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,18 +83,17 @@ option( E57_BUILD_SHARED
 	"Compile E57Format as a shared library"
 	OFF
 )
-option( SYSTEM_CRCpp
+option( E57_USE_EXTERNAL_CRCPP
 	"Use system crcpp rather than bundled version"
 	OFF
 )
 
-if( SYSTEM_CRCpp )
-	find_path(crcpp_INCLUDE_PATH crc.h
+if( E57_USE_EXTERNAL_CRCPP )
+	find_path(crcpp_INCLUDE_PATH CRC.h
 		${CMAKE_INCLUDE_PATH}
 		$ENV{include})
-	# Use bundled crcpp if not found
 	if ( NOT crcpp_INCLUDE_PATH )
-		set( SYSTEM_CRCpp OFF )
+		message( FATAL_ERROR "[${PROJECT_NAME}] E57_USE_EXTERNAL_CRCPP was enabled but CRC.h was not found" )
 	endif()
 endif()
 if( BUILD_SHARED_LIBS )
@@ -149,7 +148,7 @@ include( E57ExportHeader )
 include( GitUpdate )
 
 # Main sources and includes
-if ( NOT SYSTEM_CRCpp )
+if ( NOT E57_USE_EXTERNAL_CRCPP )
 	add_subdirectory( extern/CRCpp )
 endif()
 add_subdirectory( include )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,7 @@ option( E57_USE_EXTERNAL_CRCPP
 )
 
 if( E57_USE_EXTERNAL_CRCPP )
-	find_path(crcpp_INCLUDE_PATH CRC.h
-		${CMAKE_INCLUDE_PATH}
-		$ENV{include})
+	find_path(crcpp_INCLUDE_PATH CRC.h ${CMAKE_INCLUDE_PATH})
 	if ( NOT crcpp_INCLUDE_PATH )
 		message( FATAL_ERROR "[${PROJECT_NAME}] E57_USE_EXTERNAL_CRCPP was enabled but CRC.h was not found" )
 	endif()


### PR DESCRIPTION



## Type

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation/formatting

## Summary

Add CMake option to allow use of system CRCpp

## Rationale

Enable easier packaging on GNU/Linux distributions where bundling is discouraged.

## Additional Notes

https://bugzilla.redhat.com/show_bug.cgi?id=2483666

## Checklist

- [x] The included code and/or docs were written by a human
- [x] If including code changes, clang-format was run on the code
