### PR TITLE
Fix null dereference comparing CompressedVector prototypes

### DIFF
--- a/src/CompressedVectorNodeImpl.cpp
+++ b/src/CompressedVectorNodeImpl.cpp
@@ -151,7 +151,16 @@ namespace e57
       }
 
       // Prototypes and codecs must match ???
+      // These can be null since they are set after construction.
+      if ( !prototype_ || !cvi->prototype_ )
+      {
+         return ( false );
+      }
       if ( !prototype_->isTypeEquivalent( cvi->prototype_ ) )
+      {
+         return ( false );
+      }
+      if ( !codecs_ || !cvi->codecs_ )
       {
          return ( false );
       }

--- a/test/src/test_SimpleReader.cpp
+++ b/test/src/test_SimpleReader.cpp
@@ -124,6 +124,15 @@ TEST( SimpleReaderData, NoPrototype )
    delete reader;
 }
 
+// Checks that if a Data3D is marked as homogeneous, it does not crash if a prototype section
+// is missing.
+// https://github.com/asmaloney/libE57Format/pull/356
+TEST( SimpleReaderData, MultipleScansHomogeneousError )
+{
+   E57_ASSERT_THROW(
+      e57::Reader( TestData::Path() + "/self/MultipleScansHomogeneousError.e57", {} ) );
+}
+
 TEST( SimpleReaderData, InvalidCVHeader )
 {
    e57::Reader *reader = nullptr;


### PR DESCRIPTION
Fixes the null dereference from GHSA-f7fw-gw7v-2h7g.

`prototype_` and `codecs_` are set after construction via `setPrototype()` /
`setCodecs()`, so both can legitimately be null. Every other use in
`CompressedVectorNodeImpl.cpp` checks for that (lines 52, 97, 178, 184, 227, 231,
244, 253) — `isTypeEquivalent()` was the one place that didn't, so passing a null
prototype into `StructureNodeImpl::isTypeEquivalent()` dereferenced it at
`ni->type()`.

A missing prototype or codecs is now treated as "not equivalent", which is the
same answer a mismatch already gives.

`codecs_` is guarded as well: it has the identical gap one line later. Our
reproducer happens to trip the prototype path first, but a later fuzzing run did
produce an input that reaches the `codecs_` line, so both are needed.

Verified locally against `21c2943`:

- 6 crashing inputs from the fuzzing run are all cleanly rejected after the patch
  (with `E57_ERROR_HOMOGENEOUS_VIOLATION`, i.e. the real structural problem is now
  reported), and all 6 still crash without it.
- No behaviour change on valid files: 46 files — the 15 in `libE57Format-test-data`
  plus 31 generated through the `Writer` API across node types, bit widths,
  cartesian/spherical geometry, optional-field combinations, scan counts and
  Image2D sections — give identical open/reject results before and after.

Happy to adjust anything. Let me know when you've added your test case and I'll
rebase if needed.
