### PR TITLE
{ci} Update actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
           echo "ninja $(ninja --version)"
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           max-size: '5G'
           key: ${{ matrix.os }}-${{ matrix.build_type }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,12 +92,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Checkout Test Data
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: 'asmaloney/libE57Format-test-data'
           path: libE57Format-test-data
@@ -116,7 +116,7 @@ jobs:
 
       - name: Install Dependencies (Windows)
         if: matrix.platform == 'windows'
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           channels: conda-forge,defaults
 

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -11,7 +11,7 @@ jobs:
     name: Formatting Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Run clang-format style check
         uses: jidicula/clang-format-action@v4.18.0
         with:


### PR DESCRIPTION
## Summary

Updates CI actions:

- hendrikmuhs/ccache-action to 1.2
- actions/checkout to 7.x
- conda-incubator/setup-miniconda to 4.x

## Checklist

- [x] The included code and/or docs were written by a human
- [ ] If including code changes, clang-format was run on the code
