### PR TITLE
Fix crash with an invalid E57 file (Data3D missing the prototype section)

### DIFF
--- a/src/CompressedVectorNode.cpp
+++ b/src/CompressedVectorNode.cpp
@@ -301,6 +301,11 @@ CompressedVectorNode::writer
 */
 Node CompressedVectorNode::prototype() const
 {
+   if ( impl_->getPrototype() == nullptr )
+   {
+      throw E57_EXCEPTION2( ErrorBadPrototype, "(missing prototype section)" );
+   }
+
    return Node( impl_->getPrototype() );
 }
 

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -352,6 +352,11 @@ values:
 */
 NodeType Node::type() const
 {
+   if ( impl_ == nullptr )
+   {
+      throw E57_EXCEPTION2( ErrorInternal, "(node implementation is null)" );
+   }
+
    return impl_->type();
 }
 

--- a/test/src/test_SimpleReader.cpp
+++ b/test/src/test_SimpleReader.cpp
@@ -100,6 +100,30 @@ TEST( SimpleReaderData, ZeroPointsInvalid )
    delete reader;
 }
 
+// Check that we properly handle a file with a Data3D section which does not have a prototype
+TEST( SimpleReaderData, NoPrototype )
+{
+   e57::Reader *reader = nullptr;
+
+   E57_ASSERT_NO_THROW( reader =
+                           new e57::Reader( TestData::Path() + "/self/NoPrototype.e57", {} ) );
+
+   ASSERT_TRUE( reader->IsOpen() );
+   EXPECT_EQ( reader->GetImage2DCount(), 0 );
+   EXPECT_EQ( reader->GetData3DCount(), 1 );
+
+   e57::E57Root fileHeader;
+   ASSERT_TRUE( reader->GetE57Root( fileHeader ) );
+
+   TestHelper::CheckFileHeader( fileHeader );
+   EXPECT_EQ( fileHeader.guid, "No Prototype File GUID" );
+
+   e57::Data3D data3DHeader;
+   E57_ASSERT_THROW( reader->ReadData3D( 0, data3DHeader ) );
+
+   delete reader;
+}
+
 TEST( SimpleReaderData, InvalidCVHeader )
 {
    e57::Reader *reader = nullptr;


### PR DESCRIPTION
## Type

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation/formatting

## Summary

If you somehow end up with an invalid E57 file missing a _prototype_ section, libE57Format would crash when reading it.

This will now throw an _ErrorBadPrototype_ exception.

In addition, add a deeper check in _Node::type()_ to catch any similar issues. This will throw a more generic _ErrorInternal_ exception.

## Additional Notes

Thanks to @crook3dfingers for reporting the issue.

## Checklist

- [x] The included code and/or docs were written by a human
- [x] If including code changes, clang-format was run on the code
