### PR TITLE
Fix missing O_BINARY on MinGW in CheckedFile::open64

### DIFF
--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -210,7 +210,7 @@ CheckedFile::CheckedFile( const ustring &fileName, Mode mode, ReadChecksumPolicy
          // File truncated to zero length if already exists
 
          constexpr int writeFlags = O_RDWR | O_CREAT | O_TRUNC | O_BINARY;
-#if defined( _MSC_VER )         
+#if defined( _MSC_VER )
          constexpr int writeMode = S_IREAD | S_IWRITE;
 #else
          constexpr int writeMode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;

--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -83,6 +83,11 @@
 #include "CheckedFile.h"
 #include "StringFunctions.h"
 
+// Fallback
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
 // #define E57_CHECK_FILE_DEBUG
 #ifdef E57_CHECK_FILE_DEBUG
 #include <cassert>
@@ -187,11 +192,7 @@ CheckedFile::CheckedFile( const ustring &fileName, Mode mode, ReadChecksumPolicy
    {
       case Read:
       {
-#if defined( _WIN32 )
          constexpr int readFlags = O_RDONLY | O_BINARY;
-#else
-         constexpr int readFlags = O_RDONLY;
-#endif
 
          fd_ = open64( fileName_, readFlags, 0 );
 
@@ -208,15 +209,10 @@ CheckedFile::CheckedFile( const ustring &fileName, Mode mode, ReadChecksumPolicy
       {
          // File truncated to zero length if already exists
 
-#if defined( _WIN32 )
          constexpr int writeFlags = O_RDWR | O_CREAT | O_TRUNC | O_BINARY;
-#if defined( _MSC_VER )
+#if defined( _MSC_VER )         
          constexpr int writeMode = S_IREAD | S_IWRITE;
 #else
-         constexpr int writeMode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
-#endif
-#else
-         constexpr int writeFlags = O_RDWR | O_CREAT | O_TRUNC;
          constexpr int writeMode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
 #endif
 

--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -187,7 +187,7 @@ CheckedFile::CheckedFile( const ustring &fileName, Mode mode, ReadChecksumPolicy
    {
       case Read:
       {
-#if defined( _MSC_VER )
+#if defined( _WIN32 )
          constexpr int readFlags = O_RDONLY | O_BINARY;
 #else
          constexpr int readFlags = O_RDONLY;
@@ -208,9 +208,13 @@ CheckedFile::CheckedFile( const ustring &fileName, Mode mode, ReadChecksumPolicy
       {
          // File truncated to zero length if already exists
 
-#if defined( _MSC_VER )
+#if defined( _WIN32 )
          constexpr int writeFlags = O_RDWR | O_CREAT | O_TRUNC | O_BINARY;
+#if defined( _MSC_VER )
          constexpr int writeMode = S_IREAD | S_IWRITE;
+#else
+         constexpr int writeMode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
+#endif
 #else
          constexpr int writeFlags = O_RDWR | O_CREAT | O_TRUNC;
          constexpr int writeMode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;


### PR DESCRIPTION
## Type

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation/formatting

## Summary

CheckedFile::open64() opens files without O_BINARY on MinGW-w64, since the flag is currently gated by #if defined(_MSC_VER) rather than _WIN32. Without it, Windows' CRT performs text-mode newline translation on what is meant to be raw binary I/O, silently corrupting the physical pages of E57 files.

This pr splits the guard so O_BINARY is applied under any windows compiler, while the MSVC-specific file mode constants remain gated by _MSC_VER as before.

## Rationale

Per the discussions in #245/247, several _WIN32 guards were narrowed to _MSC_VER to skip pragma directives MinGW's preprocessor doesnt understand. That change looks like it collaterally removed O_BINARY from MinGW's open flags in open64(), even though O_BINARY has nothing to do with pragmas and MinGW fully supports it.

This pr is scoped only to the two open() flag definitions in open64(). It does *not* touch the pragma block, UTF-16 conversion code or any other _MSC_VER-gated path in the file, so it shouldnt reintroduce whatever the earlier narrowing was fixing. From my (admittedly limited) testing, it seems to work fine.

## Additional Notes

Symptom without this fix:
e57::E57Exception: read() failed (ErrorReadFailed)
context: fileName=filename.e57 result=1023
errorCode: 19

This is reproducible on any dataset large enough to statistically contain a 0x0A byte in a physical page (a 3-point test didn't trigger it, but 5000 points did).

This was consistently one byte short of the expected 1024-byte physical page, consistent with a stripped \r from \r\n translation.

I tested this locally on MinGW-w64 GCC 16.1.0 (msys2 mingw) on win11. A full clean rebuild succeeds, and a write/read round trip that previously threw ErrorReadFailed on both write and read now completes successfully.

## Checklist

- [x] The included code and/or docs were written by a human
- [x] If including code changes, clang-format was run on the code
