### PR TITLE
Bounds-check BufferView::read

### DIFF
--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -172,6 +172,16 @@ public:
    void read( char *buffer, uint64_t count )
    {
       const uint64_t start = cursorStream_;
+
+      // Written as ( count > streamSize_ - start ) rather than ( start + count > streamSize_ )
+      // so the check itself cannot overflow.
+      if ( start > streamSize_ || count > streamSize_ - start )
+      {
+         throw E57_EXCEPTION2( ErrorReadFailed, "pos=" + toString( start ) +
+                                                   " count=" + toString( count ) +
+                                                   " bufferSize=" + toString( streamSize_ ) );
+      }
+
       for ( uint64_t i = 0; i < count; ++i )
       {
          buffer[i] = stream_[start + i];


### PR DESCRIPTION
Passing a short (< 1024 byte) memory buffer to `CheckedFile` causes an out-of-bounds read and ASAN failure.

`CheckedFile::readPhysicalPage()` always requests a full `physicalPageSize` regardless of how many bytes actually remain, and `BufferView::read()` copied that many bytes without comparing against `streamSize_`. The file-backed branch immediately below it already refuses a short read — this makes the buffer-backed branch behave the same way.

The check is written as `count > streamSize_ - start` rather than `start + count > streamSize_` so it can't itself overflow.

Verified against a clean checkout of `master`:

- **before** — ASAN reports `heap-buffer-overflow`, `READ of size 1`, at `CheckedFile.cpp:177`
- **after** — throws `E57Exception` under both `ChecksumAll` and `ChecksumNone`, exit 0, no ASAN report

Happy to add a CHANGELOG entry under 3.4.0 → Fixed once this has a PR number, and a regression test that feeds a short buffer to the memory constructor — just say the word and I'll push either to this branch.