### PR TITLE
Add checks in CheckedFile constructors for file/buffer size

### DIFF
--- a/include/E57Exception.h
+++ b/include/E57Exception.h
@@ -150,6 +150,8 @@ namespace e57
       ErrorPathNameMalformed,              ///< E57 path name is not well formed
       ErrorPathNameExtensionNotRegistered, ///< E57 path name uses an unregistered extension
 
+      ErrorBadInputDataSize, ///< the file or buffer size is not a multiple of 1024 bytes
+
       /// @deprecated Will be removed in 4.0. Use e57::Success.
       E57_SUCCESS E57_DEPRECATED_ENUM( "Will be removed in 4.0. Use Success." ) = Success,
       /// @deprecated Will be removed in 4.0. Use e57::ErrorBadCVHeader.

--- a/src/CheckedFile.cpp
+++ b/src/CheckedFile.cpp
@@ -209,6 +209,13 @@ CheckedFile::CheckedFile( const ustring &fileName, Mode mode, ReadChecksumPolicy
          readOnly_ = true;
 
          physicalLength_ = lseek64( 0LL, SEEK_END );
+
+         if ( physicalLength_ % 1024 != 0 )
+         {
+            throw E57_EXCEPTION2( ErrorBadInputDataSize,
+                                  "file length is " + toString( physicalLength_ ) + " bytes" );
+         }
+
          lseek64( 0, SEEK_SET );
 
          logicalLength_ = physicalToLogical( physicalLength_ );
@@ -235,6 +242,12 @@ CheckedFile::CheckedFile( const ustring &fileName, Mode mode, ReadChecksumPolicy
 CheckedFile::CheckedFile( const char *input, uint64_t size, ReadChecksumPolicy policy ) :
    fileName_( "<StreamBuffer>" ), checkSumPolicy_( policy )
 {
+   if ( size % 1024 != 0 )
+   {
+      throw E57_EXCEPTION2( ErrorBadInputDataSize,
+                            "buffer length is " + toString( size ) + " bytes" );
+   }
+
    bufView_ = new BufferView( input, size );
 
    readOnly_ = true;

--- a/src/E57Exception.cpp
+++ b/src/E57Exception.cpp
@@ -370,6 +370,9 @@ namespace e57
             return "E57 path name uses an unregistered extension "
                    "(ErrorPathNameExtensionNotRegistered)";
 
+         case ErrorBadInputDataSize:
+            return "file or buffer size is not an integral multiple of 1024 bytes";
+
          default:
             return "unknown error (" + std::to_string( ecode ) + ")";
       }

--- a/test/src/test_ImageFile.cpp
+++ b/test/src/test_ImageFile.cpp
@@ -138,3 +138,17 @@ TEST( ImageFile, InvalidBufferLength )
 
    delete[] data;
 }
+
+// Check that we throw if the file size is not an integral multiple of 1024 bytes
+TEST( ImageFile, InvalidFileLength )
+{
+   if ( !TestData::Exists() )
+   {
+      GTEST_SKIP_( "(test data not available)" );
+   }
+
+   std::unique_ptr<e57::ImageFile> imf;
+
+   const std::string cFileName = TestData::Path() + "/self/InvalidFileLength.e57";
+   E57_ASSERT_THROW( imf = std::make_unique<e57::ImageFile>( cFileName, "r" ) );
+}


### PR DESCRIPTION
## Type

- [ ] New feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation/formatting

## Summary

Throws a new exception `ErrorBadInputDataSize` if the file size or data buffer size is not a multiple of 1024.

## Rationale

From the standard:

> 6.2.2 The length of an E57 file shall be an integral multiple of 1024 bytes.

## Checklist

- [x] The included code and/or docs were written by a human
- [x] If including code changes, clang-format was run on the code
