### PR TITLE
{test} Fixed so tests can run properly even without the test data files

### DIFF
--- a/test/src/TestData.cpp
+++ b/test/src/TestData.cpp
@@ -3,8 +3,6 @@
 
 #include <sys/stat.h>
 
-#include "gtest/gtest.h"
-
 #include "TestData.h"
 
 namespace
@@ -40,9 +38,4 @@ namespace TestData
    {
       return dirExists( TestData::Path() );
    }
-}
-
-TEST( TestData, RepoExists )
-{
-   ASSERT_TRUE( dirExists( TestData::Path() ) ) << "Data path: " << TestData::Path();
 }

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -32,7 +32,7 @@ int main( int argc, char **argv )
    // IF our data path doesn't exist, then exclude some tests.
    if ( !TestData::Exists() )
    {
-      ::testing::GTEST_FLAG( filter ) = "-*Data.*";
+      ::testing::GTEST_FLAG( filter ) = "-SimpleReaderData.*:Extension_DIST.*";
    }
 
    std::cout << "e57Format version: " << e57::Version::library() << std::endl;

--- a/test/src/test_ImageFile.cpp
+++ b/test/src/test_ImageFile.cpp
@@ -67,6 +67,11 @@ namespace
 // See: https://github.com/asmaloney/libE57Format/issues/330
 TEST( ImageFile, StructureNodeIsDefined )
 {
+   if ( !TestData::Exists() )
+   {
+      GTEST_SKIP_( "(test data not available)" );
+   }
+
    std::unique_ptr<e57::ImageFile> imf;
 
    const std::string cFileName = TestData::Path() + "/reference/bunnyDouble.e57";

--- a/test/src/test_SimpleData.cpp
+++ b/test/src/test_SimpleData.cpp
@@ -97,6 +97,11 @@ TEST( SimpleDataHeader, HeaderMinMaxDouble )
 // written, and read again. https://github.com/asmaloney/libE57Format/issues/126
 TEST( SimpleData, ReadWrite )
 {
+   if ( !TestData::Exists() )
+   {
+      GTEST_SKIP_( "(test data not available)" );
+   }
+
    e57::Reader *originalReader = nullptr;
    e57::E57Root originalFileHeader;
    e57::Data3D originalData3DHeader;
@@ -138,11 +143,12 @@ TEST( SimpleData, ReadWrite )
    }
 
    e57::Reader *copyReader = nullptr;
-   e57::E57Root copyFileHeader;
    e57::Data3D copyData3DHeader;
 
    // 3. Read in what we just wrote
    {
+      e57::E57Root copyFileHeader;
+
       E57_ASSERT_NO_THROW( copyReader = new e57::Reader( "./ColouredCubeDoubleCopy.e57", {} ) );
 
       ASSERT_TRUE( copyReader->GetE57Root( copyFileHeader ) );

--- a/test/src/test_SimpleWriter.cpp
+++ b/test/src/test_SimpleWriter.cpp
@@ -653,6 +653,11 @@ TEST( SimpleWriter, MinMaxIssuesSphericalDouble )
 
 TEST( SimpleWriterData, VisualRefImage )
 {
+   if ( !TestData::Exists() )
+   {
+      GTEST_SKIP_( "(test data not available)" );
+   }
+
    e57::WriterOptions options;
    options.guid = "Visual Reference Image File GUID";
 

--- a/test/src/test_extension_DIST.cpp
+++ b/test/src/test_extension_DIST.cpp
@@ -11,7 +11,7 @@
 #include "Helpers.h"
 #include "TestData.h"
 
-TEST( Extension_DIST_Read, PinholeImageWithDistortionParameters )
+TEST( Extension_DIST, ReadPinholeImageWithDistortionParameters )
 {
    e57::Reader *reader = nullptr;
 
@@ -101,7 +101,7 @@ TEST( Extension_DIST_Read, PinholeImageWithDistortionParameters )
    delete reader;
 }
 
-TEST( Extension_DIST_Write, PinholeImageWithDistortionParameters )
+TEST( Extension_DIST, WritePinholeImageWithDistortionParameters )
 {
    e57::WriterOptions options;
    options.guid = "Pinhole image with distortion parameters GUID";


### PR DESCRIPTION
## Type

- [ ] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation/formatting
- [x] Tests

## Summary

It will skip any tests which require the data files from https://github.com/asmaloney/libE57Format-test-data

## Checklist

- [x] The included code and/or docs were written by a human
- [x] If including code changes, clang-format was run on the code
